### PR TITLE
Add overflow hidden on navigation card so image doesn't spill over border radius.

### DIFF
--- a/docroot/themes/custom/civic/civic-library/components/02-molecules/navigation-card/navigation-card.scss
+++ b/docroot/themes/custom/civic/civic-library/components/02-molecules/navigation-card/navigation-card.scss
@@ -8,6 +8,7 @@
 
   position: relative;
   border-radius: $civic-border-radius;
+  overflow: hidden;
 
   @include civic-box-shadow();
 


### PR DESCRIPTION
<!--
Please follow these rules:
1. SUBJECT: use format [PRJ-123] Verb in past tense with dot at the end.
   - This subject will be used as a commit message after PR is merged.
   - Verbs are usually one of these: Updated, Refactored, Removed, Changed, Added.
   - If there is no ticket - do not put [NOTICKET].

2. BODY: fill-in the template below.

3. CONFLICTS: Make sure that there are no conflicts in your PR. Resolve them before submitting PR for review.

4. COMMENTS: Scan through your PR yourself and comment on the lines that does not look clear enough. This will save SIGNIFICANT time for reviewer to approve the PR.

5. LABEL: Assign 'Needs review' label as soon as you ready to have this reviewed.

6. ASSIGNEE: Assign at least 2 reviewers.     

7. SLACK: Post a link to this PR to #developers channel.

No need to remove these lines - they are comments.
-->

**Issue URL:**

### Changed
<!--
Provide a list of what was added/changed/removed etc. 

Start with a verb so that it is clear what has happened:Added/ Updated/Removed/Refactored etc.

Also, explain WHY something was done if this was not a normal implementation.
-->
1.  Added overflow hidden to navigation card so that the card obeyed the border radius. Previously the image w as overlapping, giving the card square edges on left even with a border radius


### Screenshots

<img width="695" alt="Screen Shot 2021-10-27 at 10 19 13 am" src="https://user-images.githubusercontent.com/520440/138979238-5551bd32-52b2-4526-befb-b682078c7e33.png">

<img width="639" alt="Screen Shot 2021-10-27 at 10 18 44 am" src="https://user-images.githubusercontent.com/520440/138979246-052df72b-eaf1-487b-a7ff-6982da99996f.png">

<!--
Provide as many screenshots as required to make reviewers understand what was changed.
-->
