### PR TITLE
CIVIC-309: Added aria-live attribute for error message.

### DIFF
--- a/docroot/themes/custom/civic/civic-library/components/03-organisms/message/message.twig
+++ b/docroot/themes/custom/civic/civic-library/components/03-organisms/message/message.twig
@@ -26,7 +26,7 @@
   success: 'userinterface_approve',
 } %}
 
-<div role="{% if type == 'error' %}error{% else %}contentinfo{% endif %}" class="civic-message messages {{ modifier_class }}" aria-label="{{ type }}">
+<div role="{% if type == 'error' %}error{% else %}contentinfo{% endif %}" class="civic-message messages {{ modifier_class }}" aria-label="{{ type }}" {% if type == 'error' %}aria-live="polite"{% endif %}>
   {% if icons[type] is defined %}
     <div class="civic-message__icon">
       {% include "@atoms/icon/icon.twig" with {


### PR DESCRIPTION
### Issue
[https://salsadigital.atlassian.net/browse/CIVIC-309](https://salsadigital.atlassian.net/browse/CIVIC-309)

### Changes

- Added aria-live attribute to error message.

### Screenshot
![Screenshot from 2021-12-09 12-04-56](https://user-images.githubusercontent.com/15143023/145346189-cd484730-4b52-4025-b967-085548174401.png)
