### PR TITLE
[CIVIC-425] Fix nested page title.

### DIFF
--- a/docroot/themes/contrib/civic/includes/civic_banner.inc
+++ b/docroot/themes/contrib/civic/includes/civic_banner.inc
@@ -100,11 +100,7 @@ function _civic_preprocess_civic_banner_title(&$variables) {
   $request = \Drupal::request();
   $route_match = \Drupal::routeMatch();
   $page_title = \Drupal::service('title_resolver')->getTitle($request, $route_match->getRouteObject());
-
-  if (!empty($page_title)) {
-    $plugin_block->setTitle($page_title);
-    $variables['title'] = $plugin_block->build();
-  }
+  $variables['title'] = $page_title ?? '';
 }
 
 /**


### PR DESCRIPTION
### Issue link: CIVIC-425

## Background
A bug was found where we were printing a h1 tag inside a h1 tag.

### What has changed
1. Removed page title block and outputting just the title string for the template to handle.

### Screenshot
![image](https://user-images.githubusercontent.com/57734756/149030724-1e8d4e99-2b12-4423-962b-a73daeb91410.png)
