### PR TITLE
[CIVIC-385]: Fixed the logo title text issue with storybook

### DIFF
--- a/docroot/themes/contrib/civic/civic-library/components/02-molecules/logo/logo.twig
+++ b/docroot/themes/contrib/civic/civic-library/components/02-molecules/logo/logo.twig
@@ -15,7 +15,7 @@
 
 {% set theme_class = 'civic-theme-%s'|format(theme|default('light')) %}
 {% set modifier_class = '%s %s'|format(theme_class, modifier_class|default('')) %}
-{% set title = logo.alt ? logo.alt : 'CivicTheme logo' %}
+{% set title = 'CivicTheme logo' %}
 
 {% for type, logo in logos %}
   {% set visibility_class = type == 'mobile' ? 'show-xs show-sm hide-m' : 'hide-xs hide-sm show-m' %}


### PR DESCRIPTION

**Issue URL:** https://salsadigital.atlassian.net/browse/CIVIC-385

### Changed

1.  Fixed the logo title text issue with storybook

### Screenshots
<img width="944" alt="Screenshot 2022-01-17 at 7 35 47 PM" src="https://user-images.githubusercontent.com/3881627/149783052-dff9e98d-2b52-4d70-9de0-882e9ed1e01f.png">

