### PR TITLE
Added height: auto to images.

### DIFF
--- a/docroot/themes/custom/civic/civic-library/components/02-molecules/basic-content/basic-content.scss
+++ b/docroot/themes/custom/civic/civic-library/components/02-molecules/basic-content/basic-content.scss
@@ -152,6 +152,7 @@
   }
 
   img {
+    height: auto;
     max-width: 100%;
     margin-top: $civic-basic-content-vertical-spacing * 2;
     margin-bottom: $civic-basic-content-vertical-spacing * 2;


### PR DESCRIPTION
### What has changed
1. Added `height: auto` to `img` in basic-content

### Problem
Uploaded images to WYSIWYG can have img attributes, this change overrides attributes with an auto tag allowing it to smoothly resize.
![image](https://user-images.githubusercontent.com/57734756/146131616-419e3992-60f4-418e-bc0a-51c1f8187656.png)

![image](https://user-images.githubusercontent.com/57734756/146131759-cdcaa3cf-c8d5-425e-a816-cb7472318f01.png)

 