### PR TITLE
CIVIC-321: Making accordian title not required.

### DIFF
--- a/docroot/themes/custom/civic/civic-library/components/03-organisms/accordion/accordion.scss
+++ b/docroot/themes/custom/civic/civic-library/components/03-organisms/accordion/accordion.scss
@@ -110,7 +110,6 @@
 
     #{$root}__header__button {
       background-color: $civic-accordion-light-button-background-color;
-      color: $civic-accordion-light-button-color;
 
       svg {
         fill: $civic-accordion-light-icon-color;

--- a/docroot/themes/custom/civic/civic-library/components/03-organisms/accordion/accordion.twig
+++ b/docroot/themes/custom/civic/civic-library/components/03-organisms/accordion/accordion.twig
@@ -37,17 +37,17 @@
             {% for fold in panels %}
               {% set is_expanded = (fold.expanded == true) or (expand_all == true) %}
               <li class="civic-accordion__list-item">
-                {% if fold.title %}
-                  <div class="civic-accordion__header">
-                    {% set is_open = is_expanded ? 'is-selected' : '' %}
-                    <button class="civic-accordion__header__button {{ is_open }}">
+                <div class="civic-accordion__header">
+                  {% set is_open = is_expanded ? 'is-selected' : '' %}
+                  <button class="civic-accordion__header__button {{ is_open }}">
+                    {% if fold.title %}
                       <span>{{ fold.title }}</span>
-                      {% include '@atoms/icon/icon.twig' with {
-                        symbol: 'arrows_downarrow_1'
-                      } only %}
-                    </button>
-                  </div>
-                {% endif %}
+                    {% endif %}
+                    {% include '@atoms/icon/icon.twig' with {
+                      symbol: 'arrows_downarrow_1'
+                    } only %}
+                  </button>
+                </div>
 
                 {% if fold.content %}
                   {% set is_open = is_expanded ? 'civic-accordion__content--expanded' : '' %}

--- a/docroot/themes/custom/civic/config/install/field.field.paragraph.civic_accordion_panel.field_c_p_title.yml
+++ b/docroot/themes/custom/civic/config/install/field.field.paragraph.civic_accordion_panel.field_c_p_title.yml
@@ -10,7 +10,7 @@ entity_type: paragraph
 bundle: civic_accordion_panel
 label: Title
 description: ''
-required: true
+required: false
 translatable: false
 default_value: {  }
 default_value_callback: ''

--- a/tests/behat/features/paragraph.civic_accordion.feature
+++ b/tests/behat/features/paragraph.civic_accordion.feature
@@ -33,7 +33,6 @@ Feature: Tests the Accordion
     And should see an "select[name='field_c_n_components[0][subform][field_c_p_theme]'].required" element
     And should see an "input[name='field_c_n_components[0][subform][field_c_p_expand][value]']" element
     And should see an "input[name='field_c_n_components[0][subform][field_c_p_panels][0][subform][field_c_p_title][0][value]']" element
-    And should see an "input[name='field_c_n_components[0][subform][field_c_p_panels][0][subform][field_c_p_title][0][value]'].required" element
     And should see an "textarea[name='field_c_n_components[0][subform][field_c_p_panels][0][subform][field_c_p_content][0][value]']" element
     And should see an "textarea[name='field_c_n_components[0][subform][field_c_p_panels][0][subform][field_c_p_content][0][value]'].required" element
     And should see an "input[name='field_c_n_components[0][subform][field_c_p_panels][0][subform][field_c_p_expand][value]']" element


### PR DESCRIPTION
**Issue URL:** https://salsadigital.atlassian.net/browse/CIVIC-321

### Changed
1.  Config change for the field accordion title to be not mandatory.
2. Accordion.twig file would not display the accordion__header if the title is empty. Changed the condition to make it more specific.
3.  Updated the Accordion title colour for light theme.

### Screenshots

<img width="456" alt="Screenshot 2021-12-09 at 8 03 36 AM" src="https://user-images.githubusercontent.com/3881627/145323816-bcffc08a-f8fb-4070-9ec8-0caab7d69ff3.png">

<img width="937" alt="Screenshot 2021-12-09 at 8 04 35 AM" src="https://user-images.githubusercontent.com/3881627/145323951-4e73d03b-5004-46b8-ab0c-864bf6e6e52c.png">

