### PR TITLE
Added svg to allowed image type in civic.

### DIFF
--- a/docroot/themes/contrib/civic/config/install/field.field.media.civic_image.field_c_m_image.yml
+++ b/docroot/themes/contrib/civic/config/install/field.field.media.civic_image.field_c_m_image.yml
@@ -18,7 +18,7 @@ default_value: {  }
 default_value_callback: ''
 settings:
   file_directory: 'images/[date:custom:Y]-[date:custom:m]'
-  file_extensions: 'png gif jpg jpeg'
+  file_extensions: 'png gif jpg jpeg svg'
   max_filesize: ''
   max_resolution: ''
   min_resolution: ''


### PR DESCRIPTION
### What has changed
1. Added svg as an allowed file type for image field.