### PR TITLE
[CIVIC-246] Added content paragraph type to component block.

### DIFF
--- a/docroot/themes/custom/civic/config/install/field.field.block_content.civic_component_block.field_c_b_components.yml
+++ b/docroot/themes/custom/civic/config/install/field.field.block_content.civic_component_block.field_c_b_components.yml
@@ -7,6 +7,7 @@ dependencies:
     - paragraphs.paragraphs_type.civic_attachment
     - paragraphs.paragraphs_type.civic_callout
     - paragraphs.paragraphs_type.civic_card_container
+    - paragraphs.paragraphs_type.civic_content
     - paragraphs.paragraphs_type.civic_map
     - paragraphs.paragraphs_type.civic_next_step
     - paragraphs.paragraphs_type.civic_quick_links
@@ -29,6 +30,7 @@ settings:
     target_bundles:
       civic_callout: civic_callout
       civic_card_container: civic_card_container
+      civic_content: civic_content
       civic_attachment: civic_attachment
       civic_next_step: civic_next_step
       civic_quick_links: civic_quick_links
@@ -70,12 +72,15 @@ settings:
       civic_card_subject:
         weight: 21
         enabled: false
+      civic_card_subject_reference:
+        weight: 35
+        enabled: false
       civic_card_task:
         weight: -18
         enabled: false
       civic_content:
+        enabled: true
         weight: -17
-        enabled: false
       civic_map:
         enabled: true
         weight: 24

--- a/tests/behat/features/block_type.civic_component_block.feature
+++ b/tests/behat/features/block_type.civic_component_block.feature
@@ -24,4 +24,5 @@ Feature: Tests the Civic Component Block Type
     And I should see an "input[value='Add Callout']" element
     And I should see an "input[value='Add Attachment']" element
     And I should see an "input[value='Add Map']" element
+    And I should see an "input[value='Add Content']" element
 


### PR DESCRIPTION
## What has changed
1. Added content paragraph type to component block so we can place themed WYSIWYG content via blocks.
![image](https://user-images.githubusercontent.com/57734756/134596106-f5df51d4-669c-4132-8e68-a4acb9e1e7cb.png)
