### PR TITLE
[CIVIC-431]: Changed the tag light theme color.

### DIFF
--- a/docroot/themes/contrib/civic/civic-library/components/00-base/_variables.components.scss
+++ b/docroot/themes/contrib/civic/civic-library/components/00-base/_variables.components.scss
@@ -458,7 +458,7 @@ $civic-table-dark-caption-color: civic-color-shade-light(90) !default;
 //
 $civic-tag-border-radius: $civic-border-radius !default;
 $civic-tag-border-width: 0 !default;
-$civic-tag-light-color: civic-color-neutral(60) !default;
+$civic-tag-light-color: civic-color-neutral(80) !default;
 $civic-tag-light-background-color: civic-color-neutral(5) !default;
 $civic-tag-light-border-color: civic-color-neutral(20) !default;
 $civic-tag-light-alt-color: civic-color('neutral') !default;


### PR DESCRIPTION
**Issue URL:** https://salsadigital.atlassian.net/browse/CIVIC-431

### Changed
1.  Updated the Event tag color as per the requirements

### Screenshots
<img width="563" alt="Screenshot 2022-02-02 at 10 23 23 PM" src="https://user-images.githubusercontent.com/3881627/152200144-b5c09085-424e-418b-a2df-5e9eb696ec0d.png">

