### PR TITLE
Updated small mobile breakpoint.

### DIFF
--- a/docroot/themes/custom/civic/civic-library/components/variables.scss
+++ b/docroot/themes/custom/civic/civic-library/components/variables.scss
@@ -45,8 +45,10 @@ $civic-colors: () !default;
 // Do not use these directly, except for calculations.
 // Use @include breakpoint(name) mixin instead.
 //
+// First breakpoint is set to 0 so styles apply to all window sizes (not just small mobile - 368px and above).
+//
 $civic-breakpoints: (
-  'xs': 368px,
+  'xs': 0,
   's': 576px,
   'm': 768px,
   'l': 992px,


### PR DESCRIPTION
## Background
Fixed bug where some typography / breakpoint styles was not being applied to small mobile. 
Updated xs (small mobile) breakpoint to zero, so styles are applied from 0px screen-width up.