### PR TITLE
Updated core and dependencies.

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2027,16 +2027,16 @@
         },
         {
             "name": "doctrine/dbal",
-            "version": "2.13.5",
+            "version": "2.13.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/dbal.git",
-                "reference": "d92ddb260547c2a7b650ff140f744eb6f395d8fc"
+                "reference": "67ef6d0327ccbab1202b39e0222977a47ed3ef2f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/dbal/zipball/d92ddb260547c2a7b650ff140f744eb6f395d8fc",
-                "reference": "d92ddb260547c2a7b650ff140f744eb6f395d8fc",
+                "url": "https://api.github.com/repos/doctrine/dbal/zipball/67ef6d0327ccbab1202b39e0222977a47ed3ef2f",
+                "reference": "67ef6d0327ccbab1202b39e0222977a47ed3ef2f",
                 "shasum": ""
             },
             "require": {
@@ -2049,13 +2049,13 @@
             "require-dev": {
                 "doctrine/coding-standard": "9.0.0",
                 "jetbrains/phpstorm-stubs": "2021.1",
-                "phpstan/phpstan": "1.1.1",
+                "phpstan/phpstan": "1.2.0",
                 "phpunit/phpunit": "^7.5.20|^8.5|9.5.10",
                 "psalm/plugin-phpunit": "0.16.1",
                 "squizlabs/php_codesniffer": "3.6.1",
                 "symfony/cache": "^4.4",
                 "symfony/console": "^2.0.5|^3.0|^4.0|^5.0",
-                "vimeo/psalm": "4.12.0"
+                "vimeo/psalm": "4.13.0"
             },
             "suggest": {
                 "symfony/console": "For helpful console commands such as SQL execution and import of files."
@@ -2116,7 +2116,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/dbal/issues",
-                "source": "https://github.com/doctrine/dbal/tree/2.13.5"
+                "source": "https://github.com/doctrine/dbal/tree/2.13.6"
             },
             "funding": [
                 {
@@ -2132,7 +2132,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-11-11T16:27:36+00:00"
+            "time": "2021-11-26T20:11:05+00:00"
         },
         {
             "name": "doctrine/deprecations",
@@ -3707,16 +3707,16 @@
         },
         {
             "name": "drupal/console",
-            "version": "1.9.7",
+            "version": "1.9.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/hechoendrupal/drupal-console.git",
-                "reference": "90053d30f52427edb4e4941a9063acb65b5a2c1e"
+                "reference": "d292c940c07d164e32bbe9525e909311ca65e8cb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/hechoendrupal/drupal-console/zipball/90053d30f52427edb4e4941a9063acb65b5a2c1e",
-                "reference": "90053d30f52427edb4e4941a9063acb65b5a2c1e",
+                "url": "https://api.github.com/repos/hechoendrupal/drupal-console/zipball/d292c940c07d164e32bbe9525e909311ca65e8cb",
+                "reference": "d292c940c07d164e32bbe9525e909311ca65e8cb",
                 "shasum": ""
             },
             "require": {
@@ -3786,7 +3786,7 @@
                 "docs": "https://docs.drupalconsole.com/",
                 "forum": "https://gitter.im/hechoendrupal/DrupalConsole",
                 "issues": "https://github.com/hechoendrupal/drupal-console/issues",
-                "source": "https://github.com/hechoendrupal/drupal-console/tree/1.9.7"
+                "source": "https://github.com/hechoendrupal/drupal-console/tree/1.9.8"
             },
             "funding": [
                 {
@@ -3794,7 +3794,7 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2020-11-30T02:09:53+00:00"
+            "time": "2021-11-29T17:09:44+00:00"
         },
         {
             "name": "drupal/console-core",
@@ -8244,6 +8244,10 @@
                     "homepage": "https://www.drupal.org/user/1557710"
                 },
                 {
+                    "name": "paulocs",
+                    "homepage": "https://www.drupal.org/user/3640109"
+                },
+                {
                     "name": "shrop",
                     "homepage": "https://www.drupal.org/user/14767"
                 }
@@ -11382,16 +11386,16 @@
         },
         {
             "name": "league/csv",
-            "version": "9.7.3",
+            "version": "9.7.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/csv.git",
-                "reference": "d8149032aa74a9daca6f7b35d63c46a35c9bc1d5"
+                "reference": "002f55f649e7511710dc7154ff44c7be32c8195c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/csv/zipball/d8149032aa74a9daca6f7b35d63c46a35c9bc1d5",
-                "reference": "d8149032aa74a9daca6f7b35d63c46a35c9bc1d5",
+                "url": "https://api.github.com/repos/thephpleague/csv/zipball/002f55f649e7511710dc7154ff44c7be32c8195c",
+                "reference": "002f55f649e7511710dc7154ff44c7be32c8195c",
                 "shasum": ""
             },
             "require": {
@@ -11462,7 +11466,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-11-21T19:32:00+00:00"
+            "time": "2021-11-30T07:09:34+00:00"
         },
         {
             "name": "league/event",
@@ -11848,16 +11852,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.13.1",
+            "version": "v4.13.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "63a79e8daa781cac14e5195e63ed8ae231dd10fd"
+                "reference": "210577fe3cf7badcc5814d99455df46564f3c077"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/63a79e8daa781cac14e5195e63ed8ae231dd10fd",
-                "reference": "63a79e8daa781cac14e5195e63ed8ae231dd10fd",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/210577fe3cf7badcc5814d99455df46564f3c077",
+                "reference": "210577fe3cf7badcc5814d99455df46564f3c077",
                 "shasum": ""
             },
             "require": {
@@ -11898,9 +11902,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.13.1"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.13.2"
             },
-            "time": "2021-11-03T20:52:16+00:00"
+            "time": "2021-11-30T19:35:32+00:00"
         },
         {
             "name": "npm-asset/dropzone",
@@ -12799,16 +12803,16 @@
         },
         {
             "name": "psy/psysh",
-            "version": "v0.10.11",
+            "version": "v0.10.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/bobthecow/psysh.git",
-                "reference": "38017532bba35d15d28dcc001b4274df0251c4a1"
+                "reference": "a0d9981aa07ecfcbea28e4bfa868031cca121e7d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/bobthecow/psysh/zipball/38017532bba35d15d28dcc001b4274df0251c4a1",
-                "reference": "38017532bba35d15d28dcc001b4274df0251c4a1",
+                "url": "https://api.github.com/repos/bobthecow/psysh/zipball/a0d9981aa07ecfcbea28e4bfa868031cca121e7d",
+                "reference": "a0d9981aa07ecfcbea28e4bfa868031cca121e7d",
                 "shasum": ""
             },
             "require": {
@@ -12868,9 +12872,9 @@
             ],
             "support": {
                 "issues": "https://github.com/bobthecow/psysh/issues",
-                "source": "https://github.com/bobthecow/psysh/tree/v0.10.11"
+                "source": "https://github.com/bobthecow/psysh/tree/v0.10.12"
             },
-            "time": "2021-11-23T15:02:17+00:00"
+            "time": "2021-11-30T14:05:36+00:00"
         },
         {
             "name": "ralouphie/getallheaders",
@@ -17115,16 +17119,16 @@
         },
         {
             "name": "composer/composer",
-            "version": "2.1.12",
+            "version": "2.1.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/composer.git",
-                "reference": "6e3c2b122e0ec41a7e885fcaf19fa15e2e0819a0"
+                "reference": "cd28fc05b0c9d3beaf58b57018725c4dc15a6446"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/composer/zipball/6e3c2b122e0ec41a7e885fcaf19fa15e2e0819a0",
-                "reference": "6e3c2b122e0ec41a7e885fcaf19fa15e2e0819a0",
+                "url": "https://api.github.com/repos/composer/composer/zipball/cd28fc05b0c9d3beaf58b57018725c4dc15a6446",
+                "reference": "cd28fc05b0c9d3beaf58b57018725c4dc15a6446",
                 "shasum": ""
             },
             "require": {
@@ -17139,7 +17143,7 @@
                 "react/promise": "^1.2 || ^2.7",
                 "seld/jsonlint": "^1.4",
                 "seld/phar-utils": "^1.0",
-                "symfony/console": "^2.8.52 || ^3.4.35 || ^4.4 || ^5.0 || ^6.0",
+                "symfony/console": "^2.8.52 || ^3.4.35 || ^4.4 || ^5.0",
                 "symfony/filesystem": "^2.8.52 || ^3.4.35 || ^4.4 || ^5.0 || ^6.0",
                 "symfony/finder": "^2.8.52 || ^3.4.35 || ^4.4 || ^5.0 || ^6.0",
                 "symfony/process": "^2.8.52 || ^3.4.35 || ^4.4 || ^5.0 || ^6.0"
@@ -17193,7 +17197,7 @@
             "support": {
                 "irc": "ircs://irc.libera.chat:6697/composer",
                 "issues": "https://github.com/composer/composer/issues",
-                "source": "https://github.com/composer/composer/tree/2.1.12"
+                "source": "https://github.com/composer/composer/tree/2.1.14"
             },
             "funding": [
                 {
@@ -17209,7 +17213,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-11-09T15:02:04+00:00"
+            "time": "2021-11-30T09:51:43+00:00"
         },
         {
             "name": "composer/metadata-minifier",
@@ -20759,27 +20763,27 @@
         },
         {
             "name": "symfony/phpunit-bridge",
-            "version": "v5.3.11",
+            "version": "v5.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/phpunit-bridge.git",
-                "reference": "7b3637f0ce55c510a0fbe6e4d49b223103b7bf7b"
+                "reference": "59bbd98ee7aa15b9f75c0fc088c7a5cbf7aa9b5c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/phpunit-bridge/zipball/7b3637f0ce55c510a0fbe6e4d49b223103b7bf7b",
-                "reference": "7b3637f0ce55c510a0fbe6e4d49b223103b7bf7b",
+                "url": "https://api.github.com/repos/symfony/phpunit-bridge/zipball/59bbd98ee7aa15b9f75c0fc088c7a5cbf7aa9b5c",
+                "reference": "59bbd98ee7aa15b9f75c0fc088c7a5cbf7aa9b5c",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.1.3",
-                "symfony/deprecation-contracts": "^2.1"
+                "symfony/deprecation-contracts": "^2.1|^3"
             },
             "conflict": {
                 "phpunit/phpunit": "<7.5|9.1.2"
             },
             "require-dev": {
-                "symfony/error-handler": "^4.4|^5.0"
+                "symfony/error-handler": "^4.4|^5.0|^6.0"
             },
             "suggest": {
                 "symfony/error-handler": "For tracking deprecated interfaces usages at runtime with DebugClassLoader"
@@ -20822,7 +20826,7 @@
             "description": "Provides utilities for PHPUnit, especially user deprecation notices management",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/phpunit-bridge/tree/v5.3.11"
+                "source": "https://github.com/symfony/phpunit-bridge/tree/v5.4.0"
             },
             "funding": [
                 {
@@ -20838,7 +20842,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-11-12T11:38:27+00:00"
+            "time": "2021-11-29T15:30:56+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/docroot/sites/default/default.services.yml
+++ b/docroot/sites/default/default.services.yml
@@ -169,10 +169,10 @@ parameters:
     - webcal
     - rtsp
 
-   # Configure Cross-Site HTTP requests (CORS).
-   # Read https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS
-   # for more information about the topic in general.
-   # Note: By default the configuration is disabled.
+  # Configure Cross-Site HTTP requests (CORS).
+  # Read https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS
+  # for more information about the topic in general.
+  # Note: By default the configuration is disabled.
   cors.config:
     enabled: false
     # Specify allowed headers, like 'x-allowed-header'.


### PR DESCRIPTION
Changelogs summary:

 - pyrech/composer-changelogs updated from v1.8.0 to v1.8.1 patch
   See changes: https://github.com/pyrech/composer-changelogs/compare/v1.8.0...v1.8.1
   Release notes: https://github.com/pyrech/composer-changelogs/releases/tag/v1.8.1

 - behat/gherkin updated from v4.8.0 to v4.9.0 minor
   See changes: https://github.com/Behat/Gherkin/compare/v4.8.0...v4.9.0
   Release notes: https://github.com/Behat/Gherkin/releases/tag/v4.9.0

 - chillerlan/php-qrcode updated from 4.3.1 to 4.3.2 patch
   See changes: https://github.com/chillerlan/php-qrcode/compare/4.3.1...4.3.2
   Release notes: https://github.com/chillerlan/php-qrcode/releases/tag/4.3.2

 - commerceguys/addressing installed in version v1.2.2
   Release notes: https://github.com/commerceguys/addressing/releases/tag/v1.2.2

 - composer/ca-bundle updated from 1.2.10 to 1.3.1 minor
   See changes: https://github.com/composer/ca-bundle/compare/1.2.10...1.3.1
   Release notes: https://github.com/composer/ca-bundle/releases/tag/1.3.1

 - composer/spdx-licenses updated from 1.5.5 to 1.5.6 patch
   See changes: https://github.com/composer/spdx-licenses/compare/1.5.5...1.5.6
   Release notes: https://github.com/composer/spdx-licenses/releases/tag/1.5.6

 - consolidation/annotated-command updated from 4.3.1 to 4.4.0 minor
   See changes: https://github.com/consolidation/annotated-command/compare/4.3.1...4.4.0
   Release notes: https://github.com/consolidation/annotated-command/releases/tag/4.4.0

 - squizlabs/php_codesniffer updated from 3.6.0 to 3.6.1 patch
   See changes: https://github.com/squizlabs/PHP_CodeSniffer/compare/3.6.0...3.6.1
   Release notes: https://github.com/squizlabs/PHP_CodeSniffer/releases/tag/3.6.1

 - symfony/config updated from v4.4.30 to v4.4.34 patch
   See changes: https://github.com/symfony/config/compare/v4.4.30...v4.4.34
   Release notes: https://github.com/symfony/config/releases/tag/v4.4.34

 - behat/behat updated from v3.8.1 to v3.10.0 minor
   See changes: https://github.com/Behat/Behat/compare/v3.8.1...v3.10.0
   Release notes: https://github.com/Behat/Behat/releases/tag/v3.10.0

 - instaclick/php-webdriver updated from 1.4.9 to 1.4.10 patch
   See changes: https://github.com/instaclick/php-webdriver/compare/1.4.9...1.4.10
   Release notes: https://github.com/instaclick/php-webdriver/releases/tag/1.4.10

 - behat/mink updated from v1.8.1 to v1.9.0 minor
   See changes: https://github.com/minkphp/Mink/compare/v1.8.1...v1.9.0
   Release notes: https://github.com/minkphp/Mink/releases/tag/v1.9.0

 - behat/mink-selenium2-driver updated from v1.4.0 to v1.5.0 minor
   See changes: https://github.com/minkphp/MinkSelenium2Driver/compare/v1.4.0...v1.5.0
   Release notes: https://github.com/minkphp/MinkSelenium2Driver/releases/tag/v1.5.0

 - drevops/behat-steps updated from 1.3.0 to 1.3.1 patch
   See changes: https://github.com/drevops/behat-steps/compare/1.3.0...1.3.1
   Release notes: https://github.com/drevops/behat-steps/releases/tag/1.3.1

 - drupal/core updated from 9.2.4 to 9.2.7 patch
   See changes: https://github.com/drupal/core/compare/9.2.4...9.2.7
   Release notes: https://github.com/drupal/core/releases/tag/9.2.7

 - nikic/php-parser updated from v4.12.0 to v4.13.2 minor
   See changes: https://github.com/nikic/PHP-Parser/compare/v4.12.0...v4.13.2
   Release notes: https://github.com/nikic/PHP-Parser/releases/tag/v4.13.2

 - psy/psysh updated from v0.10.8 to v0.10.12 patch
   See changes: https://github.com/bobthecow/psysh/compare/v0.10.8...v0.10.12
   Release notes: https://github.com/bobthecow/psysh/releases/tag/v0.10.12

 - drupal/console updated from 1.9.7 to 1.9.8 patch
   See changes: https://github.com/hechoendrupal/drupal-console/compare/1.9.7...1.9.8
   Release notes: https://github.com/hechoendrupal/drupal-console/releases/tag/1.9.8

 - symfony/phpunit-bridge updated from v5.3.7 to v5.4.0 minor
   See changes: https://github.com/symfony/phpunit-bridge/compare/v5.3.7...v5.4.0
   Release notes: https://github.com/symfony/phpunit-bridge/releases/tag/v5.4.0

 - symfony/lock updated from v4.4.27 to v4.4.33 patch
   See changes: https://github.com/symfony/lock/compare/v4.4.27...v4.4.33
   Release notes: https://github.com/symfony/lock/releases/tag/v4.4.33

 - sebastian/exporter updated from 4.0.3 to 4.0.4 patch
   See changes: https://github.com/sebastianbergmann/exporter/compare/4.0.3...4.0.4
   Release notes: https://github.com/sebastianbergmann/exporter/releases/tag/4.0.4

 - phpunit/php-code-coverage updated from 9.2.6 to 9.2.9 patch
   See changes: https://github.com/sebastianbergmann/php-code-coverage/compare/9.2.6...9.2.9
   Release notes: https://github.com/sebastianbergmann/php-code-coverage/releases/tag/9.2.9

 - phpdocumentor/type-resolver updated from 1.4.0 to 1.5.1 minor
   See changes: https://github.com/phpDocumentor/TypeResolver/compare/1.4.0...1.5.1
   Release notes: https://github.com/phpDocumentor/TypeResolver/releases/tag/1.5.1

 - phpdocumentor/reflection-docblock updated from 5.2.2 to 5.3.0 minor
   See changes: https://github.com/phpDocumentor/ReflectionDocBlock/compare/5.2.2...5.3.0
   Release notes: https://github.com/phpDocumentor/ReflectionDocBlock/releases/tag/5.3.0

 - phpspec/prophecy updated from 1.13.0 to 1.14.0 minor
   See changes: https://github.com/phpspec/prophecy/compare/1.13.0...1.14.0
   Release notes: https://github.com/phpspec/prophecy/releases/tag/1.14.0

 - phpunit/phpunit updated from 9.5.9 to 9.5.10 patch
   See changes: https://github.com/sebastianbergmann/phpunit/compare/9.5.9...9.5.10
   Release notes: https://github.com/sebastianbergmann/phpunit/releases/tag/9.5.10

 - mikey179/vfsstream updated from v1.6.9 to v1.6.10 patch
   See changes: https://github.com/bovigo/vfsStream/compare/v1.6.9...v1.6.10
   Release notes: https://github.com/bovigo/vfsStream/releases/tag/v1.6.10

 - composer/composer updated from 2.1.6 to 2.1.14 patch
   See changes: https://github.com/composer/composer/compare/2.1.6...2.1.14
   Release notes: https://github.com/composer/composer/releases/tag/2.1.14

 - behat/mink-goutte-driver updated from v1.2.1 to v1.3.0 minor
   See changes: https://github.com/minkphp/MinkGoutteDriver/compare/v1.2.1...v1.3.0
   Release notes: https://github.com/minkphp/MinkGoutteDriver/releases/tag/v1.3.0

 - drupal/core-dev updated from 9.2.5 to 9.2.10 patch
   See changes: https://github.com/drupal/core-dev/compare/9.2.5...9.2.10
   Release notes: https://github.com/drupal/core-dev/releases/tag/9.2.10

 - doctrine/dbal updated from 2.13.2 to 2.13.6 patch
   See changes: https://github.com/doctrine/dbal/compare/2.13.2...2.13.6
   Release notes: https://github.com/doctrine/dbal/releases/tag/2.13.6

 - drupal/stage_file_proxy updated from 1.1.0 to 1.2.0 minor

 - consolidation/site-alias updated from 3.1.0 to 3.1.1 patch
   See changes: https://github.com/consolidation/site-alias/compare/3.1.0...3.1.1
   Release notes: https://github.com/consolidation/site-alias/releases/tag/3.1.1

 - swiftmailer/swiftmailer updated from v6.2.3 to v6.2.7 patch
   See changes: https://github.com/swiftmailer/swiftmailer/compare/v6.2.3...v6.2.7
   Release notes: https://github.com/swiftmailer/swiftmailer/releases/tag/v6.2.7

 - npm-asset/dropzone installed in version 5.9.3

 - drupal/tfa updated from 1.0.0-alpha7 to 1.0.0-alpha8 patch

 - lcobucci/jwt updated from 3.4.5 to 3.4.6 patch
   See changes: https://github.com/lcobucci/jwt/compare/3.4.5...3.4.6
   Release notes: https://github.com/lcobucci/jwt/releases/tag/3.4.6

 - drupal/simple_oauth updated from 5.0.4 to 5.0.5 patch

 - solarium/solarium updated from 6.1.5 to 6.1.6 patch
   See changes: https://github.com/solariumphp/solarium/compare/6.1.5...6.1.6
   Release notes: https://github.com/solariumphp/solarium/releases/tag/6.1.6

 - drupal/search_api updated from 1.19.0 to 1.20.0 minor

 - drupal/search_api_attachments updated from 1.0.0-beta17 to 1.0.0-beta18 patch

 - league/csv updated from 9.7.1 to 9.7.4 patch
   See changes: https://github.com/thephpleague/csv/compare/9.7.1...9.7.4
   Release notes: https://github.com/thephpleague/csv/releases/tag/9.7.4

 - drupal/linkit updated from 6.0.0-beta2 to 6.0.0-beta3 patch

 - drupal/field_group updated from 3.1.0 to 3.2.0 minor

 - drupal/entity_embed updated from 1.1.0 to 1.2.0 minor

 - caxy/php-htmldiff updated from v0.1.12 to v0.1.13 patch
   See changes: https://github.com/caxy/php-htmldiff/compare/v0.1.12...v0.1.13
   Release notes: https://github.com/caxy/php-htmldiff/releases/tag/v0.1.13

 - drupal/core-recommended updated from 9.2.4 to 9.2.7 patch
   See changes: https://github.com/drupal/core-recommended/compare/9.2.4...9.2.7
   Release notes: https://github.com/drupal/core-recommended/releases/tag/9.2.7

 - drupal/context updated from 4.0.0-beta6 to 4.1.0 minor

 - drupal/admin_toolbar updated from 3.0.2 to 3.0.3 patch

 - drupal/address installed in version 1.9.0

 - govcms/govcms updated from 2.4.0 to 2.6.0 minor
   See changes: https://github.com/govCMS/GovCMS/compare/2.4.0...2.6.0
   Release notes: https://github.com/govCMS/GovCMS/releases/tag/2.6.0

 - graham-campbell/result-type updated from v1.0.2 to v1.0.4 patch
   See changes: https://github.com/GrahamCampbell/Result-Type/compare/v1.0.2...v1.0.4
   Release notes: https://github.com/GrahamCampbell/Result-Type/releases/tag/v1.0.4
