### PR TITLE
Added contained option to basic-content.

### DIFF
--- a/docroot/themes/custom/civic/civic-library/components/02-molecules/basic-content/basic-content.stories.js
+++ b/docroot/themes/custom/civic/civic-library/components/02-molecules/basic-content/basic-content.stories.js
@@ -119,6 +119,7 @@ export const BasicContent = (knobTab) => {
     theme,
     content: boolean('Content', true, generalKnobTab) ? html : null,
     modifier_class: text('Additional class', '', generalKnobTab),
+    contained: boolean('Contained', true, generalKnobTab),
   };
 
   return CivicBasicContent({

--- a/docroot/themes/custom/civic/civic-library/components/02-molecules/basic-content/basic-content.twig
+++ b/docroot/themes/custom/civic/civic-library/components/02-molecules/basic-content/basic-content.twig
@@ -7,20 +7,26 @@
  * - theme: [string] theme: light, dark.
  * - content: [string] Raw content.
  * - modifier_class: [string] Additional classes to modify component styling.
+ * - grid: [boolean]
  */
 #}
 
+{% set contained = contained is not defined or contained != false ? true : false %}
 {% set theme_class = 'civic-theme-%s'|format(theme|default('light')) %}
 {% set modifier_class = '%s %s'|format(theme_class, modifier_class|default('')) %}
 
 {% if content is not empty %}
   <div class="civic-basic-content {{ modifier_class }}">
-    <div class="container">
-      <div class="row">
-        <div class="col-xs-12">
-          {{ content|raw }}
+    {% if contained %}
+      <div class="container">
+        <div class="row">
+          <div class="col-xs-12">
+            {{ content|raw }}
+          </div>
         </div>
       </div>
-    </div>
+    {% else %}
+      {{ content|raw }}
+    {% endif %}
   </div>
 {% endif %}


### PR DESCRIPTION
## What has changed
1. Added a contained variable to basic-content template

# Why the suggested change
Printing markup inline with civic styles is not possible without the grid in a form as an example we might want to print some inline markup without grid.


## Storybook screenshot
**Uncontained**
![image](https://user-images.githubusercontent.com/57734756/142566803-d382ccf2-a56d-4f70-9242-80118d8371ba.png)
**Contained**
![image](https://user-images.githubusercontent.com/57734756/142566885-6c355518-6938-470e-8bf7-376a2f011d36.png)
