### PR TITLE
Add fix for preprocess_form when class attribute is not array.

### DIFF
--- a/docroot/themes/custom/civic/includes/form.inc
+++ b/docroot/themes/custom/civic/includes/form.inc
@@ -40,8 +40,8 @@ function civic_preprocess_select(&$variables) {
  */
 function civic_preprocess_form_element(&$variables) {
   // Handle any malformed attribute class properties.
-//  $variables['attributes']['class'] = $variables['attributes']['class'] ?? [];
-//  $variables['attributes']['class'] = is_string($variables['attributes']['class']) ? [$variables['attributes']['class']] : $variables['attributes']['class'];
+  $variables['attributes']['class'] = $variables['attributes']['class'] ?? [];
+  $variables['attributes']['class'] = is_string($variables['attributes']['class']) ? [$variables['attributes']['class']] : $variables['attributes']['class'];
 
   // Add missing core Drupal form element classes that are added in template
   // file.


### PR DESCRIPTION
### Background

As an example diff sets classes as string rather than array, so we cannot rely on other modules providing data structures to convention.

Added some handling code to ensure we change it to array before adding new elements to the array in the civic_preprocess_form_element.