### PR TITLE
[CIVIC-457] Added a check for empty breadcrumb title.

### DIFF
--- a/docroot/themes/contrib/civic/civic-library/components/03-organisms/breadcrumb/breadcrumb.twig
+++ b/docroot/themes/contrib/civic/civic-library/components/03-organisms/breadcrumb/breadcrumb.twig
@@ -21,29 +21,31 @@
   <nav class="{{ '%s %s'|format(component_class, theme_class) }}" aria-label="breadcrumb">
     <ul class="civic-breadcrumb__links">
       {% for linkObj in links %}
-        <li class="civic-breadcrumb__links--link">
+        {% if linkObj.text %}
+          <li class="civic-breadcrumb__links--link">
 
-          {% if loop.index == links_count - 1 %}
-            {% set parent = linkObj %}
-          {% endif %}
-
-          {% if not active_is_link and (loop.index == links_count) %}
-            <span aria-current="location">{{ linkObj.text }}</span>
-          {% else %}
-            {% include '@atoms/link/link.twig' with {
-              theme: theme,
-              text: linkObj.text,
-              url: linkObj.url,
-              attributes: loop.index == links_count ? 'aria-current="location"' : '',
-            } only %}
-            {% if (loop.index < links_count) %}
-              {% include '@atoms/icon/icon.twig' with {
-                symbol: 'arrows_rightarrow',
-              } only %}
+            {% if loop.index == links_count - 1 %}
+              {% set parent = linkObj %}
             {% endif %}
-          {% endif %}
 
-        </li>
+            {% if not active_is_link and (loop.index == links_count) %}
+              <span aria-current="location">{{ linkObj.text }}</span>
+            {% else %}
+              {% include '@atoms/link/link.twig' with {
+                theme: theme,
+                text: linkObj.text,
+                url: linkObj.url,
+                attributes: loop.index == links_count ? 'aria-current="location"' : '',
+              } only %}
+              {% if (loop.index < links_count) %}
+                {% include '@atoms/icon/icon.twig' with {
+                  symbol: 'arrows_rightarrow',
+                } only %}
+              {% endif %}
+            {% endif %}
+
+          </li>
+        {% endif %}
       {% endfor %}
 
       {% if parent is not empty %}


### PR DESCRIPTION
**Issue URL:** https://salsadigital.atlassian.net/browse/CIVIC-457

### Changed

1.  Added a check for empty breadcrumb title.

### Screenshots
Before:
<img width="637" alt="Screenshot 2022-02-03 at 10 40 54 AM" src="https://user-images.githubusercontent.com/3881627/152284968-10f1e352-4fa1-4d88-a10c-5a445e9d0334.png">


After:
<img width="632" alt="Screenshot 2022-02-03 at 10 38 46 AM" src="https://user-images.githubusercontent.com/3881627/152284818-ff3af4ef-aec4-4977-a03e-b754861ac638.png">

