### PR TITLE
[CIVIC-393] Added title attribute to attachment link on publication card.

### DIFF
--- a/docroot/themes/custom/civic/civic-library/components/02-molecules/publication-card/publication-card.twig
+++ b/docroot/themes/custom/civic/civic-library/components/02-molecules/publication-card/publication-card.twig
@@ -90,6 +90,7 @@
         {% include '@atoms/link/link.twig' with {
           theme: theme,
           text: link.text,
+          title: 'Download %s'|format(link.text),
           url: link.url,
           modifier_class: 'civic-link--attachment'
         } only %}


### PR DESCRIPTION
### Issue
[https://salsadigital.atlassian.net/browse/CIVIC-393](https://salsadigital.atlassian.net/browse/CIVIC-393)

### Changes

Added title attribute to attachment link.

### Screenshot
![Screenshot from 2021-12-14 08-50-54](https://user-images.githubusercontent.com/15143023/145927361-167c67f5-0c4a-4a56-9035-2c2e2d90e0b0.png)
