### PR TITLE
Added DOMContentLoaded wrapper for library.

### DIFF
--- a/docroot/themes/custom/civic/civic-library/components/02-molecules/accordion/accordion.js
+++ b/docroot/themes/custom/civic/civic-library/components/02-molecules/accordion/accordion.js
@@ -185,9 +185,7 @@ CivicAccordion.prototype.destroy = function () {
   }
 };
 
-document.addEventListener('DOMContentLoaded', () => {
-  document.querySelectorAll('.civic-accordion .civic-accordion__list').forEach((accordion) => {
-    // eslint-disable-next-line no-new
-    new CivicAccordion(accordion);
-  });
+document.querySelectorAll('.civic-accordion .civic-accordion__list').forEach((accordion) => {
+  // eslint-disable-next-line no-new
+  new CivicAccordion(accordion);
 });

--- a/docroot/themes/custom/civic/civic-library/components/02-molecules/alert/alert.stories.js
+++ b/docroot/themes/custom/civic/civic-library/components/02-molecules/alert/alert.stories.js
@@ -3,6 +3,9 @@ import CivicAlert from './alert.twig';
 
 export default {
   title: 'Molecule/Alert',
+  parameters: {
+    layout: 'fullscreen',
+  },
 };
 
 export const Alert = () => CivicAlert({

--- a/docroot/themes/custom/civic/civic-library/package-lock.json
+++ b/docroot/themes/custom/civic/civic-library/package-lock.json
@@ -21,6 +21,7 @@
         "@storybook/html": "^6.3.8",
         "@whitespace/storybook-addon-html": "^5.0.0",
         "babel-loader": "^8.2.2",
+        "babel-plugin-syntax-dynamic-import": "^6.18.0",
         "clean-webpack-plugin": "^4.0.0",
         "css-loader": "^5.2.7",
         "eslint": "^7.32.0",
@@ -5715,6 +5716,12 @@
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
       }
+    },
+    "node_modules/babel-plugin-syntax-dynamic-import": {
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz",
+      "integrity": "sha1-jWomIpyDdFqZgqRBBRVyyqF5sdo=",
+      "dev": true
     },
     "node_modules/babel-plugin-syntax-jsx": {
       "version": "6.18.0",
@@ -24853,6 +24860,12 @@
       "requires": {
         "@babel/helper-define-polyfill-provider": "^0.2.2"
       }
+    },
+    "babel-plugin-syntax-dynamic-import": {
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz",
+      "integrity": "sha1-jWomIpyDdFqZgqRBBRVyyqF5sdo=",
+      "dev": true
     },
     "babel-plugin-syntax-jsx": {
       "version": "6.18.0",

--- a/docroot/themes/custom/civic/civic-library/package.json
+++ b/docroot/themes/custom/civic/civic-library/package.json
@@ -35,6 +35,7 @@
     "@storybook/html": "^6.3.8",
     "@whitespace/storybook-addon-html": "^5.0.0",
     "babel-loader": "^8.2.2",
+    "babel-plugin-syntax-dynamic-import": "^6.18.0",
     "clean-webpack-plugin": "^4.0.0",
     "css-loader": "^5.2.7",
     "eslint": "^7.32.0",

--- a/docroot/themes/custom/civic/civic-library/webpack/babel-plugin-script-wrapper.js
+++ b/docroot/themes/custom/civic/civic-library/webpack/babel-plugin-script-wrapper.js
@@ -1,0 +1,26 @@
+const template = require('babel-template');
+
+const wrapper = template(`document.addEventListener('DOMContentLoaded', () => {{BODY}});`);
+module.exports = function (babel) {
+  const t = babel.types;
+
+  return {
+    inherits: require("babel-plugin-transform-strict-mode"),
+    visitor: {
+      Program: {
+        exit(path) {
+          if (!this.isWrapped) {
+            this.isWrapped = true;
+
+            path.replaceWith(
+              t.program([wrapper({
+                BODY: path.node.body
+              })])
+            );
+          }
+          path.node.directives = [];
+        }
+      }
+    }
+  };
+};

--- a/docroot/themes/custom/civic/civic-library/webpack/webpack.common.js
+++ b/docroot/themes/custom/civic/civic-library/webpack/webpack.common.js
@@ -61,6 +61,23 @@ module.exports = {
           loader: 'twigjs-loader'
         }]
       },
+      // Wrap JS with DOMContentLoaded.
+      {
+        test: /components\/[^\/]+\/(?!.*\.(stories|component)\.js$).*\.js$/,
+        exclude: /(node_modules|webpack|themejs\.js|css\.js)/,
+        use: [{
+          loader: 'babel-loader',
+          options: {
+            presets: [
+              '@babel/preset-env'
+            ],
+            plugins: [
+              './node_modules/babel-plugin-syntax-dynamic-import',
+              './webpack/babel-plugin-script-wrapper.js',
+            ],
+          }
+        }]
+      }
     ],
   },
   resolve: {


### PR DESCRIPTION
## Changesd

This PR wraps all non-stories JS with `DOMContentLoaded`. For Civic Library Storybook and `dist`.

This has no effect on Civic and Civic Demo theme - JS there is wrapped in Drupal behaviours.

## How to test
1. Build and check that Accordion JS is working in Civic Library storybook.
1. Build and check that Accordion JS is working in Civic theme storybook.