### PR TITLE
Fix  php warnings in callback modifier.

### DIFF
--- a/docroot/themes/contrib/civic/includes/form.inc
+++ b/docroot/themes/contrib/civic/includes/form.inc
@@ -172,7 +172,6 @@ function _civic_form_alter__modify_element_callbacks(&$element) {
     }
   }
 
-
   // Modifying the ajax callbacks.
   if (!empty($element['#pre_render'])) {
     foreach ($element['#process'] as $index => $callback) {


### PR DESCRIPTION
### What has changed
1. Added checks for existence before iterating.