### PR TITLE
[CIVIC-385]: Added alt text and title for header logo.

### DIFF
--- a/docroot/themes/contrib/civic/civic-library/components/02-molecules/logo/logo.twig
+++ b/docroot/themes/contrib/civic/civic-library/components/02-molecules/logo/logo.twig
@@ -21,7 +21,7 @@
   {% if logo.src is not empty %}
     <div class="civic-logo {{ visibility_class }} {{ modifier_class }}">
     {% if url %}
-      <a class="civic-logo__url" href="{{ url }}">
+      <a class="civic-logo__url" href="{{ url }}" title="Click to go to the homepage">
     {% endif %}
         <img src="{{ logo.src }}" {% if logo.alt is not empty %}alt="{{ logo.alt }}"{% endif %}/>
     {% if url %}

--- a/docroot/themes/contrib/civic/includes/block--system_branding.inc
+++ b/docroot/themes/contrib/civic/includes/block--system_branding.inc
@@ -17,7 +17,7 @@ function civic_preprocess_block__system_branding_block(&$variables) {
   $variables['show_site_slogan'] = !empty($variables['elements']['#configuration']['use_site_slogan']);
   if ($variables['show_site_logo']) {
     $variables['show_logo'] = TRUE;
-    $alt_attribute = theme_get_setting('civic_site_logo_alt') ?? '';
+    $alt_attribute = theme_get_setting('civic_site_logo_alt') ?? 'CivicTheme logo';
 
     $block = Block::load($variables['elements']['#id']);
     $region = $block->getRegion();


### PR DESCRIPTION
**Issue URL:** https://salsadigital.atlassian.net/browse/CIVIC-385

### Changed

1.  Added default alt text for the logo
2. Added title for the logo wrapping a tag

### Screenshots


<img width="842" alt="Screenshot 2021-12-23 at 12 22 07 PM" src="https://user-images.githubusercontent.com/3881627/147200951-8727e027-0313-4dcf-83d6-5b9d511cd4fb.png">

