### PR TITLE
CIVIC-332: Subject card image bg colour.

### DIFF
--- a/docroot/themes/custom/civic/civic-library/components/00-base/_variables.components.scss
+++ b/docroot/themes/custom/civic/civic-library/components/00-base/_variables.components.scss
@@ -636,7 +636,7 @@ $civic-subject-card-border-radius: $civic-border-radius !default;
 $civic-subject-card-light-color: civic-color('neutral') !default;
 $civic-subject-card-light-hover-color: civic-color('neutral') !default;
 $civic-subject-card-light-active-color: civic-color-shade-dark(40) !default;
-$civic-subject-card-light-image-background-color: civic-color-neutral(10) !default;
+$civic-subject-card-light-image-background-color: civic-color-neutral(80) !default;
 $civic-subject-card-dark-color: civic-color('neutral') !default;
 $civic-subject-card-dark-hover-color: civic-color('accent') !default;
 $civic-subject-card-dark-active-color: civic-color-neutral(20) !default;


### PR DESCRIPTION
**Issue URL:** https://salsadigital.atlassian.net/browse/CIVIC-332

### Changed
1.  Changed the subject card image wrapper background colour.

### Screenshots
<img width="847" alt="Screenshot 2021-12-14 at 11 30 08 PM" src="https://user-images.githubusercontent.com/3881627/146054103-2522ae54-f208-4912-99d9-7f1042537c97.png">


