### PR TITLE
Added fix for collapsible.

### DIFF
--- a/docroot/themes/custom/civic/civic-library/components/00-base/collapsible/collapsible.js
+++ b/docroot/themes/custom/civic/civic-library/components/00-base/collapsible/collapsible.js
@@ -39,6 +39,7 @@ function CivicCollapsible(el) {
   // Attach event listener.
   this.trigger.addEventListener('click', this.clickEvent.bind(this));
   this.trigger.addEventListener('keydown', this.keydownEvent.bind(this.trigger));
+  this.panel.addEventListener('click', (e) => e.stopPropagation());
 
   // Collapse if was set as initially collapsed.
   if (this.collapsed) {


### PR DESCRIPTION
## Background
Header menu has the collapsible panel inserted inside the trigger which causes it to close every time the panel is clicked

## What has changed
1. Added a stop propagation event on the panel which stops the click event propagating up to the collapsible trigger.

https://user-images.githubusercontent.com/57734756/141240916-6bbb0553-c37a-4d8a-b3bf-cc7df241353d.mp4



