### PR TITLE
[CIVIC-354] Change button type for promo component.

### DIFF
--- a/docroot/themes/contrib/civic/civic-library/components/01-atoms/button/button.scss
+++ b/docroot/themes/contrib/civic/civic-library/components/01-atoms/button/button.scss
@@ -291,11 +291,6 @@
             @include _civic-button-print-rules($type-kind-values);
           }
         }
-        @else if $type-kind == 'visited' {
-          &:visited {
-            @include _civic-button-print-rules($type-kind-values);
-          }
-        }
         @else if $type-kind == 'active' {
           &:active {
             @include _civic-button-print-rules($type-kind-values);

--- a/docroot/themes/contrib/civic/civic-library/components/02-molecules/promo/promo.twig
+++ b/docroot/themes/contrib/civic/civic-library/components/02-molecules/promo/promo.twig
@@ -31,7 +31,7 @@
         text: call_to_action.title,
         url: call_to_action.url,
         new_window: call_to_action.new_window,
-        type: 'primary',
+        type: 'secondary',
         theme: theme,
         kind: 'link',
         modifier_class: 'civic-promo__button',


### PR DESCRIPTION
### What has changed
1. Changed button type to secondary for promo
2. Removed visited state for button links as this was causing contrast issues.

### Screenshot

**New promo button at rest**

![image](https://user-images.githubusercontent.com/57734756/150241193-e881967a-07bb-4a41-9aaa-9f8cdc677ba9.png)

![image](https://user-images.githubusercontent.com/57734756/150241222-5e290bcb-ab92-4433-b63f-18aa6513b2f7.png)


**Before removal of visited state on hover:**
![image](https://user-images.githubusercontent.com/57734756/150241084-90c25bab-3789-4426-8719-945330d5228f.png)


**After**

![image](https://user-images.githubusercontent.com/57734756/150241144-a4f63d07-0c8e-4e44-8c79-d7481c52b511.png)
