### PR TITLE
Remove duplicated css.

### DIFF
--- a/docroot/themes/custom/civic/civic-library/components/00-base/debug/_index.scss
+++ b/docroot/themes/custom/civic/civic-library/components/00-base/debug/_index.scss
@@ -1,0 +1,6 @@
+//
+// Block debug class
+//
+.civic-block-debug {
+  @include block-debug;
+}

--- a/docroot/themes/custom/civic/civic-library/components/00-base/global.scss
+++ b/docroot/themes/custom/civic/civic-library/components/00-base/global.scss
@@ -1,3 +1,0 @@
-@import 'fonts';
-@import 'grid';
-@import 'visibility';

--- a/docroot/themes/custom/civic/civic-library/components/00-base/mixins/_debug.scss
+++ b/docroot/themes/custom/civic/civic-library/components/00-base/mixins/_debug.scss
@@ -21,7 +21,3 @@
     }
   }
 }
-
-.civic-block-debug {
-  @include block-debug;
-}


### PR DESCRIPTION
## Background

There was duplicate css in the `dist/styles.css` files for no obvious reason. Upon investigation, realised that webpack includes and aggregates every scss file in components/ directory (except for stories.scss) - this meant that global.scss was being included with it's imports and then global's imports were being included again by webpack (doubling up the built css).

## What has changed
1. Deleted global.scss - webpack does the aggregation for us (no need to aggregate scss)
2. Moved debug out of mixins as this caused it to duplicate multiple times on every mixin import.


Effect: Reduces css by 1/3.