### PR TITLE
[CIVIC-278] Updated the table link colour for links coming from WYSIWYG.

### DIFF
--- a/docroot/themes/contrib/civic/civic-library/components/00-base/mixins/_table.scss
+++ b/docroot/themes/contrib/civic/civic-library/components/00-base/mixins/_table.scss
@@ -122,7 +122,8 @@
       td {
         color: $civic-table-light-row-odd-color;
 
-        .civic-link {
+        .civic-link,
+        a {
           color: $civic-table-light-row-odd-link-color;
 
           &:hover {
@@ -138,7 +139,8 @@
       td {
         color: $civic-table-light-row-even-color;
 
-        .civic-link {
+        .civic-link,
+        a {
           color: $civic-table-light-row-even-link-color;
 
           &:hover {
@@ -204,7 +206,8 @@
       td {
         color: $civic-table-dark-row-odd-color;
 
-        .civic-link {
+        .civic-link,
+        a {
           color: $civic-table-dark-row-odd-link-color;
 
           &:hover {
@@ -220,7 +223,8 @@
       td {
         color: $civic-table-dark-row-even-color;
 
-        .civic-link {
+        .civic-link,
+        a {
           color: $civic-table-dark-row-even-link-color;
 
           &:hover {


### PR DESCRIPTION
**Issue URL:** https://salsadigital.atlassian.net/browse/CIVIC-278

### Changed
1. Updating the table link colour.

### Screenshots

<img width="1294" alt="Screenshot 2022-01-19 at 11 01 55 AM" src="https://user-images.githubusercontent.com/3881627/150071123-c692d17b-422a-4cf2-b3a9-b2e789a802aa.png">

