### PR TITLE
[CIVIC-691] Added Behat test to ensure that external menu links open in a new tab.

### DIFF
--- a/tests/behat/bootstrap/FeatureContext.php
+++ b/tests/behat/bootstrap/FeatureContext.php
@@ -15,6 +15,7 @@ use DrevOps\BehatSteps\FileTrait;
 use DrevOps\BehatSteps\JsTrait;
 use DrevOps\BehatSteps\LinkTrait;
 use DrevOps\BehatSteps\MediaTrait;
+use DrevOps\BehatSteps\MenuTrait;
 use DrevOps\BehatSteps\OverrideTrait;
 use DrevOps\BehatSteps\ParagraphsTrait;
 use DrevOps\BehatSteps\PathTrait;
@@ -38,6 +39,7 @@ class FeatureContext extends DrupalContext {
   use JsTrait;
   use LinkTrait;
   use MediaTrait;
+  use MenuTrait;
   use OverrideTrait;
   use PathTrait;
   use ParagraphsTrait;

--- a/tests/behat/features/menu.feature
+++ b/tests/behat/features/menu.feature
@@ -1,0 +1,23 @@
+@civictheme @menu
+Feature: Open external links in a new tab
+
+  Ensure that external menu links open in a new tab.
+
+  Background:
+    Given 'Footer' menu_links:
+      | title                       | enabled | uri                     |
+      | [TEST] External Footer link | 1       | https://example.com     |
+    Given 'Primary Navigation' menu_links:
+      | title                        | enabled | uri                     |
+      | [TEST] External Primary link | 1       | https://example.com     |
+    Given 'Secondary Navigation' menu_links:
+      | title                          | enabled | uri                     |
+      | [TEST] External Secondary link | 1       | https://example.com     |
+
+  @api
+  Scenario: External menu links open in a new tab.
+    Given I go to the homepage
+    Then I save screenshot
+    And I should see the '.civictheme-secondary-navigation__menu a[href="https://example.com"]' element with the "target" attribute set to '_blank'
+    And I should see the '.civictheme-primary-navigation__menu a[href="https://example.com"]' element with the "target" attribute set to '_blank'
+    And I should see the '.civictheme-navigation__menu a[href="https://example.com"]' element with the "target" attribute set to '_blank'


### PR DESCRIPTION
<!--
Please follow these rules:
1. SUBJECT: use format [PRJ-123] Verb in past tense with dot at the end.
   - This subject will be used as a commit message after PR is merged.
   - Verbs are usually one of these: Updated, Refactored, Removed, Changed, Added.
   - If there is no ticket - do not put [NOTICKET].

2. BODY: fill-in the template below.

3. CONFLICTS: Make sure that there are no conflicts in your PR. Resolve them before submitting PR for review.

4. COMMENTS: Scan through your PR yourself and comment on the lines that does not look clear enough. This will save SIGNIFICANT time for reviewer to approve the PR.

5. LABEL: Assign 'Needs review' label as soon as you ready to have this reviewed.

6. ASSIGNEE: Assign at least 2 reviewers.     

7. SLACK: Post a link to this PR to #developers channel.

No need to remove these lines - they are comments.
-->

**Issue URL:** https://salsadigital.atlassian.net/browse/CIVIC-691

### Changed
<!--
Provide a list of what was added/changed/removed etc. 

Start with a verb so that it is clear what has happened:Added/ Updated/Removed/Refactored etc.

Also, explain WHY something was done if this was not a normal implementation.
-->
1. Behat test to ensure that external menu links open in a new tab.

Note: Links already have a preprocess to make as external and new window. 
https://github.com/salsadigitalauorg/civictheme_source/blob/develop/docroot/themes/contrib/civictheme/civictheme_library/components/01-atoms/link/link.twig#L24
https://github.com/salsadigitalauorg/civictheme_source/blob/develop/docroot/themes/contrib/civictheme/includes/menu.inc#L38

### Screenshots

<!--
Provide as many screenshots as required to make reviewers understand what was changed.
-->

![Screenshot 2022-06-29 at 8 00 56 PM](https://user-images.githubusercontent.com/83997348/176472927-65c28097-88bd-48c0-a6d8-5a2dd1bb5026.png)
![Screenshot 2022-06-29 at 8 43 26 PM](https://user-images.githubusercontent.com/83997348/176472937-bc54fec2-4fef-48ea-a518-e238a8e3c9ca.png)

