### PR TITLE
[CIVIC-327]: Added theme to search component.

### DIFF
--- a/docroot/themes/contrib/civic/config/install/core.entity_form_display.paragraph.civic_search.default.yml
+++ b/docroot/themes/contrib/civic/config/install/core.entity_form_display.paragraph.civic_search.default.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.field.paragraph.civic_search.field_c_p_help_text
     - field.field.paragraph.civic_search.field_c_p_placeholder
     - field.field.paragraph.civic_search.field_c_p_search_url
+    - field.field.paragraph.civic_search.field_c_p_theme
     - field.field.paragraph.civic_search.field_c_p_title
     - paragraphs.paragraphs_type.civic_search
 id: paragraph.civic_search.default
@@ -44,6 +45,12 @@ content:
       placeholder: ''
     third_party_settings: {  }
     type: string_textfield
+    region: content
+  field_c_p_theme:
+    weight: 5
+    settings: {  }
+    third_party_settings: {  }
+    type: options_select
     region: content
   field_c_p_title:
     weight: 0

--- a/docroot/themes/contrib/civic/config/install/core.entity_view_display.paragraph.civic_search.default.yml
+++ b/docroot/themes/contrib/civic/config/install/core.entity_view_display.paragraph.civic_search.default.yml
@@ -6,8 +6,11 @@ dependencies:
     - field.field.paragraph.civic_search.field_c_p_help_text
     - field.field.paragraph.civic_search.field_c_p_placeholder
     - field.field.paragraph.civic_search.field_c_p_search_url
+    - field.field.paragraph.civic_search.field_c_p_theme
     - field.field.paragraph.civic_search.field_c_p_title
     - paragraphs.paragraphs_type.civic_search
+  module:
+    - options
 id: paragraph.civic_search.default
 targetEntityType: paragraph
 bundle: civic_search
@@ -44,6 +47,13 @@ content:
       link_to_entity: false
     third_party_settings: {  }
     type: string
+    region: content
+  field_c_p_theme:
+    weight: 5
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: list_default
     region: content
   field_c_p_title:
     weight: 0

--- a/docroot/themes/contrib/civic/config/install/field.field.paragraph.civic_search.field_c_p_theme.yml
+++ b/docroot/themes/contrib/civic/config/install/field.field.paragraph.civic_search.field_c_p_theme.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_c_p_theme
+    - paragraphs.paragraphs_type.civic_search
+  module:
+    - options
+id: paragraph.civic_search.field_c_p_theme
+field_name: field_c_p_theme
+entity_type: paragraph
+bundle: civic_search
+label: Theme
+description: ''
+required: true
+translatable: true
+default_value:
+  -
+    value: light
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/docroot/themes/contrib/civic/includes/paragraph--civic_search.inc
+++ b/docroot/themes/contrib/civic/includes/paragraph--civic_search.inc
@@ -19,6 +19,7 @@ function civic_preprocess_paragraph__civic_search(&$variables) {
   $variables['help_text'] = $paragraph->get('field_c_p_help_text')->getString();
   $variables['placeholder'] = $paragraph->get('field_c_p_placeholder')->getString();
   $search_url = $paragraph->get('field_c_p_search_url')->getString();
+  $variables['theme'] = $paragraph->get('field_c_p_theme')->getString();
 
   // Check if the url is valid.
   if (UrlHelper::isValid($search_url)) {

--- a/tests/behat/features/paragraph.civic_search.feature
+++ b/tests/behat/features/paragraph.civic_search.feature
@@ -18,6 +18,7 @@ Feature: Tests the Civic search paragraph
     And I should see the text "field_c_p_placeholder" in the "Placeholder text" row
     And I should see the text "field_c_p_search_url" in the "Search url" row
     And I should see the text "field_c_p_title" in the "Title" row
+    And I should see the text "field_c_p_theme" in the "Theme" row
 
   @api @javascript
   Scenario: Show relevant fields depending on the 'Content type' selected
@@ -34,6 +35,9 @@ Feature: Tests the Civic search paragraph
     And I should see an "input[name='field_c_n_banner_components[0][subform][field_c_p_help_text][0][value]']" element
     And I should see an "input[name='field_c_n_banner_components[0][subform][field_c_p_button_text][0][value]']" element
     And I should see an "input[name='field_c_n_banner_components[0][subform][field_c_p_search_url][0][value]']" element
+    And I should see an "select[name='field_c_n_banner_components[0][subform][field_c_p_theme]']" element
+    And I should see an "select[name='field_c_n_banner_components[0][subform][field_c_p_theme]'].required" element
+    And the option "Light" from select "Theme" is selected
 
   @api
   Scenario: Civic page node field_c_n_banner_components fields settings.


### PR DESCRIPTION

**Issue URL:** https://salsadigital.atlassian.net/browse/CIVIC-327

### Changed
1.  Added theme field to the search component
2. Exported required config files
3. Added behat test case for the above field

### Screenshots
<img width="588" alt="Screenshot 2021-12-21 at 10 09 26 PM" src="https://user-images.githubusercontent.com/3881627/146966338-0797726b-c8dc-4636-83a5-4d764661756d.png">

