### PR TITLE
Changed container width to max-width.

### DIFF
--- a/docroot/themes/custom/civic/civic-library/components/00-base/mixins/_grid.scss
+++ b/docroot/themes/custom/civic/civic-library/components/00-base/mixins/_grid.scss
@@ -197,13 +197,13 @@
 
   // Support super-narrow screens as well.
   $width: map-get($civic-grid-offsets, xs) * 2;
-  width: calc(100% - #{$width});
+  max-width: calc(100% - #{$width});
 
   // Set width for container at each breakpoint accounting for offsets at this
   // breakpoint.
   @each $bp, $value in $civic-breakpoints {
     @include civic-breakpoint($bp) {
-      width: map-get($civic-breakpoints, $bp) - (map-get($civic-grid-offsets, $bp) * 2);
+      max-width: map-get($civic-breakpoints, $bp) - (map-get($civic-grid-offsets, $bp) * 2);
     }
   }
 }


### PR DESCRIPTION
## Background

I found I was having breakouts of container on footer on mobile and investigated and saw container was setting a fixed width. I investigated it further and found container sets width and not max-width on the container.

Html structure is as follows:

```

<footer class="{{ classes|join(' ') }}" role="contentinfo" data-component-name="civic-footer">
  <div class="container">
    <div class="civic-footer__top civic-footer__region">
      <div class="row">

        <div class="col-m-3">
          {% block logo %}
            {% if logo is not empty %}
              <div class="civic-footer__logo">
                {{ logo }}
              </div>
            {% endif %}
          {% endblock %}
        </div>

        <div class="col-m-3">
          {% block top_left %}
            <div class="civic-footer__top--left">
              {{ top_left }}
            </div>
          {% endblock %}
        </div>

        <div class="col-m-3 col-m-offset-3">
          {% block top_right %}
            <div class="civic-footer__top--right">
              {{ top_right }}
            </div>
          {% endblock %}
        </div>
      </div>
    </div>

    {% block middle %}
      {% if middle_1 or middle_2 or middle_3 or middle_4 %}
        <div class="civic-footer__middle civic-footer__region">
          <div class="row">
            <div class="civic-footer__middle--1 col-xs-12 col-m-3">
              {% block middle_1 %}
                {{ middle_1 }}
              {% endblock %}
            </div>
            <div class="civic-footer__middle--2 col-xs-12 col-m-3">
              {% block middle_2 %}
                {{ middle_2 }}
              {% endblock %}
            </div>
            <div class="civic-footer__middle_3 col-xs-12 col-m-3">
              {% block middle_3 %}
                {{ middle_3 }}
              {% endblock %}
            </div>
            <div class="civic-footer__middle_4 col-xs-12 col-m-3">
              {% block middle_4 %}
                {{ middle_4 }}
              {% endblock %}
            </div>
          </div>
        </div>
      {% endif %}
    {% endblock %}

    <div class="civic-footer__bottom civic-footer__region">
      <div class="row">

        <div class="col-m-7">
          {% block bottom_left %}
            <div class="civic-footer__bottom--left">
              {{ bottom_left }}
            </div>
          {% endblock %}
        </div>

        <div class="col-m-3 col-m-offset-2">
          {% block bottom_right %}
            <div class="civic-footer__bottom--right">
              {{ bottom_right }}
            </div>
          {% endblock %}
        </div>
      </div>
    </div>
  </div>
</footer>

```

## Screenshot
With width set on container:

![image](https://user-images.githubusercontent.com/57734756/137259119-99a42078-e7ac-4f9d-991b-2e4d80f9d8d2.png)


With max-width set on container:
![image](https://user-images.githubusercontent.com/57734756/137259283-d0d77dbb-1445-43f9-87b8-52f67e7a6ed0.png)
