### PR TITLE
Added fix for webpoack.

### DIFF
--- a/docroot/themes/custom/civic_demo/webpack/webpack.common.js
+++ b/docroot/themes/custom/civic_demo/webpack/webpack.common.js
@@ -66,7 +66,7 @@ module.exports = {
       },
       // Wrap JS into Drupal.behaviours.
       {
-        test: /components\/[^\/]+\/(?!.*\.(stories|component)\.js$).*\.js$/,
+        test: /components-combined\/[^\/]+\/(?!.*\.(stories|component)\.js$).*\.js$/,
         exclude: /(node_modules|webpack|themejs\.js|css\.js)/,
         use: [{
           loader: 'babel-loader',


### PR DESCRIPTION
We were building from the wrong directory in child theme and so civic JS was not being built in combined storybook.
### What has changed
1. Updated webpack config in `civic_demo`
### Work to come
1. Fix JS issue in child theme when you click a knob the JS doesn't get reloaded.
