### PR TITLE
[CIVIC-258] Added support for external link icon indicator on navigation card.

### DIFF
--- a/docroot/themes/custom/civic/civic-library/components/02-molecules/navigation-card/navigation-card.scss
+++ b/docroot/themes/custom/civic/civic-library/components/02-molecules/navigation-card/navigation-card.scss
@@ -98,7 +98,8 @@
       @include civic-icon-fill-color($civic-navigation-card-light-icon-color, true);
     }
 
-    #{$root}__icon--arrow {
+    #{$root}__icon--arrow,
+    #{$root}__icon--external {
       @include civic-icon-fill-color($civic-navigation-card-light-icon-arrow-color, true);
     }
   }
@@ -126,7 +127,8 @@
       @include civic-icon-fill-color($civic-navigation-card-dark-icon-color, true);
     }
 
-    #{$root}__icon--arrow {
+    #{$root}__icon--arrow,
+    #{$root}__icon--external {
       @include civic-icon-fill-color($civic-navigation-card-dark-icon-arrow-color, true);
     }
   }

--- a/docroot/themes/custom/civic/civic-library/components/02-molecules/navigation-card/navigation-card.stories.js
+++ b/docroot/themes/custom/civic/civic-library/components/02-molecules/navigation-card/navigation-card.stories.js
@@ -37,6 +37,7 @@ export const NavigationCard = (knobTab) => {
     title: text('Title', 'Navigation card heading which runs across two or three lines', generalKnobTab),
     summary: text('Summary', 'Bring to the table win-win survival strategies to ensure proactive domination. At the end of the day, going forward, a new normal that has evolved from generation X is on the runway heading towards a streamlined cloud solution. User generated content in real-time will have multiple touchpoints for offshoring.', generalKnobTab),
     url: text('URL', randomUrl(), generalKnobTab),
+    is_external: boolean('Is external', false, generalKnobTab),
     image: boolean('With image', true, generalKnobTab) ? {
       src: demoImage(),
       alt: 'Image alt text',

--- a/docroot/themes/custom/civic/civic-library/components/02-molecules/navigation-card/navigation-card.twig
+++ b/docroot/themes/custom/civic/civic-library/components/02-molecules/navigation-card/navigation-card.twig
@@ -14,6 +14,7 @@
  * - summary: [string] Summary of the card.
  * - image: [string] Card type: large, small.
  * - url: [string] Card link.
+ * - is_external: [boolean] Link is external.
  * - content_bottom: [string] Component slot for bottom of Card.
  * - modifier_class: [string] Classes to modify the default component styling.
  */
@@ -62,11 +63,19 @@
           {{ title }}
           {% if url %}
           <span>
-            {% include '@atoms/icon/icon.twig' with {
-              symbol: 'arrows_rightarrow_3',
-              color: 'primary',
-              modifier_class: 'civic-navigation-card__icon--arrow',
-            } only %}
+            {% if is_external %}
+              {% include '@atoms/icon/icon.twig' with {
+                symbol: 'arrows_upperrightarrow',
+                color: 'primary',
+                modifier_class: 'civic-navigation-card__icon--external'
+              } only %}
+            {% else %}
+              {% include '@atoms/icon/icon.twig' with {
+                symbol: 'arrows_rightarrow_3',
+                color: 'primary',
+                modifier_class: 'civic-navigation-card__icon--arrow',
+              } only %}
+            {% endif %}
           </span>
         </a>
         {% endif %}

--- a/docroot/themes/custom/civic/includes/paragraph--civic_card_navigation.inc
+++ b/docroot/themes/custom/civic/includes/paragraph--civic_card_navigation.inc
@@ -5,6 +5,8 @@
  * Civic navigation card paragraph component.
  */
 
+use Drupal\Component\Utility\UrlHelper;
+
 /**
  * Implements template_preprocess_paragraph().
  *
@@ -15,4 +17,5 @@ function civic_preprocess_paragraph__civic_card_navigation(&$variables) {
   $paragraph = $variables['paragraph'];
   $link = ($paragraph->hasField('field_c_p_link') && !$paragraph->get('field_c_p_link')->isEmpty()) ? $paragraph->get('field_c_p_link')->first()->getValue() : [];
   $variables['url'] = $link['uri'] ?? NULL;
+  $variables['is_external'] = (isset($link['uri']) && !empty($link['uri'])) ? UrlHelper::isExternal($link['uri']) : FALSE;
 }


### PR DESCRIPTION
### Issue
[https://salsadigital.atlassian.net/browse/CIVIC-258](https://salsadigital.atlassian.net/browse/CIVIC-258)

### Changes

- Added support for external link  icon indicator.
- Update nav card integration code to provide value for if current url is external or not. 

### Screenshot
![Molecules-Card-Navigation-Card-Navigation-Card-⋅-Storybook](https://user-images.githubusercontent.com/15143023/145940899-abe4ce78-3b48-4468-8adf-c281a1b6f447.png)
![Molecules-Card-Navigation-Card-Navigation-Card-⋅-Storybook(1)](https://user-images.githubusercontent.com/15143023/145940904-78ce39a1-9437-42d1-b1a0-c26380ec750a.png)
