### PR TITLE
Removed padding on root on fullscreen components.

### DIFF
--- a/docroot/themes/custom/civic/civic-library/components/00-base/base.stories.scss
+++ b/docroot/themes/custom/civic/civic-library/components/00-base/base.stories.scss
@@ -7,6 +7,7 @@
   padding: civic-space(2);
 }
 
+.sb-show-main.sb-main-fullscreen #root,
 .sb-show-main.sb-main-centered #root {
   padding: 0;
 }


### PR DESCRIPTION
## What has changed
1. Added base story scss -removing padding on #root when fullscreen (edge to edge) parameter set.\


### Screenshots
No padding on mobile - this was causing distortion with the grid
![image](https://user-images.githubusercontent.com/57734756/137443328-110e08de-7afa-4b68-8d30-fdb28de9840b.png)
