### PR TITLE
Fix change between 9.2 and 9.3 loading revision parameters.

### DIFF
--- a/docroot/themes/contrib/civic/includes/civic_banner.inc
+++ b/docroot/themes/contrib/civic/includes/civic_banner.inc
@@ -131,12 +131,11 @@ function _civic_preprocess_civic_banner_node(&$variables) {
   /** @var \Drupal\node\Entity\Node $node */
   $node = \Drupal::routeMatch()->getParameter('node');
   $node_revision = \Drupal::routeMatch()->getParameter('node_revision');
+
   if ($node_revision !== NULL) {
-    if ($node_revision instanceof NodeInterface) {
-      $node_revision = $node_revision->id();
-    }
-    $node = node_revision_load($node_revision);
+    $node = $node_revision instanceof NodeInterface ? $node_revision : node_revision_load($node_revision);
   }
+
   if (is_null($node)) {
     return;
   }


### PR DESCRIPTION
### Background

**node.routing.yml - 9.2.x**
```
entity.node.revision:
  path: '/node/{node}/revisions/{node_revision}/view'
  defaults:
    _controller: '\Drupal\node\Controller\NodeController::revisionShow'
    _title_callback: '\Drupal\node\Controller\NodeController::revisionPageTitle'
  requirements:
    _access_node_revision: 'view'
    node: \d+
```

**node.routing.yml - 9.3.x**

```
entity.node.revision:
  path: '/node/{node}/revisions/{node_revision}/view'
  defaults:
    _controller: '\Drupal\node\Controller\NodeController::revisionShow'
    _title_callback: '\Drupal\node\Controller\NodeController::revisionPageTitle'
  requirements:
    _entity_access: 'node_revision.view revision'
    node: \d+
  options:
    parameters:
      node:
        type: entity:node
      node_revision:
        type: entity_revision:node
```

### What has changed
1. Added check before loading revision as we received NodeRevision in 9.3.x but only vid integer in 9.2.x
