### PR TITLE
[CIVIC-424] Fixed share text.

### DIFF
--- a/docroot/themes/contrib/civic/includes/civic_media.inc
+++ b/docroot/themes/contrib/civic/includes/civic_media.inc
@@ -90,7 +90,7 @@ function _civic_preprocess_media_civic_video(&$variables) {
     $share_attributes = new Attribute();
     $share_attributes->setAttribute('aria-label', 'Share this video ' . $media->label());
     $variables['share_link'] = [
-      'text' => 'Share this video',
+      'text' => t('Share this video'),
       'is_external' => $media->get('field_c_m_share_link')->first()->isExternal(),
       'new_window' => $media->get('field_c_m_share_link')->first()->isExternal(),
       'url' => $media->get('field_c_m_share_link')->first()->getUrl()->toString(),


### PR DESCRIPTION
### What has changed
1. Hardcoded "Share this video" text as Drupal does not allow changing it.

### Screenshot
![image](https://user-images.githubusercontent.com/57734756/152747050-7c59c676-9769-4a4a-9a67-133326195f80.png)
