### PR TITLE
CIVIC-394: Fixed description not being read by screen reader.

### DIFF
--- a/docroot/themes/custom/civic/civic-library/components/03-organisms/accordion/accordion.twig
+++ b/docroot/themes/custom/civic/civic-library/components/03-organisms/accordion/accordion.twig
@@ -51,7 +51,7 @@
 
                 {% if fold.content %}
                   {% set is_open = is_expanded ? 'civic-accordion__content--expanded' : '' %}
-                  <div class="civic-accordion__content {{ is_open }}">
+                  <div class="civic-accordion__content {{ is_open }}" tabindex="0">
                     <div class="civic-accordion__content--inner">
                       {{ fold.content|raw }}
                     </div>


### PR DESCRIPTION
### Issue
[https://salsadigital.atlassian.net/browse/CIVIC-394](https://salsadigital.atlassian.net/browse/CIVIC-394)

### Changes
Added tabindex to content wrapper in accordion.