### PR TITLE
[CIVIC-395]: Updated the table dark styling and template.

### DIFF
--- a/docroot/themes/contrib/civic/civic-library/components/00-base/mixins/_table.scss
+++ b/docroot/themes/contrib/civic/civic-library/components/00-base/mixins/_table.scss
@@ -161,6 +161,10 @@
 @mixin civic-table-dark() {
   color: $civic-table-dark-color;
 
+  .civic-table__header {
+    color: $civic-table-dark-heading-color;
+  }
+
   table {
     background-color: $civic-table-dark-background-color;
   }
@@ -233,5 +237,9 @@
     &:hover {
       color: $civic-table-dark-link-hover-color;
     }
+  }
+
+  caption {
+    color: $civic-table-dark-caption-color;
   }
 }


### PR DESCRIPTION
**Issue URL:** https://salsadigital.atlassian.net/browse/CIVIC-395

### Changed

1.  Fixed the table heading colour 
2. One of the PR's did override the caption css, adding it back

### Screenshots

