### PR TITLE
Check for menu items before accessing items.

### DIFF
--- a/docroot/themes/contrib/civictheme/README.md
+++ b/docroot/themes/contrib/civictheme/README.md
@@ -42,8 +42,8 @@ Run the following command from within your sub-theme directory:
 
 ## Development documentation
 
-- [CivicTheme Component Library Documentation](./civictheme_library/docs/introduction.md)
-- [CivicTheme Drupal Theme Documentation](./docs/introduction.md)
+- [CivicTheme Component Library Documentation](./civictheme_library/docs/README.md)
+- [CivicTheme Drupal Theme Documentation](./docs/README.md)
 
 ----
 

--- a/docroot/themes/contrib/civictheme/civictheme_library/README.md
+++ b/docroot/themes/contrib/civictheme/civictheme_library/README.md
@@ -42,7 +42,7 @@ This will build:
 
 ## Documentation
 
-Please refer to dedicated [Documentation](docs/introduction.md).
+Please refer to dedicated [Documentation](docs/README.md).
 
 ----
 

--- a/docroot/themes/contrib/civictheme/civictheme_library/components/01-atoms/input/input.scss
+++ b/docroot/themes/contrib/civictheme/civictheme_library/components/01-atoms/input/input.scss
@@ -37,6 +37,10 @@
     display: inline;
   }
 
+  &--hidden {
+    margin-bottom: 0;
+  }
+
   &__state {
     position: relative;
     margin-left: - civictheme-space(4);

--- a/docroot/themes/contrib/civictheme/docs/namespaces.md
+++ b/docroot/themes/contrib/civictheme/docs/namespaces.md
@@ -1,4 +1,4 @@
-_[CivicTheme Documentation](../README.md) &#8594; [CivicTheme Drupal Theme documentation](introduction.md)  &#8594; Namespaces_
+_[CivicTheme Documentation](../README.md) &#8594; [CivicTheme Drupal Theme documentation](README.md)  &#8594; Namespaces_
 
 # Namespaces
 

--- a/docroot/themes/contrib/civictheme/includes/mobile_navigation.inc
+++ b/docroot/themes/contrib/civictheme/includes/mobile_navigation.inc
@@ -48,7 +48,8 @@ function _civictheme_preprocess_block__civictheme_mobile_navigation(&$variables)
         ['callable' => 'menu.default_tree_manipulators:generateIndexAndSort'],
       ];
       $tree = $menu_tree_service->transform($tree, $manipulators);
-      $variables[$menu_key] = $menu_tree_service->build($tree)['#items'];
+      $build = $menu_tree_service->build($tree);
+      $variables[$menu_key] = $build['#items'] ?? [];
       _civictheme_preprocess_menu_items($variables[$menu_key]);
       $cache_tags = Cache::mergeTags($cache_tags, $menu_block->getCacheTags());
     }


### PR DESCRIPTION
### What has changed
1. Check for menu items before accessing items property.
2. Updated docs to point to `README.md` rather than the non-existent `introduction.md`
3. Remove `margin-bottom` on hidden inputs