### PR TITLE
[CIVIC-397] Change spacing class names to match css naming guide.

### DIFF
--- a/docroot/themes/contrib/civic/civic-library/components/02-molecules/attachment/attachment.scss
+++ b/docroot/themes/contrib/civic/civic-library/components/02-molecules/attachment/attachment.scss
@@ -51,15 +51,15 @@
   flex-grow: 1;
   margin: 0;
 
-  &.civic_attachment--with-space-top {
+  &.civic-attachment--with-space-top {
     padding-top: $civic-attachment-padding-vertical;
   }
 
-  &.civic_attachment--with-space-bottom {
+  &.civic-attachment--with-space-bottom {
     padding-bottom: $civic-attachment-padding-vertical;
   }
 
-  &.civic_attachment--with-space-both {
+  &.civic-attachment--with-space-both {
     padding: $civic-attachment-padding-vertical 0;
   }
 
@@ -160,7 +160,7 @@
   }
 
   &.civic-theme-light {
-    &.civic_attachment--with-background {
+    &.civic-attachment--with-background {
       background-color: $civic-attachment-light-wrapper-background-color;
       padding-left: $civic-attachment-padding-horizontal;
       padding-right: $civic-attachment-padding-horizontal;
@@ -194,7 +194,7 @@
   &.civic-theme-dark {
     background-color: $civic-attachment-dark-background-color;
 
-    &.civic_attachment--with-background {
+    &.civic-attachment--with-background {
       background-color: $civic-attachment-dark-wrapper-background-color;
       padding-left: $civic-attachment-padding-horizontal;
       padding-right: $civic-attachment-padding-horizontal;

--- a/docroot/themes/contrib/civic/civic-library/components/02-molecules/basic-content/basic-content.scss
+++ b/docroot/themes/contrib/civic/civic-library/components/02-molecules/basic-content/basic-content.scss
@@ -5,15 +5,15 @@
 .civic-basic-content {
   $root: &;
 
-  &.civic_content--with-space-top {
+  &.civic-content--with-space-top {
     padding-top: $civic-basic-content-padding-vertical;
   }
 
-  &.civic_content--with-space-bottom {
+  &.civic-content--with-space-bottom {
     padding-bottom: $civic-basic-content-padding-vertical;
   }
 
-  &.civic_content--with-space-both {
+  &.civic-content--with-space-both {
     padding: $civic-basic-content-padding-vertical 0;
   }
 
@@ -185,7 +185,7 @@
   }
 
   &.civic-theme-light {
-    &.civic_content--with-background {
+    &.civic-content--with-background {
       background-color: $civic-basic-content-light-wrapper-background-color;
       padding-left: $civic-basic-content-padding-horizontal;
       padding-right: $civic-basic-content-padding-horizontal;
@@ -251,7 +251,7 @@
   }
 
   &.civic-theme-dark {
-    &.civic_content--with-background {
+    &.civic-content--with-background {
       background-color: $civic-basic-content-dark-wrapper-background-color;
       padding-left: $civic-basic-content-padding-horizontal;
       padding-right: $civic-basic-content-padding-horizontal;

--- a/docroot/themes/contrib/civic/civic-library/components/02-molecules/map/map.scss
+++ b/docroot/themes/contrib/civic/civic-library/components/02-molecules/map/map.scss
@@ -2,15 +2,15 @@
 // Civic Map.
 //
 .civic-map {
-  &.civic_map--with-space-top {
+  &.civic-map--with-space-top {
     padding-top: $civic-map-padding-vertical;
   }
 
-  &.civic_map--with-space-bottom {
+  &.civic-map--with-space-bottom {
     padding-bottom: $civic-map-padding-vertical;
   }
 
-  &.civic_map--with-space-both {
+  &.civic-map--with-space-both {
     padding: $civic-map-padding-vertical 0;
   }
 
@@ -65,7 +65,7 @@
   &.civic-theme-light {
     background-color: $civic-map-light-background-color;
 
-    &.civic_map--with-background {
+    &.civic-map--with-background {
       background-color: $civic-map-light-wrapper-background-color;
       padding-left: $civic-map-padding-horizontal;
       padding-right: $civic-map-padding-horizontal;
@@ -87,7 +87,7 @@
   &.civic-theme-dark {
     background-color: $civic-map-dark-background-color;
 
-    &.civic_map--with-background {
+    &.civic-map--with-background {
       background-color: $civic-map-dark-wrapper-background-color;
       padding-left: $civic-map-padding-horizontal;
       padding-right: $civic-map-padding-horizontal;

--- a/docroot/themes/contrib/civic/civic-library/components/02-molecules/next-steps/next-steps.scss
+++ b/docroot/themes/contrib/civic/civic-library/components/02-molecules/next-steps/next-steps.scss
@@ -9,15 +9,15 @@
   position: relative;
   text-decoration: none;
 
-  &.civic_next_step--with-space-top {
+  &.civic-next-step--with-space-top {
     padding-top: $civic-next-steps-padding-vertical;
   }
 
-  &.civic_next_step--with-space-bottom {
+  &.civic-next-step--with-space-bottom {
     padding-bottom: $civic-next-steps-padding-vertical;
   }
 
-  &.civic_next_step--with-space-both {
+  &.civic-next-step--with-space-both {
     padding: $civic-next-steps-padding-vertical 0;
   }
 

--- a/docroot/themes/contrib/civic/civic-library/components/02-molecules/promo/promo.scss
+++ b/docroot/themes/contrib/civic/civic-library/components/02-molecules/promo/promo.scss
@@ -5,15 +5,15 @@
 .civic-promo {
   $root: &;
 
-  &.civic_promo--with-space-top {
+  &.civic-promo--with-space-top {
     padding-top: $civic-promo-padding-vertical;
   }
 
-  &.civic_promo--with-space-bottom {
+  &.civic-promo--with-space-bottom {
     padding-bottom: $civic-promo-padding-vertical;
   }
 
-  &.civic_promo--with-space-both {
+  &.civic-promo--with-space-both {
     padding: $civic-promo-padding-vertical 0;
   }
 

--- a/docroot/themes/contrib/civic/civic-library/components/03-organisms/accordion/accordion.scss
+++ b/docroot/themes/contrib/civic/civic-library/components/03-organisms/accordion/accordion.scss
@@ -5,15 +5,15 @@
 .civic-accordion {
   $root: &;
 
-  &.civic_accordion--with-space-top {
+  &.civic-accordion--with-space-top {
     padding-top: $civic-accordion-padding-vertical;
   }
 
-  &.civic_accordion--with-space-bottom {
+  &.civic-accordion--with-space-bottom {
     padding-bottom: $civic-accordion-padding-vertical;
   }
 
-  &.civic_accordion--with-space-both {
+  &.civic-accordion--with-space-both {
     padding: $civic-accordion-padding-vertical 0;
   }
 
@@ -120,7 +120,7 @@
   &.civic-theme-light {
     color: $civic-accordion-light-color;
 
-    &.civic_accordion--with-background {
+    &.civic-accordion--with-background {
       background-color: $civic-accordion-light-wrapper-background-color;
       padding-left: $civic-accordion-padding-horizontal;
       padding-right: $civic-accordion-padding-horizontal;
@@ -150,7 +150,7 @@
   &.civic-theme-dark {
     color: $civic-accordion-dark-color;
 
-    &.civic_accordion--with-background {
+    &.civic-accordion--with-background {
       background-color: $civic-accordion-dark-wrapper-background-color;
       padding-left: $civic-accordion-padding-horizontal;
       padding-right: $civic-accordion-padding-horizontal;

--- a/docroot/themes/contrib/civic/civic-library/components/03-organisms/callout/callout.scss
+++ b/docroot/themes/contrib/civic/civic-library/components/03-organisms/callout/callout.scss
@@ -5,15 +5,15 @@
 .civic-callout {
   $root: &;
 
-  &.civic_callout--with-space-top {
+  &.civic-callout--with-space-top {
     padding-top: $civic-callout-padding-vertical;
   }
 
-  &.civic_callout--with-space-bottom {
+  &.civic-callout--with-space-bottom {
     padding-bottom: $civic-callout-padding-vertical;
   }
 
-  &.civic_callout--with-space-both {
+  &.civic-callout--with-space-both {
     padding: $civic-callout-padding-vertical 0;
   }
 

--- a/docroot/themes/contrib/civic/civic-library/components/03-organisms/card-container/card-container.scss
+++ b/docroot/themes/contrib/civic/civic-library/components/03-organisms/card-container/card-container.scss
@@ -5,15 +5,15 @@
 .civic-card-container {
   $root: &;
 
-  &.civic_card_container--with-space-top {
+  &.civic-card-container--with-space-top {
     padding-top: $civic-card-container-padding-vertical;
   }
 
-  &.civic_card_container--with-space-bottom {
+  &.civic-card-container--with-space-bottom {
     padding-bottom: $civic-card-container-padding-vertical;
   }
 
-  &.civic_card_container--with-space-both {
+  &.civic-card-container--with-space-both {
     padding: $civic-card-container-padding-vertical 0;
   }
 
@@ -101,7 +101,7 @@
   &.civic-theme-light {
     color: $civic-card-container-light-color;
 
-    &.civic_card_container--with-background {
+    &.civic-card-container--with-background {
       background-color: $civic-accordion-light-wrapper-background-color;
       padding-left: $civic-card-container-padding-horizontal;
       padding-right: $civic-card-container-padding-horizontal;
@@ -139,7 +139,7 @@
   &.civic-theme-dark {
     color: $civic-card-container-dark-color;
 
-    &.civic_card_container--with-background {
+    &.civic-card-container--with-background {
       background-color: $civic-accordion-dark-wrapper-background-color;
       padding-left: $civic-card-container-padding-horizontal;
       padding-right: $civic-card-container-padding-horizontal;

--- a/docroot/themes/contrib/civic/civic-library/components/03-organisms/slider/slider.scss
+++ b/docroot/themes/contrib/civic/civic-library/components/03-organisms/slider/slider.scss
@@ -1,15 +1,15 @@
 .civic-slider {
   $root: &;
 
-  &.civic_slider--with-space-top {
+  &.civic-slider--with-space-top {
     padding-top: $civic-slider-padding-vertical;
   }
 
-  &.civic_slider--with-space-bottom {
+  &.civic-slider--with-space-bottom {
     padding-bottom: $civic-slider-padding-vertical;
   }
 
-  &.civic_slider--with-space-both {
+  &.civic-slider--with-space-both {
     padding: $civic-slider-padding-vertical 0;
   }
 
@@ -112,7 +112,7 @@
   &.civic-theme-light {
     background-color: $civic-slider-light-background-color;
 
-    &.civic_slider--with-background {
+    &.civic-slider--with-background {
       background-color: $civic-slider-light-wrapper-background-color;
       padding-left: $civic-slider-padding-horizontal;
       padding-right: $civic-slider-padding-horizontal;
@@ -131,7 +131,7 @@
   &.civic-theme-dark {
     background-color: $civic-slider-dark-background-color;
 
-    &.civic_slider--with-background {
+    &.civic-slider--with-background {
       background-color: $civic-slider-dark-wrapper-background-color;
       padding-left: $civic-slider-padding-horizontal;
       padding-right: $civic-slider-padding-horizontal;

--- a/docroot/themes/contrib/civic/includes/paragraphs.inc
+++ b/docroot/themes/contrib/civic/includes/paragraphs.inc
@@ -120,7 +120,7 @@ function _civic_preprocess_paragraph_space(&$variables) {
   /** @var \Drupal\paragraphs\Entity\Paragraph $paragraph */
   $paragraph = $variables['paragraph'];
   if ($paragraph->hasField('field_c_p_space') && !$paragraph->get('field_c_p_space')->isEmpty()) {
-    $component_name = $type = $paragraph->getType();
+    $component_name = str_replace('_', '-', $paragraph->getType());
     $variables['modifier_class'] = $component_name . '--with-space-' . $paragraph->get('field_c_p_space')->getString();
   }
 }
@@ -135,7 +135,7 @@ function _civic_preprocess_paragraph_background(&$variables) {
     && !$paragraph->get('field_c_p_background')->isEmpty()
     && $paragraph->field_c_p_background->value != FALSE
   ) {
-    $component_name = $type = $paragraph->getType();
+    $component_name = str_replace('_', '-', $paragraph->getType());
     if (!array_key_exists('modifier_class', $variables)) {
       $variables['modifier_class'] = '';
     }


### PR DESCRIPTION
### What has changed
1. Updated css class names for with space and with background to match css naming style.

No visual change

### Screenshot
![image](https://user-images.githubusercontent.com/57734756/153994244-8d5858e1-c195-4792-822b-cbfa268df738.png)
