### PR TITLE
CIVIC-201: Table header is visually hidden on mobile devices.

### DIFF
--- a/docroot/themes/custom/civic/civic-library/components/00-base/mixins/_index.scss
+++ b/docroot/themes/custom/civic/civic-library/components/00-base/mixins/_index.scss
@@ -13,3 +13,4 @@
 @import 'rem';
 @import 'space';
 @import 'typography';
+@import 'visibility';

--- a/docroot/themes/custom/civic/civic-library/components/00-base/mixins/_visibility.scss
+++ b/docroot/themes/custom/civic/civic-library/components/00-base/mixins/_visibility.scss
@@ -1,0 +1,15 @@
+//
+// Visually hidden mixin.
+//
+
+//
+// Make element visually hidden but readable by screen readers.
+//
+@mixin civic-visually-hidden() {
+  position: absolute !important;
+  clip: rect(1px, 1px, 1px, 1px);
+  overflow: hidden;
+  height: 1px;
+  width: 1px;
+  word-wrap: normal;
+}

--- a/docroot/themes/custom/civic/civic-library/components/00-base/visibility/_index.scss
+++ b/docroot/themes/custom/civic/civic-library/components/00-base/visibility/_index.scss
@@ -34,10 +34,5 @@
 }
 
 .visually-hidden {
-  position: absolute !important;
-  clip: rect(1px, 1px, 1px, 1px);
-  overflow: hidden;
-  height: 1px;
-  width: 1px;
-  word-wrap: normal;
+  @include civic-visually-hidden();
 }

--- a/docroot/themes/custom/civic/civic-library/components/01-atoms/table/table.scss
+++ b/docroot/themes/custom/civic/civic-library/components/01-atoms/table/table.scss
@@ -21,7 +21,7 @@
 
     @include civic-breakpoint-upto('m') {
       thead {
-        display: none;
+        @include civic-visually-hidden();
       }
 
       tbody tr {


### PR DESCRIPTION
### Issue
[https://salsadigital.atlassian.net/browse/CIVIC-301](https://salsadigital.atlassian.net/browse/CIVIC-301)

### Changes

- Created mixin for visibility hidden.
- Table header is visually hidden on mobile devices.
