### PR TITLE
CIVIC-347: Inputs - Error messages - width fix.

### DIFF
--- a/docroot/themes/custom/civic/civic-library/components/01-atoms/input/input.scss
+++ b/docroot/themes/custom/civic/civic-library/components/01-atoms/input/input.scss
@@ -5,14 +5,18 @@
 .civic-input {
   $root: &;
 
+  position: relative;
+
   &__label {
     display: block;
     margin-bottom: civic-space();
   }
 
   &__element {
+    width: 100%;
     border: rem(1px) solid;
     border-radius: $civic-input-border-radius;
+    box-sizing: border-box;
     padding: civic-space(1.5) civic-space(5) civic-space(1.5) civic-space(2);
 
     &::placeholder {
@@ -29,13 +33,16 @@
   }
 
   &__state {
-    position: relative;
-    margin-left: - civic-space(4);
+    position: absolute;
+    width: civic-space(2);
+    height: civic-space(2);
+    right: civic-space(2);
+    top: civic-space(1.5);
 
     svg {
       width: civic-space(2);
       height: civic-space(2);
-      vertical-align: middle;
+      vertical-align: unset;
     }
   }
 

--- a/docroot/themes/custom/civic/civic-library/components/01-atoms/select/select.scss
+++ b/docroot/themes/custom/civic/civic-library/components/01-atoms/select/select.scss
@@ -5,6 +5,8 @@
 .civic-select {
   $root: &;
 
+  width: 100%;
+
   @include civic-typography('text-regular');
 
   font-weight: 600;

--- a/docroot/themes/custom/civic/civic-library/components/01-atoms/select/select.twig
+++ b/docroot/themes/custom/civic/civic-library/components/01-atoms/select/select.twig
@@ -18,16 +18,18 @@
 {% set required_class = required ? 'civic-input--required required' : '' %}
 {% set modifier_class = '%s %s %s %s %s'|format(theme_class, state_class, disabled_class, required_class, modifier_class|default('')) %}
 
-<select class="civic-select civic-input__element {{ modifier_class }}" {{ attributes }} {{ disabled ? 'disabled' }} {{ required ? 'required' }}>
-  {% for option in options %}
-    {% if option.type == 'optgroup' %}
-      <optgroup label="{{ option.label }}">
-        {% for sub_option in option.options %}
-          <option value="{{ sub_option.value }}"{{ sub_option.selected ? ' selected="selected"' }}>{{ sub_option.label }}</option>
-        {% endfor %}
-      </optgroup>
-    {% elseif option.type == 'option' %}
-      <option value="{{ option.value }}"{{ option.selected ? ' selected="selected"' }}>{{ option.label }}</option>
-    {% endif %}
-  {% endfor %}
-</select>
+<div class="civic-input {{ modifier_class }}">
+  <select class="civic-input__element civic-select civic-input__select" {{ attributes }} {{ disabled ? 'disabled' }} {{ required ? 'required' }}>
+    {% for option in options %}
+      {% if option.type == 'optgroup' %}
+        <optgroup label="{{ option.label }}">
+          {% for sub_option in option.options %}
+            <option value="{{ sub_option.value }}"{{ sub_option.selected ? ' selected="selected"' }}>{{ sub_option.label }}</option>
+          {% endfor %}
+        </optgroup>
+      {% elseif option.type == 'option' %}
+        <option value="{{ option.value }}"{{ option.selected ? ' selected="selected"' }}>{{ option.label }}</option>
+      {% endif %}
+    {% endfor %}
+  </select>
+</div>

--- a/docroot/themes/custom/civic/civic-library/components/03-organisms/form-element/form-element.scss
+++ b/docroot/themes/custom/civic/civic-library/components/03-organisms/form-element/form-element.scss
@@ -23,32 +23,35 @@
     }
   }
 
-  .civic-input {
-    margin: civic-space() auto;
-  }
+  &__wrapper {
+    width: 100%;
 
-  .civic-message {
-    padding: civic-space();
-    margin-bottom: civic-space(2);
-    display: inline-flex;
-    align-items: center;
-    border: none;
-
-    @include civic-typography('label-small');
-
-    &__title {
-      font-weight: 400;
+    .civic-input {
+      margin: civic-space() auto;
     }
 
-    .civic-icon {
-      width: rem(18px);
-      height: rem(18px);
-      vertical-align: middle;
-    }
+    .civic-message {
+      padding: civic-space();
+      margin-bottom: civic-space(2);
+      align-items: center;
+      border: none;
 
-    .civic-message__icon {
-      width: rem(18px);
-      margin-right: civic-space();
+      @include civic-typography('label-small');
+
+      &__title {
+        font-weight: 400;
+      }
+
+      .civic-icon {
+        width: rem(18px);
+        height: rem(18px);
+        vertical-align: middle;
+      }
+
+      .civic-message__icon {
+        width: rem(18px);
+        margin-right: civic-space();
+      }
     }
   }
 

--- a/docroot/themes/custom/civic/civic-library/components/03-organisms/form-element/form-element.twig
+++ b/docroot/themes/custom/civic/civic-library/components/03-organisms/form-element/form-element.twig
@@ -33,20 +33,22 @@
       {{ description.content }}
     </div>
   {% endif %}
-  {{ children }}
-  {% if suffix is not empty %}
-    <span class="field-suffix">{{ suffix }}</span>
-  {% endif %}
-  {% if label_display == 'after' %}
-    {{ label }}
-  {% endif %}
-  {% if errors %}
-    {% include '@organisms/message/message.twig' with {
-      theme: theme,
-      type: 'error',
-      title: errors
-    } only %}
-  {% endif %}
+  <div class="civic-form-element__wrapper">
+    {{ children }}
+    {% if suffix is not empty %}
+      <span class="field-suffix">{{ suffix }}</span>
+    {% endif %}
+    {% if label_display == 'after' %}
+      {{ label }}
+    {% endif %}
+    {% if errors %}
+      {% include '@organisms/message/message.twig' with {
+        theme: theme,
+        type: 'error',
+        title: errors
+      } only %}
+    {% endif %}
+  </div>
   {% if description_display in ['after', 'invisible'] and description.content %}
     <div class="{{ description_classes|join(' ') }}" {{ description.attributes }}>
       {{ description.content }}

--- a/docroot/themes/custom/civic/civic-library/components/03-organisms/message/message.scss
+++ b/docroot/themes/custom/civic/civic-library/components/03-organisms/message/message.scss
@@ -13,6 +13,7 @@
   border-radius: $civic-message-border-radius;
   border-left: solid rem(6px) transparent;
   padding: civic-space(3) civic-space(3) civic-space(3) civic-space(2);
+  box-sizing: border-box;
 
   @include civic-typography('text-regular');
 


### PR DESCRIPTION
### Issue
[https://salsadigital.atlassian.net/browse/CIVIC-347](https://salsadigital.atlassian.net/browse/CIVIC-347)

### Changes

1. Fixed input width issue.
2. Fixed theming for select element.


### Screenshots
![Screenshot from 2021-11-12 00-01-19](https://user-images.githubusercontent.com/15143023/141350677-c3c6c266-0e6e-4645-969e-99f82bfa3dab.png)
![Screenshot from 2021-11-12 00-01-32](https://user-images.githubusercontent.com/15143023/141350688-0d53c55a-24ac-417e-aa85-d97ad1a99379.png)
![Screenshot from 2021-11-12 00-01-41](https://user-images.githubusercontent.com/15143023/141350698-8292bc4b-a42a-4ec3-9fc5-62c18044449b.png)
![Screenshot from 2021-11-12 00-01-54](https://user-images.githubusercontent.com/15143023/141350707-cccde5f1-2955-49e3-8b68-b7815e7a008f.png)


