### PR TITLE
Remove duplicate selectors from compile CSS.

### DIFF
--- a/docroot/themes/custom/civic/civic-library/components/00-base/base.scss
+++ b/docroot/themes/custom/civic/civic-library/components/00-base/base.scss
@@ -1,5 +1,2 @@
 @import 'variables';
 @import 'mixins';
-@import 'fonts';
-@import 'grid';
-@import 'visibility';

--- a/docroot/themes/custom/civic/civic-library/components/00-base/global.scss
+++ b/docroot/themes/custom/civic/civic-library/components/00-base/global.scss
@@ -1,0 +1,3 @@
+@import 'fonts';
+@import 'grid';
+@import 'visibility';


### PR DESCRIPTION
base.scss is imported 31 times through various components.
As base.scss adds grid, font and visibility class selectors, these selectors get duplicated, causing additional performance issues when compiling, and when rendered in browser.
Moving the grids, fonts and visibility imports into a separate global.scss file means they get imported once, while base.scss only contains functions / mixins and variables, which are safe to import more than once.

<!--
Please follow these rules:
1. SUBJECT: use format [PRJ-123] Verb in past tense with dot at the end.
   - This subject will be used as a commit message after PR is merged.
   - Verbs are usually one of these: Updated, Refactored, Removed, Changed, Added.
   - If there is no ticket - do not put [NOTICKET].

2. BODY: fill-in the template below.

3. CONFLICTS: Make sure that there are no conflicts in your PR. Resolve them before submitting PR for review.

4. COMMENTS: Scan through your PR yourself and comment on the lines that does not look clear enough. This will save SIGNIFICANT time for reviewer to approve the PR.

5. LABEL: Assign 'Needs review' label as soon as you ready to have this reviewed.

6. ASSIGNEE: Assign at least 2 reviewers.     

7. SLACK: Post a link to this PR to #developers channel.

No need to remove these lines - they are comments.
-->

**Issue URL:**

### Changed
<!--
Provide a list of what was added/changed/removed etc. 

Start with a verb so that it is clear what has happened:Added/ Updated/Removed/Refactored etc.

Also, explain WHY something was done if this was not a normal implementation.
-->
1.  

### Screenshots

<!--
Provide as many screenshots as required to make reviewers understand what was changed.
-->
