### PR TITLE
[CIVIC-349] Fixed primary navigation dropdown offset.

### DIFF
--- a/docroot/themes/contrib/civic/civic-library/components/00-base/_variables.components.scss
+++ b/docroot/themes/contrib/civic/civic-library/components/00-base/_variables.components.scss
@@ -970,7 +970,7 @@ $civic-message-success-dark-border-color: civic-color('success') !default;
 $civic-primary-navigation-dropdown-cols: 4;
 
 // Top offset for the dropdown from the bottom of the trigger.
-$civic-primary-navigation-dropdown-top-offset: civic-space(3);
+$civic-primary-navigation-dropdown-top-offset: civic-space(2);
 
 // Gutter size between columns.
 $civic-primary-navigation-dropdown-column-gutter: civic-space(4);


### PR DESCRIPTION
### What has changed
1. Updated dropdown menu offset for primary navigation - was showing gap on lower resolutions.

### Screenshot

#### Before

![image](https://user-images.githubusercontent.com/57734756/147202564-20cc55fb-efd4-4064-b562-4e7a83802a36.png)


#### After
![image](https://user-images.githubusercontent.com/57734756/147202616-2ee17ebf-0616-44f6-8042-b58f55283a6d.png)
