### PR TITLE
[CIVIC-57] Fix icon link.

### DIFF
--- a/docroot/themes/contrib/civic/civic-library/components/02-molecules/back-to-top/back-to-top.scss
+++ b/docroot/themes/contrib/civic/civic-library/components/02-molecules/back-to-top/back-to-top.scss
@@ -8,6 +8,7 @@
   position: fixed;
   right: civic-space(1);
   bottom: civic-space(8);
+  border-radius: rem(100px);
 
   &[data-scrollspy='true'] {
     display: none;
@@ -18,8 +19,9 @@
   }
 
   &.civic-theme-light {
+    background-color: $civic-back-to-top-light-background-color;
+
     .civic-icon {
-      background-color: $civic-back-to-top-light-background-color;
       fill: $civic-back-to-top-light-color;
     }
 
@@ -31,8 +33,9 @@
   }
 
   &.civic-theme-dark {
+    background-color: $civic-back-to-top-dark-background-color;
+
     .civic-icon {
-      background-color: $civic-back-to-top-dark-background-color;
       fill: $civic-back-to-top-dark-color;
     }
 

--- a/docroot/themes/contrib/civic/civic-library/components/02-molecules/icon-link/icon-link.scss
+++ b/docroot/themes/contrib/civic/civic-library/components/02-molecules/icon-link/icon-link.scss
@@ -10,10 +10,6 @@
   text-decoration: none;
   padding: civic-space();
 
-  @include civic-breakpoint('m') {
-    padding: civic-space(1.5);
-  }
-
   &#{$root}--with-border {
     border: 1px solid currentColor;
     border-radius: rem(100px);


### PR DESCRIPTION
### What has changed
1. Moved background from .civic-icon into surrounding .civic-back-to-top component due to changes to icon-link to accommodate social icons.
2. Removed desktop padding from social icon as the icons were too big on desktop.

### Screenshots

![image](https://user-images.githubusercontent.com/57734756/152481849-b8ae195f-79aa-4738-9e3c-c2e2c195c3b3.png)

![image](https://user-images.githubusercontent.com/57734756/152481955-81e90f6c-01f8-4f61-bd0f-786e50855bfd.png)

