### PR TITLE
Added layout / grid to no result area.

### DIFF
--- a/docroot/themes/contrib/civic/templates/views/views-view.html.twig
+++ b/docroot/themes/contrib/civic/templates/views/views-view.html.twig
@@ -61,7 +61,15 @@
   {% if rows -%}
     {{ rows }}
   {% elseif empty -%}
-    {{ empty }}
+    <div class="civic-listing__empty-results">
+      <div class="container">
+        <div class="row">
+          <div class="col-xs-12">
+            {{ empty }}
+          </div>
+        </div>
+      </div>
+    </div>
   {% endif %}
   {{ pager }}
 


### PR DESCRIPTION
### What has changed
1. Added grid to no result area of view

### Background

Often no results is an after thought and so I have found the most common method for no results text is to add a paragraph with "No results".

This change allow that paragraph to be centered in the grid system within the view.