### PR TITLE
[CIVIC-732] Added civictheme_get_field_value. 

### DIFF
--- a/docroot/themes/contrib/civictheme/civictheme_library/components/03-organisms/callout/callout.twig
+++ b/docroot/themes/contrib/civictheme/civictheme_library/components/03-organisms/callout/callout.twig
@@ -66,6 +66,7 @@
                     text: link.text,
                     url: link.url,
                     icon: link.text ? '' : 'arrows_rightarrow_3',
+                    is_external: link.is_external,
                   } only %}
                 {% endif %}
               {% endfor %}

--- a/docroot/themes/contrib/civictheme/includes/accordion.inc
+++ b/docroot/themes/contrib/civictheme/includes/accordion.inc
@@ -5,23 +5,20 @@
  * CivicTheme Accordion paragraph component.
  */
 
-use Drupal\paragraphs\Entity\Paragraph;
-
 /**
  * Implements template_preprocess_paragraph().
  */
 function civictheme_preprocess_paragraph__civictheme_accordion(&$variables) {
   /** @var \Drupal\paragraphs\Entity\Paragraph $paragraph */
   $paragraph = $variables['paragraph'];
-  $variables['expand_all'] = (bool) $paragraph->get('field_c_p_expand')->getString();
+  $variables['expand_all'] = civictheme_get_field_value($paragraph, 'field_c_p_expand') ?? FALSE;
   $variables['panels'] = [];
-  foreach ($paragraph->get('field_c_p_panels') as $panel_reference) {
-    $paragraph_id = $panel_reference->getValue()['target_id'];
-    $panel_paragraph = Paragraph::load($paragraph_id);
+  $panels = civictheme_get_field_value($paragraph, 'field_c_p_panels') ?? [];
+  foreach ($panels as $panel) {
     $variables['panels'][] = [
-      'expanded' => (bool) $panel_paragraph->get('field_c_p_expand')->getString(),
-      'title' => $panel_paragraph->get('field_c_p_title')->getString(),
-      'content' => $panel_paragraph->get('field_c_p_content')->view(),
+      'expanded' => civictheme_get_field_value($panel, 'field_c_p_expand'),
+      'title' => civictheme_get_field_value($panel, 'field_c_p_title'),
+      'content' => civictheme_get_field_value($panel, 'field_c_p_content'),
     ];
   }
 }

--- a/docroot/themes/contrib/civictheme/includes/attachment.inc
+++ b/docroot/themes/contrib/civictheme/includes/attachment.inc
@@ -14,33 +14,32 @@ function civictheme_preprocess_paragraph__civictheme_attachment(&$variables) {
   /** @var \Drupal\paragraphs\Entity\Paragraph $paragraph */
   $paragraph = $variables['paragraph'];
 
-  if (civictheme_field_has_value($paragraph, 'field_c_p_attachments')) {
-    $attachments = [];
-    foreach ($paragraph->field_c_p_attachments->referencedEntities() as $attachment) {
-      $fid = $attachment->getSource()->getSourceFieldValue($attachment);
-      /** @var \Drupal\file\FileInterface $file */
-      $file = $fid ? File::load($fid) : NULL;
-      if (!empty($file)) {
-        $url = $file->createFileUrl(FALSE);
-        $file_size = format_size($file->getSize());
-        $mime_type = $file->getMimeType();
-        $icon = _civictheme_attachment_file_icon_map($mime_type);
-        $file_extension = pathinfo($file->getFileUri(), PATHINFO_EXTENSION);
-        $attachments[] = [
-          'url' => $url,
-          'text' => t('@name <span class="extension">(@ext, @size)</span>', [
-            '@name' => $file->label(),
-            '@ext' => strtoupper($file_extension),
-            '@size' => strtoupper($file_size),
-          ]),
-          'icon' => $icon,
-          'last_updated' => \Drupal::service('date.formatter')->format($attachment->getChangedTime(), 'civictheme_short_date'),
-        ];
-      }
+  $links = NULL;
+  $attachments = civictheme_get_field_value($paragraph, 'field_c_p_attachments') ?? [];
+  foreach ($attachments as $attachment) {
+    $fid = $attachment->getSource()->getSourceFieldValue($attachment);
+    /** @var \Drupal\file\FileInterface $file */
+    $file = $fid ? File::load($fid) : NULL;
+    if (!empty($file)) {
+      $url = $file->createFileUrl(FALSE);
+      $file_size = format_size($file->getSize());
+      $mime_type = $file->getMimeType();
+      $icon = _civictheme_attachment_file_icon_map($mime_type);
+      $file_extension = pathinfo($file->getFileUri(), PATHINFO_EXTENSION);
+      $links[] = [
+        'url' => $url,
+        'text' => t('@name <span class="extension">(@ext, @size)</span>', [
+          '@name' => $file->label(),
+          '@ext' => strtoupper($file_extension),
+          '@size' => strtoupper($file_size),
+        ]),
+        'icon' => $icon,
+        'last_updated' => \Drupal::service('date.formatter')->format($attachment->getChangedTime(), 'civictheme_short_date'),
+      ];
     }
-
-    $variables['links'] = $attachments;
   }
+
+  $variables['links'] = $links;
 }
 
 /**

--- a/docroot/themes/contrib/civictheme/includes/banner.inc
+++ b/docroot/themes/contrib/civictheme/includes/banner.inc
@@ -88,9 +88,7 @@ function _civictheme_preprocess_civictheme_banner_title(&$variables) {
   }
 
   if (!is_null($node)) {
-    if (civictheme_field_has_value($node, 'field_c_n_banner_title')) {
-      $page_title = $node->get('field_c_n_banner_title')->getString();
-    }
+    $page_title = civictheme_get_field_value($node, 'field_c_n_banner_title') ?? $page_title;
   }
 
   $variables['title'] = $page_title ?? '';
@@ -118,9 +116,7 @@ function _civictheme_preprocess_civictheme_banner_breadcrumb(&$variables) {
   // Breadcrumb visibility.
   $hide_breadcrumb = FALSE;
   if (!is_null($node)) {
-    if (civictheme_field_has_value($node, 'field_c_n_banner_hide_breadcrumb')) {
-      $hide_breadcrumb = $node->get('field_c_n_banner_hide_breadcrumb')->getString();
-    }
+    $hide_breadcrumb = civictheme_get_field_value($node, 'field_c_n_banner_hide_breadcrumb') ?? FALSE;
   }
 
   if (!$hide_breadcrumb) {
@@ -154,9 +150,7 @@ function _civictheme_preprocess_civictheme_banner_node(&$variables) {
     return;
   }
 
-  if (civictheme_field_has_value($node, 'field_c_n_banner_type')) {
-    $variables['type'] = $node->get('field_c_n_banner_type')->getString();
-  }
+  $variables['type'] = civictheme_get_field_value($node, 'field_c_n_banner_type');
 
   $variables['theme'] = civictheme_get_theme_value($node) ?? CIVICTHEME_BANNER_DEFAULT_THEME;
 
@@ -164,7 +158,8 @@ function _civictheme_preprocess_civictheme_banner_node(&$variables) {
   $variables['is_front'] = $is_front;
 
   // Last updated date.
-  if (civictheme_field_has_value($node, 'field_c_n_show_last_updated') && $node->get('field_c_n_show_last_updated')->getString()) {
+  $last_updated = civictheme_get_field_value($node, 'field_c_n_show_last_updated');
+  if ($last_updated) {
     $variables['content_middle'][] = [
       '#theme' => 'civictheme_basic_content',
       '#component_theme' => $variables['theme'] ?? NULL,
@@ -173,28 +168,30 @@ function _civictheme_preprocess_civictheme_banner_node(&$variables) {
   }
 
   // Banner background.
-  if (civictheme_field_has_value($node, 'field_c_n_banner_background')) {
-    $variables['background_image'] = civictheme_media_get_url_from_field($node, 'field_c_n_banner_background');
+  $background_image = civictheme_get_field_value($node, 'field_c_n_banner_background', TRUE);
+  if ($background_image !== NULL) {
+    $variables['background_image'] = civictheme_media_get_url($background_image);
   }
 
   // Banner featured image.
-  if (civictheme_field_has_value($node, 'field_c_n_banner_featured_image')) {
-    $variables['featured_image']['src'] = civictheme_media_get_url_from_field($node, 'field_c_n_banner_featured_image');
-    // @todo Iplement correct getter for alt attribute.
-    $variables['featured_image']['alt'] = t('Banner featured image');
+  $featured_image = civictheme_get_field_value($node, 'field_c_n_banner_featured_image', TRUE);
+  if ($featured_image !== NULL) {
+    $image = civictheme_get_field_value($featured_image, 'field_c_m_image', TRUE);
+    $variables['featured_image']['src'] = civictheme_media_get_url($featured_image);
+    $variables['featured_image']['alt'] = $image !== NULL ? $image->getValue()['alt'] : '';
   }
 
   // Banner content components.
-  if (civictheme_field_has_value($node, 'field_c_n_banner_components')) {
-    $entities = $node->field_c_n_banner_components->referencedEntities();
+  $banner_components = civictheme_get_field_value($node, 'field_c_n_banner_components');
+  if ($banner_components) {
     $render_controller = \Drupal::entityTypeManager()->getViewBuilder('paragraph');
-    $variables['content'][] = $render_controller->viewMultiple($entities, 'default');
+    $variables['content'][] = $render_controller->viewMultiple($banner_components, 'default');
   }
 
   // Banner content below components.
-  if (civictheme_field_has_value($node, 'field_c_n_banner_components_bott')) {
-    $entities = $node->field_c_n_banner_components_bott->referencedEntities();
+  $banner_below_components = civictheme_get_field_value($node, 'field_c_n_banner_components_bott');
+  if ($banner_below_components) {
     $render_controller = \Drupal::entityTypeManager()->getViewBuilder('paragraph');
-    $variables['content_below'][] = $render_controller->viewMultiple($entities, 'default');
+    $variables['content_below'][] = $render_controller->viewMultiple($banner_below_components, 'default');
   }
 }

--- a/docroot/themes/contrib/civictheme/includes/callout.inc
+++ b/docroot/themes/contrib/civictheme/includes/callout.inc
@@ -5,35 +5,23 @@
  * CivicTheme Callout paragraph component.
  */
 
-use Drupal\Component\Utility\UrlHelper;
-use Drupal\Core\Url;
-
 /**
  * Implements template_preprocess_paragraph().
  */
 function civictheme_preprocess_paragraph__civictheme_callout(&$variables) {
   /** @var \Drupal\paragraphs\Entity\Paragraph $paragraph */
   $paragraph = $variables['paragraph'];
-
-  if (civictheme_field_has_value($paragraph, 'field_c_p_links')) {
-    $links = [];
-    foreach ($paragraph->field_c_p_links as $link) {
-      if (empty($link)) {
-        continue;
-      }
-      $link_uri = $link->uri;
-      $is_external = UrlHelper::isExternal($link->uri);
-      if (!$is_external) {
-        $link_uri = Url::fromUri($link->uri)->toString();
-      }
-      $links[] = [
-        'url' => $link_uri,
-        'text' => $link->title,
-        'type' => 'primary',
-        'size' => 'regular',
-      ];
-    }
-
-    $variables['links'] = $links;
+  $paragraph_links = civictheme_get_field_value($paragraph, 'field_c_p_links') ?? [];
+  $links = [];
+  foreach ($paragraph_links as $paragraph_link) {
+    $links[] = [
+      'url' => $paragraph_link->getUrl()->toString(),
+      'text' => $paragraph_link->title,
+      'type' => 'primary',
+      'size' => 'regular',
+      'is_external' => $paragraph_link->getUrl()->isExternal(),
+    ];
   }
+
+  $variables['links'] = $links;
 }

--- a/docroot/themes/contrib/civictheme/includes/card_container.inc
+++ b/docroot/themes/contrib/civictheme/includes/card_container.inc
@@ -12,19 +12,17 @@ function civictheme_preprocess_paragraph__civictheme_card_container(&$variables)
   /** @var \Drupal\paragraphs\Entity\Paragraph $paragraph */
   $paragraph = $variables['paragraph'];
 
-  $variables['column_count'] = civictheme_field_has_value($paragraph, 'field_c_p_column_count') ? $paragraph->get('field_c_p_column_count')->getString() : '';
+  $variables['column_count'] = civictheme_get_field_value($paragraph, 'field_c_p_column_count') ?? '';
+  $variables['fill_width'] = civictheme_get_field_value($paragraph, 'field_c_p_fill_width') ?? FALSE;
 
-  $variables['fill_width'] = civictheme_field_has_value($paragraph, 'field_c_p_fill_width') ? (bool) $paragraph->get('field_c_p_fill_width')->getString() : FALSE;
+  $header_link = civictheme_get_field_value($paragraph, 'field_c_p_header_link', TRUE) ?? NULL;
+  $variables['header_link_text'] = $header_link !== NULL ? $header_link->get('title')->getString() : NULL;
+  $variables['header_link_url'] = $header_link !== NULL ? $header_link->getUrl()->toString() : NULL;
 
-  $header_link = civictheme_field_has_value($paragraph, 'field_c_p_header_link') ? $paragraph->get('field_c_p_header_link')->first()->getValue() : [];
-  $variables['header_link_text'] = $header_link['title'] ?? NULL;
-  $variables['header_link_url'] = $header_link['uri'] ?? NULL;
-
-  $footer_link = civictheme_field_has_value($paragraph, 'field_c_p_footer_link') ? $paragraph->get('field_c_p_footer_link')->first()->getValue() : [];
-  $variables['footer_link_text'] = $footer_link['title'] ?? NULL;
-  $variables['footer_link_url'] = $footer_link['uri'] ?? NULL;
-
-  $variables['description'] = civictheme_field_has_value($paragraph, 'field_c_p_description') ? $paragraph->get('field_c_p_description')->getString() : FALSE;
+  $footer_link = civictheme_get_field_value($paragraph, 'field_c_p_footer_link', TRUE);
+  $variables['footer_link_text'] = $footer_link !== NULL ? $footer_link->get('title')->getString() : NULL;
+  $variables['footer_link_url'] = $footer_link !== NULL ? $footer_link->getUrl()->toString() : NULL;
+  $variables['description'] = civictheme_get_field_value($paragraph, 'field_c_p_description') ?? '';
 
   $variables['cards'] = array_filter($variables['content']['field_c_p_cards'], function ($key) {
     return is_numeric($key);

--- a/docroot/themes/contrib/civictheme/includes/cards.inc
+++ b/docroot/themes/contrib/civictheme/includes/cards.inc
@@ -28,7 +28,7 @@ function _civictheme_preprocess_node__card(&$variables) {
 function _civictheme_preprocess_node__civictheme_event_card(&$variables) {
   _civictheme_preprocess_node__card($variables);
   _civictheme_preprocess_node__date($variables);
-  _civictheme_preprocess_node__thumbnail($variables);
+  _civictheme_preprocess_node__thumbnail($variables, 'civictheme_promo_card');
   _civictheme_preprocess_node__topics($variables);
 }
 
@@ -56,7 +56,7 @@ function _civictheme_preprocess_node__theme(&$variables) {
  */
 function _civictheme_preprocess_node__civictheme_navigation_card(&$variables) {
   _civictheme_preprocess_node__card($variables);
-  _civictheme_preprocess_node__thumbnail($variables);
+  _civictheme_preprocess_node__thumbnail($variables, 'civictheme_navigation_card');
 }
 
 /**
@@ -68,7 +68,7 @@ function _civictheme_preprocess_node__civictheme_promo_card(&$variables) {
   $variables['date'] = \Drupal::service('date.formatter')->format($node->getCreatedTime(), 'civictheme_short_date');
   _civictheme_preprocess_node__card($variables);
   _civictheme_preprocess_node__date($variables);
-  _civictheme_preprocess_node__thumbnail($variables);
+  _civictheme_preprocess_node__thumbnail($variables, 'civictheme_promo_card');
   _civictheme_preprocess_node__topics($variables);
 }
 
@@ -86,10 +86,9 @@ function _civictheme_preprocess_node__civictheme_subject_card(&$variables) {
 function _civictheme_preprocess_node__date(&$variables) {
   /** @var \Drupal\node\NodeInterface $node */
   $node = $variables['node'];
-  if ($node->hasField('field_c_n_date')) {
-    if ($date_range = $node->get('field_c_n_date')->getValue()) {
-      $variables['date'] = civictheme_format_short_date($date_range[0]['value']);
-    }
+  $date_range = civictheme_get_field_value($node, 'field_c_n_date', TRUE);
+  if ($date_range) {
+    $variables['date'] = civictheme_format_short_date($date_range->get('value')->getString());
   }
 }
 
@@ -99,24 +98,23 @@ function _civictheme_preprocess_node__date(&$variables) {
 function _civictheme_preprocess_node__topics(&$variables) {
   /** @var \Drupal\node\NodeInterface $node */
   $node = $variables['node'];
-  if ($node->hasField('field_c_n_topics')) {
-    $tags = [];
-    foreach ($node->get('field_c_n_topics')->referencedEntities() as $term) {
-      $tags[] = $term->getName();
-    }
-    $variables['tags'] = $tags;
+  $tags = [];
+  $topic_terms = civictheme_get_field_value($node, 'field_c_n_topics') ?? [];
+  foreach ($topic_terms as $topic_term) {
+    $tags[] = $topic_term->getName();
   }
+  $variables['tags'] = $tags;
 }
 
 /**
  * Pre-process image thumbnail for nodes.
  */
-function _civictheme_preprocess_node__thumbnail(&$variables) {
+function _civictheme_preprocess_node__thumbnail(&$variables, $image_style = NULL) {
   /** @var \Drupal\node\NodeInterface $node */
   $node = $variables['node'];
-  if (civictheme_field_has_value($node, 'field_c_n_thumbnail')) {
-    $media = $node->get('field_c_n_thumbnail')->first()->get('entity')->getTarget()->getValue();
-    $variables['image'] = civictheme_media_image_process_variables($media);
+  $media = civictheme_get_field_value($node, 'field_c_n_thumbnail', TRUE);
+  if ($media) {
+    $variables['image'] = civictheme_media_image_process_variables($media, $image_style);
   }
 }
 
@@ -126,8 +124,9 @@ function _civictheme_preprocess_node__thumbnail(&$variables) {
 function _civictheme_preprocess_node__civictheme_page__summary(&$variables) {
   /** @var \Drupal\node\NodeInterface $node */
   $node = $variables['node'];
-  if (civictheme_field_has_value($node, 'field_c_n_summary')) {
-    $variables['summary'] = text_summary($node->get('field_c_n_summary')->getString(), NULL, 100);
+  $summary = civictheme_get_field_value($node, 'field_c_n_summary');
+  if ($summary) {
+    $variables['summary'] = text_summary($summary, NULL, 100);
   }
 }
 
@@ -138,7 +137,6 @@ function _civictheme_preprocess_node__civictheme_event__summary(&$variables) {
   /** @var \Drupal\node\NodeInterface $node */
   $node = $variables['node'];
   if (civictheme_field_has_value($node, 'field_c_n_body')) {
-    $value = $node->get('field_c_n_body')->getValue();
-    $variables['summary'] = $value[0]['value'];
+    $variables['summary'] = text_summary($node->get('field_c_n_body')->getString(), NULL, 100);
   }
 }

--- a/docroot/themes/contrib/civictheme/includes/content.inc
+++ b/docroot/themes/contrib/civictheme/includes/content.inc
@@ -9,7 +9,6 @@
  * Implements template_preprocess_paragraph().
  */
 function civictheme_preprocess_paragraph__civictheme_content(&$variables) {
-  _civictheme_preprocess_paragraph($variables);
   $content = '';
   if (!empty($variables['content']['field_c_p_content'])) {
     $content = \Drupal::service('renderer')->render($variables['content']['field_c_p_content']);

--- a/docroot/themes/contrib/civictheme/includes/event_card.inc
+++ b/docroot/themes/contrib/civictheme/includes/event_card.inc
@@ -5,9 +5,6 @@
  * CivicTheme event card paragraph component.
  */
 
-use Drupal\Component\Utility\UrlHelper;
-use Drupal\Core\Url;
-
 /**
  * Implements template_preprocess_paragraph().
  */
@@ -16,25 +13,21 @@ function civictheme_preprocess_paragraph__civictheme_event_card(&$variables) {
   $paragraph = $variables['paragraph'];
 
   // Event url.
-  $link = civictheme_field_has_value($paragraph, 'field_c_p_link') ? $paragraph->get('field_c_p_link')->first()->getValue() : [];
-  if (!empty($link['uri']) && !UrlHelper::isExternal($link['uri'])) {
-    $link['uri'] = Url::fromUri($link['uri'])->toString();
+  $link = civictheme_get_field_value($paragraph, 'field_c_p_link', TRUE);
+  if ($link) {
+    $variables['url'] = $link->getUrl()->toString();
+    $variables['is_external'] = $link->isExternal();
   }
-  $variables['url'] = $link['uri'] ?? NULL;
-  $variables['is_external'] = !empty($link['uri']) ? UrlHelper::isExternal($link['uri']) : FALSE;
 
   // Event date.
-  if (civictheme_field_has_value($paragraph, 'field_c_p_date')) {
-    $variables['date'] = \Drupal::service('date.formatter')->format(strtotime($paragraph->get('field_c_p_date')->value), 'civictheme_short_date');
+  $date = civictheme_get_field_value($paragraph, 'field_c_p_date', TRUE);
+  if ($date) {
+    $variables['date'] = civictheme_format_short_date($date->get('value')->getDateTime());
   }
 
   // Event topics.
-  if (civictheme_field_has_value($paragraph, 'field_c_p_topic')) {
-    foreach ($paragraph->get('field_c_p_topic')->referencedEntities() as $topic) {
-      $variables['tags'][] = $topic->label();
-    }
-  }
+  $variables['tags'] = civictheme_get_referenced_entity_labels($paragraph, 'field_c_p_topic');
 
   // Event location.
-  $variables['location'] = civictheme_field_has_value($paragraph, 'field_c_p_location') ? $paragraph->get('field_c_p_location')->getString() : NULL;
+  $variables['location'] = civictheme_get_field_value($paragraph, 'field_c_p_location');
 }

--- a/docroot/themes/contrib/civictheme/includes/iframe.inc
+++ b/docroot/themes/contrib/civictheme/includes/iframe.inc
@@ -13,17 +13,11 @@ use Drupal\Core\Template\Attribute;
 function civictheme_preprocess_paragraph__civictheme_iframe(&$variables) {
   /** @var \Drupal\paragraphs\Entity\Paragraph $paragraph */
   $paragraph = $variables['paragraph'];
-  $variables['url'] = $paragraph->get('field_c_p_url')->getString();
+  $variables['url'] = civictheme_get_field_value($paragraph, 'field_c_p_url');
+  $variables['width'] = civictheme_get_field_value($paragraph, 'field_c_p_width');
+  $variables['height'] = civictheme_get_field_value($paragraph, 'field_c_p_height');
 
-  if (civictheme_field_has_value($paragraph, 'field_c_p_width')) {
-    $variables['width'] = $paragraph->get('field_c_p_width')->getString();
-  }
-
-  if (civictheme_field_has_value($paragraph, 'field_c_p_height')) {
-    $variables['height'] = $paragraph->get('field_c_p_height')->getString();
-  }
-
-  if (civictheme_field_has_value($paragraph, 'field_c_p_attributes')) {
-    $variables['attributes'] = new Attribute(civictheme_parse_attributes($paragraph->get('field_c_p_attributes')->getString()));
+  if ($attributes = civictheme_get_field_value($paragraph, 'field_c_p_attributes')) {
+    $variables['attributes'] = new Attribute(civictheme_parse_attributes($attributes));
   }
 }

--- a/docroot/themes/contrib/civictheme/includes/listing.inc
+++ b/docroot/themes/contrib/civictheme/includes/listing.inc
@@ -6,7 +6,6 @@
  */
 
 use Drupal\Component\Utility\Html;
-use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Render\Element;
 use Drupal\paragraphs\Entity\Paragraph;
 use Drupal\views\Views;
@@ -34,8 +33,8 @@ function civictheme_preprocess_paragraph__civictheme_listing(&$variables) {
   /** @var \Drupal\paragraphs\Entity\Paragraph $paragraph */
   $paragraph = $variables['paragraph'];
   // Get the parent bundle.
-  $variables['view_as'] = $paragraph->get('field_c_p_view_as')->getString();
-  $variables['limit'] = $paragraph->field_c_p_listing_limit->value;
+  $variables['view_as'] = civictheme_get_field_value($paragraph, 'field_c_p_view_as');
+  $variables['limit'] = civictheme_get_field_value($paragraph, 'field_c_p_listing_limit');
   $variables['attributes']['id'] = Html::getUniqueId('listing-' . $paragraph->id());
   if (is_array($variables['attributes'])) {
     $variables['modifier_class'] = implode(' ', $variables['attributes']['class']);
@@ -94,14 +93,14 @@ function _civictheme_listing_get_view_name($view_name) {
  */
 function _civictheme_listing_alter_view($paragraph, &$view) {
   $fallback_limit = CIVICTHEME_LISTINGS_FULL_FALLBACK_LIMIT;
-  $title = $paragraph->field_c_p_title->value;
-  $content_type = $paragraph->field_c_p_content_type->value;
-  $topics = _civictheme_get_entity_field_values($paragraph, 'field_c_p_topics', 'target_id');
-  $view_mode = $paragraph->field_c_p_view_as->value;
-  $limit_type = $paragraph->field_c_p_limit_type->value;
-  $limit = (int) $paragraph->field_c_p_listing_limit->value;
-  $items_per_page = (int) $paragraph->field_c_p_listing_limit->value;
-  $show_filters = (int) $paragraph->field_c_p_show_filters->value;
+  $title = civictheme_get_field_value($paragraph, 'field_c_p_title');
+  $content_type = civictheme_get_field_value($paragraph, 'field_c_p_content_type');
+  $topics = civictheme_get_entity_field_key_values($paragraph, 'field_c_p_topics', 'target_id');
+  $view_mode = civictheme_get_field_value($paragraph, 'field_c_p_view_as');
+  $limit_type = civictheme_get_field_value($paragraph, 'field_c_p_limit_type');
+  $limit = civictheme_get_field_value($paragraph, 'field_c_p_listing_limit');
+  $items_per_page = civictheme_get_field_value($paragraph, 'field_c_p_listing_limit');
+  $show_filters = civictheme_get_field_value($paragraph, 'field_c_p_show_filters');
 
   if ($view) {
     $args = [];
@@ -163,32 +162,4 @@ function _civictheme_listing_alter_view($paragraph, &$view) {
     }
   }
 
-}
-
-/**
- * Get raw multivalued field values from the entity.
- *
- * @param \Drupal\Core\Entity\EntityInterface $entity
- *   The entity to get the values from.
- * @param string $field_name
- *   The field name.
- * @param string $value_key
- *   (optional) The value key. Default to 'value'.
- *
- * @return array
- *   Array of field values. If field does not exist or incorrect $value_key
- *   provided, empty array will be returned.
- */
-function _civictheme_get_entity_field_values(EntityInterface $entity, $field_name, $value_key = 'value') {
-  $values = [];
-
-  if ($entity->hasField($field_name)) {
-    foreach ($entity->get($field_name)->getValue() as $value) {
-      if (isset($value[$value_key])) {
-        $values[] = $value[$value_key];
-      }
-    }
-  }
-
-  return $values;
 }

--- a/docroot/themes/contrib/civictheme/includes/map.inc
+++ b/docroot/themes/contrib/civictheme/includes/map.inc
@@ -5,24 +5,24 @@
  * CivicTheme Accordion paragraph component.
  */
 
-use Drupal\Component\Utility\UrlHelper;
-
 /**
  * Implements template_preprocess_paragraph().
  */
 function civictheme_preprocess_paragraph__civictheme_map(&$variables) {
   /** @var \Drupal\paragraphs\Entity\Paragraph $paragraph */
   $paragraph = $variables['paragraph'];
-  $variables['url'] = $paragraph->get('field_c_p_embed_url')->getString();
-  $variables['address'] = $paragraph->get('field_c_p_address')->getString();
-  if (civictheme_field_has_value($paragraph, 'field_c_p_share_link')) {
-    $link = $paragraph->get('field_c_p_share_link');
-    $variables['share_link'] = $link->getString();
-    $variables['share_link_is_external'] = UrlHelper::isExternal($link->first()->getValue()['uri']);
-  }
-  if (civictheme_field_has_value($paragraph, 'field_c_p_view_link')) {
-    $link = $paragraph->get('field_c_p_view_link');
-    $variables['view_link'] = $link->getString();
-    $variables['view_link_is_external'] = UrlHelper::isExternal($link->first()->getValue()['uri']);
+  $link_embed_url = civictheme_get_field_value($paragraph, 'field_c_p_embed_url', TRUE);
+  $variables['url'] = $link_embed_url->getUrl()->toString();
+  $variables['address'] = civictheme_get_field_value($paragraph, 'field_c_p_address');
+  $link_list = [
+    'share_link' => 'field_c_p_share_link',
+    'view_link' => 'field_c_p_view_link',
+  ];
+  foreach ($link_list as $key => $field_name) {
+    $link = civictheme_get_field_value($paragraph, $field_name, TRUE);
+    if ($link) {
+      $variables[$key] = $link->getUrl()->toString();
+      $variables[$key . '_is_external'] = $link->isExternal();
+    }
   }
 }

--- a/docroot/themes/contrib/civictheme/includes/media.inc
+++ b/docroot/themes/contrib/civictheme/includes/media.inc
@@ -17,8 +17,8 @@ function civictheme_preprocess_media__civictheme_image(&$variables) {
 
   /** @var \Drupal\media\MediaInterface $media */
   $media = $variables['media'];
-  /** @var \Drupal\file\Entity\File $image_file */
-  $image_file = $media->get('field_c_m_image')->referencedEntities()[0];
+  /** @var \Drupal\file\Entity\File|null $image_file */
+  $image_file = civictheme_get_field_referenced_entities($media, 'field_c_m_image', TRUE);
   if ($image_file) {
     /** @var \Drupal\Core\Image\ImageInterface $image */
     $image = \Drupal::service('image.factory')->get($image_file->getFileUri());

--- a/docroot/themes/contrib/civictheme/includes/mobile_navigation.inc
+++ b/docroot/themes/contrib/civictheme/includes/mobile_navigation.inc
@@ -30,47 +30,39 @@ function _civictheme_preprocess_block__civictheme_mobile_navigation(&$variables)
   $cache_tags = $entity->getCacheTags();
   $cacheability = new CacheableMetadata();
   foreach ($menu_fields as $menu_key => $menu_field) {
-    if (
-      civictheme_field_has_value($entity, $menu_field)
-      && !empty($entity->get($menu_field)->referencedEntities()[0])
-      && strpos($entity->get($menu_field)->referencedEntities()[0]->getPluginId(), 'menu_block') === 0
-    ) {
-      $menu_block = $entity->get($menu_field)->referencedEntities()[0];
-      $menu_name = str_replace('menu_block:', '', $menu_block->get('settings')['id']);
-      $root = empty(str_replace($menu_name . ':', '', $menu_block->get('settings')['parent'] ?? '')) ? '' : $menu_block->get('settings')['parent'];
+    $menu_block = civictheme_get_field_referenced_entities($entity, $menu_field, TRUE);
+    if ($menu_block) {
+      if (str_starts_with($menu_block->getPluginId(), 'menu_block:')) {
+        $menu_name = str_replace('menu_block:', '', $menu_block->get('settings')['id']);
+        $root = empty(str_replace($menu_name . ':', '', $menu_block->get('settings')['parent'] ?? '')) ? '' : $menu_block->get('settings')['parent'];
 
-      $menu_parameters = new MenuTreeParameters();
-      // Only set max depth if the depth was provided (greater than 0).
-      if ($menu_block->get('settings')['depth'] ?? 0) {
-        $menu_parameters->setMaxDepth($menu_block->get('settings')['depth']);
+        $menu_parameters = new MenuTreeParameters();
+        // Only set max depth if the depth was provided (greater than 0).
+        if ($menu_block->get('settings')['depth'] ?? 0) {
+          $menu_parameters->setMaxDepth($menu_block->get('settings')['depth']);
+        }
+        $menu_parameters->setRoot($root);
+        $menu_parameters->excludeRoot();
+        $menu_tree_service = \Drupal::service('menu.link_tree');
+
+        $tree = $menu_tree_service->load($menu_name, $menu_parameters);
+        $manipulators = [
+          ['callable' => 'menu.default_tree_manipulators:generateIndexAndSort'],
+        ];
+        $tree = $menu_tree_service->transform($tree, $manipulators);
+
+        $build = $menu_tree_service->build($tree);
+        $variables[$menu_key] = $build['#items'] ?? [];
+
+        _civictheme_preprocess_menu_items($variables[$menu_key]);
+
+        $cacheability = $cacheability->merge(CacheableMetadata::createFromRenderArray($build), $cache_tags, $menu_block->getCacheTags());
       }
-      $menu_parameters->setRoot($root);
-      $menu_parameters->excludeRoot();
-      $menu_tree_service = \Drupal::service('menu.link_tree');
-
-      $tree = $menu_tree_service->load($menu_name, $menu_parameters);
-      $manipulators = [
-        ['callable' => 'menu.default_tree_manipulators:generateIndexAndSort'],
-      ];
-      $tree = $menu_tree_service->transform($tree, $manipulators);
-
-      $build = $menu_tree_service->build($tree);
-      $variables[$menu_key] = $build['#items'] ?? [];
-
-      _civictheme_preprocess_menu_items($variables[$menu_key]);
-
-      $cacheability = $cacheability->merge(CacheableMetadata::createFromRenderArray($build), $cache_tags, $menu_block->getCacheTags());
     }
   }
   $cacheability->applyTo($variables);
 
-  if (civictheme_field_has_value($entity, 'field_c_b_trigger_text')) {
-    $variables['trigger_text'] = $entity->get('field_c_b_trigger_text')->getString();
-  }
-
+  $variables['trigger_text'] = civictheme_get_field_value($entity, 'field_c_b_trigger_text');
   $variables['theme'] = civictheme_get_theme_value($entity);
-
-  if (civictheme_field_has_value($entity, 'field_c_b_trigger_theme')) {
-    $variables['trigger_theme'] = strtolower($entity->get('field_c_b_trigger_theme')->getString());
-  }
+  $variables['trigger_theme'] = civictheme_get_field_value($entity, 'field_c_b_trigger_theme') ?? 'light';
 }

--- a/docroot/themes/contrib/civictheme/includes/navigation_card.inc
+++ b/docroot/themes/contrib/civictheme/includes/navigation_card.inc
@@ -5,19 +5,16 @@
  * CivicTheme navigation card paragraph component.
  */
 
-use Drupal\Component\Utility\UrlHelper;
-use Drupal\Core\Url;
-
 /**
  * Implements template_preprocess_paragraph().
  */
 function civictheme_preprocess_paragraph__civictheme_navigation_card(&$variables) {
   /** @var \Drupal\paragraphs\Entity\Paragraph $paragraph */
   $paragraph = $variables['paragraph'];
-  $link = civictheme_field_has_value($paragraph, 'field_c_p_link') ? $paragraph->get('field_c_p_link')->first()->getValue() : [];
-  if (!empty($link['uri']) && !UrlHelper::isExternal($link['uri'])) {
-    $link['uri'] = Url::fromUri($link['uri'])->toString();
+  /** @var \Drupal\link\Plugin\Field\FieldType\LinkItem|NULL $link */
+  $link = civictheme_get_field_value($paragraph, 'field_c_p_link', TRUE);
+  if ($link) {
+    $variables['url'] = $link->getUrl()->toString();
+    $variables['is_external'] = $link->isExternal();
   }
-  $variables['url'] = $link['uri'] ?? NULL;
-  $variables['is_external'] = (isset($link['uri']) && !empty($link['uri'])) ? UrlHelper::isExternal($link['uri']) : FALSE;
 }

--- a/docroot/themes/contrib/civictheme/includes/next_step.inc
+++ b/docroot/themes/contrib/civictheme/includes/next_step.inc
@@ -5,19 +5,16 @@
  * CivicTheme Next step paragraph component.
  */
 
-use Drupal\Component\Utility\UrlHelper;
-use Drupal\Core\Url;
-
 /**
  * Implements template_preprocess_paragraph().
  */
 function civictheme_preprocess_paragraph__civictheme_next_step(&$variables) {
   /** @var \Drupal\paragraphs\Entity\Paragraph $paragraph */
   $paragraph = $variables['paragraph'];
-
-  $link = (civictheme_field_has_value($paragraph, 'field_c_p_link')) ? $paragraph->get('field_c_p_link')->first()->getValue() : [];
-  if (!empty($link['uri']) && !UrlHelper::isExternal($link['uri'])) {
-    $link['uri'] = Url::fromUri($link['uri'])->toString();
+  /** @var \Drupal\link\Plugin\Field\FieldType\LinkItem|NULL $link */
+  $link = civictheme_get_field_value($paragraph, 'field_c_p_link', TRUE);
+  if ($link) {
+    $variables['url'] = $link->getUrl()->toString();
+    $variables['is_external'] = $link->isExternal();
   }
-  $variables['url'] = $link['uri'] ?? NULL;
 }

--- a/docroot/themes/contrib/civictheme/includes/node.inc
+++ b/docroot/themes/contrib/civictheme/includes/node.inc
@@ -8,6 +8,11 @@
 use Drupal\Core\Template\Attribute;
 
 /**
+ * Defines default node theme.
+ */
+define('CIVICTHEME_NODE_DEFAULT_THEME', 'light');
+
+/**
  * Generic pre-process for all view mode of nodes.
  */
 function _civictheme_preprocess_node(&$variables) {
@@ -29,7 +34,7 @@ function _civictheme_preprocess_node(&$variables) {
   }
 
   // Add Table of Contents if the value is set on node.
-  if ($node->hasField('field_c_n_show_toc') && $node->field_c_n_show_toc->getString()) {
+  if (civictheme_get_field_value($node, 'field_c_n_show_toc')) {
     $toc_attributes = [];
     $toc_attributes['data-table-of-contents-position'] = 'prepend';
     $toc_attributes['data-table-of-contents-theme'] = 'light';
@@ -80,7 +85,7 @@ function _civictheme_preprocess_node__civictheme_alert__full(&$variables) {
   $variables['id'] = $node->id();
   $variables['title'] = $node->label();
   $variables['description'] = $node->get('field_c_n_body')->value;
-  $variables['type'] = $node->get('field_c_n_alert_type')->getString();
+  $variables['type'] = civictheme_get_field_value($node, 'field_c_n_alert_type');
 }
 
 /**
@@ -97,15 +102,10 @@ function _civictheme_preprocess_page__node(&$variables) {
   // Layout determines whether a node is contained and what it's layout is.
   $variables['page']['content_contained'] = FALSE;
 
-  // Add vertical space.
-  if ($node->hasField('field_c_n_space')) {
-    $variables['vertical_space'] = $node->get('field_c_n_space')->getString();
-  }
+  $variables['vertical_space'] = civictheme_get_field_value($node, 'field_c_n_space');
 
   // Hide sidebar check.
-  if (civictheme_field_has_value($node, 'field_c_n_hide_sidebar') && $node->get('field_c_n_hide_sidebar')->getString()) {
-    $variables['hide_sidebar'] = TRUE;
-  }
+  $variables['hide_sidebar'] = civictheme_get_field_value($node, 'field_c_n_hide_sidebar') ?? FALSE;
 }
 
 /**
@@ -114,6 +114,10 @@ function _civictheme_preprocess_page__node(&$variables) {
 function _civictheme_preprocess_node__civictheme_slider_slide(&$variables) {
   /** @var \Drupal\node\NodeInterface $node */
   $node = $variables['node'];
+  // @todo add theme field to reference slide.
+  $paragraph = $node->_referringItem->getEntity();
+  $variables['theme'] = $paragraph->civic_theme;
+  $theme = $variables['theme'];
 
   $variables['title'] = $node->label();
 
@@ -129,29 +133,22 @@ function _civictheme_preprocess_node__civictheme_slider_slide(&$variables) {
   $variables['attributes']['data-component-civictheme-slider-slide'] = '';
 
   // Topic.
-  if (civictheme_field_has_value($node, 'field_c_n_topics')) {
-    $topics = [];
-    foreach ($node->get('field_c_n_topics')->referencedEntities() as $topic) {
-      $topics[] = [
-        'theme' => $variables['theme'],
-        'text' => $topic->label(),
+  if ($topics = civictheme_get_referenced_entity_labels($paragraph, 'field_c_p_topic')) {
+    $topics = array_map(function ($topic) use ($theme) {
+      return [
+        'text' => $topic,
+        'theme' => $theme,
       ];
-    }
+    }, $topics);
+
     $variables['content_top']['slide_topics'] = [
       '#theme' => 'civictheme_slider_slide_tags',
       '#tags' => $topics,
     ];
   }
 
-  // Summary.
-  // Page.
-  if (civictheme_field_has_value($node, 'field_c_n_summary')) {
-    $variables['summary'] = $node->get('field_c_n_summary')->view();
-  }
-  // Event.
-  if (civictheme_field_has_value($node, 'field_c_n_tagline')) {
-    $variables['summary'] = $node->get('field_c_n_tagline')->view();
-  }
+  // Set summary for either page or event.
+  $variables['summary'] = civictheme_get_field_value($node, 'field_c_n_summary') ?? civictheme_get_field_value($node, 'field_c_n_tagline');
 
   // Links.
   $inverse_theme = $variables['theme'] === 'dark' ? 'light' : 'dark';

--- a/docroot/themes/contrib/civictheme/includes/paragraphs.inc
+++ b/docroot/themes/contrib/civictheme/includes/paragraphs.inc
@@ -89,7 +89,7 @@ function _civictheme_preprocess_paragraph__field__summary(&$variables) {
   /** @var \Drupal\paragraphs\Entity\Paragraph $paragraph */
   $paragraph = $variables['paragraph'];
   if (civictheme_field_has_value($paragraph, 'field_c_p_summary')) {
-    $variables['summary'] = text_summary($paragraph->get('field_c_p_summary')->getString(), NULL, 100);
+    $variables['summary'] = text_summary(civictheme_get_field_value($paragraph, 'field_c_p_summary'), NULL, 100);
   }
 }
 
@@ -100,7 +100,7 @@ function _civictheme_preprocess_paragraph__field__title(&$variables) {
   /** @var \Drupal\paragraphs\Entity\Paragraph $paragraph */
   $paragraph = $variables['paragraph'];
   if (civictheme_field_has_value($paragraph, 'field_c_p_title')) {
-    $variables['title'] = $paragraph->get('field_c_p_title')->getString();
+    $variables['title'] = civictheme_get_field_value($paragraph, 'field_c_p_title');
   }
 }
 
@@ -111,7 +111,7 @@ function _civictheme_preprocess_paragraph__field__space(&$variables) {
   /** @var \Drupal\paragraphs\Entity\Paragraph $paragraph */
   $paragraph = $variables['paragraph'];
   if (civictheme_field_has_value($paragraph, 'field_c_p_space')) {
-    $variables['vertical_space'] = $paragraph->get('field_c_p_space')->getString();
+    $variables['vertical_space'] = civictheme_get_field_value($paragraph, 'field_c_p_space');
   }
 }
 
@@ -121,7 +121,7 @@ function _civictheme_preprocess_paragraph__field__space(&$variables) {
 function _civictheme_preprocess_paragraph__field__background(&$variables) {
   /** @var \Drupal\paragraphs\Entity\Paragraph $paragraph */
   $paragraph = $variables['paragraph'];
-  if (civictheme_field_has_value($paragraph, 'field_c_p_background') && (bool) $paragraph->field_c_p_background->value !== FALSE) {
+  if (civictheme_get_field_value($paragraph, 'field_c_p_background')) {
     $component_name = str_replace('_', '-', $paragraph->getType());
     if (!array_key_exists('modifier_class', $variables)) {
       $variables['modifier_class'] = '';
@@ -136,14 +136,9 @@ function _civictheme_preprocess_paragraph__field__background(&$variables) {
 function _civictheme_preprocess_paragraph__card__icon(&$variables) {
   /** @var \Drupal\paragraphs\Entity\Paragraph $paragraph */
   $paragraph = $variables['paragraph'];
-  if (civictheme_field_has_value($paragraph, 'field_c_p_icon')) {
-    $target = $paragraph->get('field_c_p_icon')->first()->get('entity')->getTarget();
-    if ($target) {
-      $media = $target->getValue();
-      if ($image = civictheme_media_image_process_variables($media)) {
-        $variables['image'] = $image;
-      }
-    }
+  $media = civictheme_get_field_value($paragraph, 'field_c_p_icon', TRUE);
+  if ($media) {
+    $variables['image'] = civictheme_media_image_process_variables($media);
   }
 }
 
@@ -153,12 +148,9 @@ function _civictheme_preprocess_paragraph__card__icon(&$variables) {
 function _civictheme_preprocess_paragraph__card__image(&$variables) {
   /** @var \Drupal\paragraphs\Entity\Paragraph $paragraph */
   $paragraph = $variables['paragraph'];
-  if (civictheme_field_has_value($paragraph, 'field_c_p_image')) {
-    $target = $paragraph->get('field_c_p_image')->first()->get('entity')->getTarget();
-    if ($target) {
-      $media = $target->getValue();
-      $variables['image'] = civictheme_media_image_process_variables($media);
-    }
+  $media = civictheme_get_field_value($paragraph, 'field_c_p_image', TRUE);
+  if ($media) {
+    $variables['image'] = civictheme_media_image_process_variables($media);
   }
 }
 

--- a/docroot/themes/contrib/civictheme/includes/promo.inc
+++ b/docroot/themes/contrib/civictheme/includes/promo.inc
@@ -5,24 +5,20 @@
  * CivicTheme promo paragraph component.
  */
 
-use Drupal\Component\Utility\UrlHelper;
-use Drupal\Core\Url;
-
 /**
  * Implements template_preprocess_paragraph().
  */
 function civictheme_preprocess_paragraph__civictheme_promo(&$variables) {
   /** @var \Drupal\paragraphs\Entity\Paragraph $paragraph */
   $paragraph = $variables['paragraph'];
-  $link = civictheme_field_has_value($paragraph, 'field_c_p_link') ? $paragraph->get('field_c_p_link')->first()->getValue() : [];
-  if (!empty($link['uri'])) {
+  /** @var \Drupal\link\Plugin\Field\FieldType\LinkItem|null $link */
+  $link = civictheme_get_field_value($paragraph, 'field_c_p_link', TRUE);
+  if ($link) {
     $variables['link'] = [
-      'text' => $link['title'] ?? '',
-      'url' => Url::fromUri($link['uri'])->toString(),
-      'is_new_window' => UrlHelper::isExternal($link['uri']),
+      'text' => $link->get('title')->getString(),
+      'url' => $link->getUrl()->toString(),
+      'is_new_window' => $link->isExternal(),
     ];
   }
-  if (civictheme_field_has_value($paragraph, 'field_c_p_summary')) {
-    $variables['content'] = $paragraph->get('field_c_p_summary')->getString();
-  }
+  $variables['content'] = civictheme_get_field_value($paragraph, 'field_c_p_summary');
 }

--- a/docroot/themes/contrib/civictheme/includes/promo_card.inc
+++ b/docroot/themes/contrib/civictheme/includes/promo_card.inc
@@ -5,31 +5,28 @@
  * CivicTheme card promo paragraph component.
  */
 
-use Drupal\Component\Utility\UrlHelper;
-use Drupal\Core\Url;
-
 /**
  * Implements template_preprocess_paragraph().
  */
 function civictheme_preprocess_paragraph__civictheme_promo_card(&$variables) {
   /** @var \Drupal\paragraphs\Entity\Paragraph $paragraph */
   $paragraph = $variables['paragraph'];
-  $link = civictheme_field_has_value($paragraph, 'field_c_p_link') ? $paragraph->get('field_c_p_link')->first()->getValue() : [];
-  if (!empty($link['uri']) && !UrlHelper::isExternal($link['uri'])) {
-    $link['uri'] = Url::fromUri($link['uri'])->toString();
+  /** @var \Drupal\link\Plugin\Field\FieldType\LinkItem|null $link */
+  $link = civictheme_get_field_value($paragraph, 'field_c_p_link', TRUE);
+  if ($link) {
+    $variables['url'] = $link->getUrl()->toString();
+    $variables['is_external'] = $link->isExternal();
   }
-  $variables['url'] = $link['uri'] ?? NULL;
-  $variables['is_external'] = !empty($link['uri']) ? UrlHelper::isExternal($link['uri']) : FALSE;
 
   // Promo date.
-  if (civictheme_field_has_value($paragraph, 'field_c_p_date')) {
-    $variables['date'] = \Drupal::service('date.formatter')->format(strtotime($paragraph->get('field_c_p_date')->value), 'civictheme_short_date');
+  $date = civictheme_get_field_value($paragraph, 'field_c_p_date', TRUE);
+  if ($date) {
+    $variables['date'] = civictheme_format_short_date($date->get('value')->getDateTime());
   }
 
   // Topics.
-  if (civictheme_field_has_value($paragraph, 'field_c_p_topics')) {
-    foreach ($paragraph->get('field_c_p_topics')->referencedEntities() as $topic) {
-      $variables['tags'][] = $topic->label();
-    }
+  $topics = civictheme_get_referenced_entity_labels($paragraph, 'field_c_p_topics');
+  if ($topics) {
+    $variables['tags'] = $topics;
   }
 }

--- a/docroot/themes/contrib/civictheme/includes/publication_card.inc
+++ b/docroot/themes/contrib/civictheme/includes/publication_card.inc
@@ -5,8 +5,6 @@
  * CivicTheme publication card paragraph component.
  */
 
-use Drupal\Component\Utility\UrlHelper;
-use Drupal\Core\Url;
 use Drupal\file\Entity\File;
 
 /**
@@ -15,30 +13,29 @@ use Drupal\file\Entity\File;
 function civictheme_preprocess_paragraph__civictheme_publication_card(&$variables) {
   /** @var \Drupal\paragraphs\Entity\Paragraph $paragraph */
   $paragraph = $variables['paragraph'];
-  $link = civictheme_field_has_value($paragraph, 'field_c_p_link') ? $paragraph->get('field_c_p_link')->first()->getValue() : [];
-  if (!empty($link['uri']) && !UrlHelper::isExternal($link['uri'])) {
-    $link['uri'] = Url::fromUri($link['uri'])->toString();
-  }
-  $variables['url'] = $link['uri'] ?? NULL;
-  $variables['is_external'] = !empty($link['uri']) ? UrlHelper::isExternal($link['uri']) : FALSE;
-  // Publication card size.
-  if (civictheme_field_has_value($paragraph, 'field_c_p_size')) {
-    $variables['size'] = $paragraph->get('field_c_p_size')->getString();
+  $link = civictheme_get_field_value($paragraph, 'field_c_p_link', TRUE);
+  if ($link) {
+    $variables['url'] = $link->getUrl()->toString();
+    $variables['is_external'] = $link->isExternal();
   }
 
-  if (civictheme_field_has_value($paragraph, 'field_c_p_document')) {
-    $documents = $paragraph->field_c_p_document->referencedEntities();
-    $document = reset($documents);
+  // Publication card size.
+  $variables['size'] = civictheme_get_field_value($paragraph, 'field_c_p_size');
+  /** @var \Drupal\media\MediaInterface|null $document $document */
+  $document = civictheme_get_field_value($paragraph, 'field_c_p_document', TRUE);
+  if ($document) {
     $fid = $document->getSource()->getSourceFieldValue($document);
 
     /** @var \Drupal\file\FileInterface $file */
     $file = $fid ? File::load($fid) : NULL;
     if (!empty($file)) {
-      $url = $file->createFileUrl(FALSE);
-      $file_size = format_size($file->getSize());
-      $variables['link']['url'] = $url;
-      $variables['link']['text'] = sprintf('%s (%s)', $file->getFilename(), $file_size);
-      $variables['url'] = $url;
+      $url = file_create_url($file->createFileUrl());
+      if ($url) {
+        $file_size = format_size($file->getSize());
+        $variables['link']['url'] = $url;
+        $variables['link']['text'] = sprintf('%s (%s)', $file->getFilename(), $file_size);
+        $variables['url'] = $url;
+      }
     }
   }
 }

--- a/docroot/themes/contrib/civictheme/includes/quick_links.inc
+++ b/docroot/themes/contrib/civictheme/includes/quick_links.inc
@@ -5,25 +5,20 @@
  * CivicTheme quick links paragraph component.
  */
 
-use Drupal\Component\Utility\UrlHelper;
-use Drupal\Core\Url;
-
 /**
  * Implements template_preprocess_paragraph().
  */
 function civictheme_preprocess_paragraph__civictheme_quick_links(&$variables) {
   /** @var \Drupal\paragraphs\Entity\Paragraph $paragraph */
   $paragraph = $variables['paragraph'];
-
-  if (civictheme_field_has_value($paragraph, 'field_c_p_links')) {
-    foreach ($paragraph->get('field_c_p_links')->getValue() as $link) {
-      $is_external = UrlHelper::isExternal($link['uri']);
-      $variables['links'][] = [
-        'url' => Url::fromUri($link['uri'])->toString(),
-        'text' => $link['title'],
-        'is_external' => $is_external,
-        'is_new_window' => $is_external,
-      ];
-    }
+  /** @var \Drupal\link\Plugin\Field\FieldType\LinkItem[]|null $links */
+  $links = civictheme_get_field_value($paragraph, 'field_c_p_links') ?? [];
+  foreach ($links as $link) {
+    $variables['links'][] = [
+      'url' => $link->getUrl()->toString(),
+      'text' => $link->get('title')->getString(),
+      'is_external' => $link->isExternal(),
+      'is_new_window' => $link->isExternal(),
+    ];
   }
 }

--- a/docroot/themes/contrib/civictheme/includes/search.inc
+++ b/docroot/themes/contrib/civictheme/includes/search.inc
@@ -5,8 +5,6 @@
  * CivicTheme Search block type.
  */
 
-use Drupal\Core\Url;
-
 /**
  * Implements template_preprocess_block().
  */
@@ -21,8 +19,9 @@ function civictheme_preprocess_block__civictheme_search(&$variables) {
   }
 
   $variables['content'] = NULL;
-
-  $link = $entity->get('field_c_b_link')->first()->getValue();
-  $variables['url'] = Url::fromUri($link['uri'])->toString();
-  $variables['text'] = $link['title'] ?? '';
+  /** @var \Drupal\link\Plugin\Field\FieldType\LinkItem|null $link */
+  if ($link = civictheme_get_field_value($entity, 'field_c_b_link', TRUE)) {
+    $variables['url'] = $link->getUrl()->toString();
+    $variables['text'] = $link->get('title')->getString();
+  }
 }

--- a/docroot/themes/contrib/civictheme/includes/service_card.inc
+++ b/docroot/themes/contrib/civictheme/includes/service_card.inc
@@ -5,9 +5,6 @@
  * CivicTheme Service card paragraph component.
  */
 
-use Drupal\Component\Utility\UrlHelper;
-use Drupal\Core\Url;
-
 /**
  * Implements template_preprocess_paragraph().
  */
@@ -15,18 +12,14 @@ function civictheme_preprocess_paragraph__civictheme_service_card(&$variables) {
   /** @var \Drupal\paragraphs\Entity\Paragraph $paragraph */
   $paragraph = $variables['paragraph'];
 
-  if (civictheme_field_has_value($paragraph, 'field_c_p_links')) {
-    foreach ($paragraph->get('field_c_p_links')->getValue() as $link) {
-      $is_external = UrlHelper::isExternal($link['uri']);
-      if (!$is_external) {
-        $link['uri'] = Url::fromUri($link['uri'])->toString();
-      }
-      $variables['links'][] = [
-        'url' => $link['uri'],
-        'text' => $link['title'],
-        'is_external' => $is_external,
-        'is_new_window' => $is_external,
-      ];
-    }
+  /** @var \Drupal\link\Plugin\Field\FieldType\LinkItem[]|null $links */
+  $links = civictheme_get_field_value($paragraph, 'field_c_p_links') ?? [];
+  foreach ($links as $link) {
+    $variables['links'][] = [
+      'url' => $link->getUrl()->toString(),
+      'text' => $link->get('title')->getString(),
+      'is_external' => $link->isExternal(),
+      'is_new_window' => $link->isExternal(),
+    ];
   }
 }

--- a/docroot/themes/contrib/civictheme/includes/slider.inc
+++ b/docroot/themes/contrib/civictheme/includes/slider.inc
@@ -5,8 +5,6 @@
  * CivicTheme Slider paragraph component.
  */
 
-use Drupal\Core\Url;
-
 /**
  * Implements template_preprocess_paragraph().
  */
@@ -17,13 +15,14 @@ function civictheme_preprocess_paragraph__civictheme_slider(&$variables) {
   $variables['next_label'] = t('Next');
 
   // Link.
-  if (civictheme_field_has_value($paragraph, 'field_c_p_link')) {
-    $link = $paragraph->get('field_c_p_link')->first();
+  $link = civictheme_get_field_value($paragraph, 'field_c_p_link', TRUE);
+  if ($link) {
     $variables['link'] = [
       'type' => 'secondary',
       'size' => 'regular',
       'text' => $link->get('title')->getString(),
-      'url' => Url::fromUri($link->get('uri')->getString()),
+      'url' => $link->getUrl()->toString(),
+      'is_external' => $link->isExternal(),
     ];
   }
 
@@ -39,25 +38,24 @@ function civictheme_preprocess_paragraph__civictheme_slider(&$variables) {
 function civictheme_preprocess_paragraph__civictheme_slider_slide(&$variables) {
   /** @var \Drupal\paragraphs\Entity\Paragraph $paragraph */
   $paragraph = $variables['paragraph'];
+  $theme = $variables['theme'];
 
   _civictheme_preprocess_paragraph__card__image($variables);
 
   $variables['attributes']['data-component-civictheme-slider-slide'] = '';
 
   // Image position.
-  if (civictheme_field_has_value($paragraph, 'field_c_p_image_position')) {
-    $variables['image_position'] = $paragraph->get('field_c_p_image_position')->getString();
-  }
+  $variables['image_position'] = civictheme_get_field_value($paragraph, 'field_c_p_image_position');
 
   // Topic.
-  if (civictheme_field_has_value($paragraph, 'field_c_p_topic')) {
-    $topics = [];
-    foreach ($paragraph->get('field_c_p_topic')->referencedEntities() as $topic) {
-      $topics[] = [
-        'theme' => $variables['theme'],
-        'text' => $topic->label(),
+  if ($topics = civictheme_get_referenced_entity_labels($paragraph, 'field_c_p_topic')) {
+    $topics = array_map(function ($topic) use ($theme) {
+      return [
+        'text' => $topic,
+        'theme' => $theme,
       ];
-    }
+    }, $topics);
+
     $variables['content_top']['slide_topics'] = [
       '#theme' => 'civictheme_slider_slide_tags',
       '#tags' => $topics,
@@ -65,20 +63,17 @@ function civictheme_preprocess_paragraph__civictheme_slider_slide(&$variables) {
   }
 
   // Summary.
-  if (civictheme_field_has_value($paragraph, 'field_c_p_content')) {
-    $variables['summary'] = $paragraph->get('field_c_p_content')->view();
-  }
+  $variables['summary'] = civictheme_get_field_value($paragraph, 'field_c_p_content', TRUE);
 
   // Links.
-  if (civictheme_field_has_value($paragraph, 'field_c_p_link')) {
-    $inverse_theme = $variables['theme'] === 'dark' ? 'light' : 'dark';
-    $link = $paragraph->get('field_c_p_link')->first();
-    $links = [];
+  $link = civictheme_get_field_value($paragraph, 'field_c_p_link', TRUE);
+  if ($link) {
+    $inverse_theme = $theme === 'dark' ? 'light' : 'dark';
     $links[] = [
       'type' => 'primary',
       'size' => 'regular',
       'text' => $link->get('title')->getString(),
-      'url' => Url::fromUri($link->get('uri')->getString()),
+      'url' => $link->getUrl()->toString(),
     ];
     $variables['links']['slide_links'] = [
       '#theme' => 'civictheme_slider_slide_links',
@@ -86,4 +81,16 @@ function civictheme_preprocess_paragraph__civictheme_slider_slide(&$variables) {
       '#links' => $links,
     ];
   }
+}
+
+/**
+ * Implements template_preprocess_paragraph().
+ */
+function civictheme_preprocess_paragraph__civictheme_slider_slide_ref(&$variables) {
+  /** @var \Drupal\paragraphs\Entity\Paragraph $paragraph */
+  $paragraph = $variables['paragraph'];
+  $parent = $paragraph->_referringItem->getEntity();
+  // @todo add theme field to reference slide.
+  $theme = civictheme_get_theme_value($parent);
+  $paragraph->civic_theme = $theme;
 }

--- a/docroot/themes/contrib/civictheme/includes/social_links.inc
+++ b/docroot/themes/contrib/civictheme/includes/social_links.inc
@@ -23,37 +23,33 @@ function _civictheme_preprocess_block__civictheme_social_links(&$variables) {
     return;
   }
 
-  /** @var \Drupal\paragraphs\Entity\Paragraph[] $paragraphs */
-  $paragraphs = $entity->field_c_b_social_icons->referencedEntities();
-
   $items = [];
-  if (!empty($paragraphs)) {
-    foreach ($paragraphs as $paragraph) {
-      $item = [];
-      $link = civictheme_field_has_value($paragraph, 'field_c_p_link') ? $paragraph->get('field_c_p_link')->first()->getValue() : [];
-      $item['url'] = $link['uri'] ?? NULL;
-      $item['title'] = $link['title'] ?? NULL;
-      $item['size'] = 'regular';
-
-      if (!isset($items['image'])) {
-        $item['paragraph'] = $paragraph;
-        _civictheme_preprocess_paragraph__card__icon($item);
-        unset($item['paragraph']);
-      }
-
-      if (isset($item['image'])) {
-        // Embed SVG as HTML content by passing as text.
-        $item['text'] = civictheme_embed_svg($item['image']['src'], [
-          'civictheme-icon',
-          'civictheme-icon--size-' . $item['size'],
-        ]);
-      }
-      $items[] = $item;
+  /** @var \Drupal\paragraphs\Entity\Paragraph[] $paragraphs|null */
+  $social_link_paragraphs = civictheme_get_field_referenced_entities($entity, 'field_c_b_social_icons') ?? [];
+  foreach ($social_link_paragraphs as $social_link_paragraph) {
+    $item = [];
+    /** @var \Drupal\link\Plugin\Field\FieldType\LinkItem|null $link */
+    $link = civictheme_get_field_value($social_link_paragraph, 'field_c_p_link', TRUE);
+    if ($link) {
+      $item['url'] = $link->getUrl()->toString();
+      $item['title'] = $link->get('title')->getString();
     }
+    $item['size'] = 'regular';
+    $media = civictheme_get_field_value($social_link_paragraph, 'field_c_p_icon', TRUE);
+    if ($media) {
+      $item['image'] = civictheme_media_image_process_variables($media);
+    }
+
+    if (isset($item['image'])) {
+      // Embed SVG as HTML content by passing as text.
+      $item['text'] = civictheme_embed_svg($item['image']['src'], [
+        'civictheme-icon',
+        'civictheme-icon--size-' . $item['size'],
+      ]);
+    }
+    $items[] = $item;
   }
   $variables['items'] = $items;
-
   $variables['theme'] = civictheme_get_theme_value($entity) ?? CIVICTHEME_SOCIAL_LINKS_DEFAULT_THEME;
-
-  $variables['with_border'] = civictheme_field_has_value($entity, 'field_c_b_with_border') ? (bool) $entity->get('field_c_b_with_border')->getString() : FALSE;
+  $variables['with_border'] = civictheme_get_field_value($entity, 'field_c_b_with_border') ?? FALSE;
 }

--- a/docroot/themes/contrib/civictheme/includes/subject_card.inc
+++ b/docroot/themes/contrib/civictheme/includes/subject_card.inc
@@ -5,18 +5,16 @@
  * CivicTheme subject card paragraph component.
  */
 
-use Drupal\Component\Utility\UrlHelper;
-use Drupal\Core\Url;
-
 /**
  * Implements template_preprocess_paragraph().
  */
 function civictheme_preprocess_paragraph__civictheme_subject_card(&$variables) {
   /** @var \Drupal\paragraphs\Entity\Paragraph $paragraph */
   $paragraph = $variables['paragraph'];
-  $link = civictheme_field_has_value($paragraph, 'field_c_p_link') ? $paragraph->get('field_c_p_link')->first()->getValue() : [];
-  if (!empty($link['uri']) && !UrlHelper::isExternal($link['uri'])) {
-    $link['uri'] = Url::fromUri($link['uri'])->toString();
+  /** @var \Drupal\link\Plugin\Field\FieldType\LinkItem|null $link */
+  $link = civictheme_get_field_value($paragraph, 'field_c_p_link', TRUE);
+  if ($link) {
+    $variables['url'] = $link->getUrl()->toString();
+    $variables['is_external'] = $link->isExternal();
   }
-  $variables['url'] = $link['uri'] ?? NULL;
 }

--- a/docroot/themes/contrib/civictheme/includes/task_card.inc
+++ b/docroot/themes/contrib/civictheme/includes/task_card.inc
@@ -5,20 +5,18 @@
  * CivicTheme Task card paragraph component.
  */
 
-use Drupal\Component\Utility\UrlHelper;
-use Drupal\Core\Url;
-
 /**
  * Implements template_preprocess_paragraph().
  */
 function civictheme_preprocess_paragraph__civictheme_task_card(&$variables) {
   /** @var \Drupal\paragraphs\Entity\Paragraph $paragraph */
   $paragraph = $variables['paragraph'];
-  $link = civictheme_field_has_value($paragraph, 'field_c_p_link') ? $paragraph->get('field_c_p_link')->first()->getValue() : [];
-  if (!empty($link['uri']) && !UrlHelper::isExternal($link['uri'])) {
-    $link['uri'] = Url::fromUri($link['uri'])->toString();
+  /** @var \Drupal\link\Plugin\Field\FieldType\LinkItem|null $link */
+  $link = civictheme_get_field_value($paragraph, 'field_c_p_link', TRUE);
+  if ($link) {
+    $variables['url'] = $link->getUrl()->toString();
+    $variables['is_external'] = $link->isExternal();
   }
-  $variables['url'] = $link['uri'] ?? NULL;
   $variables['size'] = 'small';
 
   // Added to render image as icon.

--- a/docroot/themes/contrib/civictheme/includes/utilities.inc
+++ b/docroot/themes/contrib/civictheme/includes/utilities.inc
@@ -85,16 +85,29 @@ function civictheme_media_image_process_variables(MediaInterface $media, $image_
  *   Image URL or FALSE if not available.
  */
 function civictheme_media_get_url_from_field(EntityInterface $entity, string $field_name) {
-  if (civictheme_field_has_value($entity, $field_name)) {
-    /** @var \Drupal\media\Entity\Media $media */
-    $media = $entity->get($field_name)->first()->entity;
-    if ($media) {
-      $fid = $media->getSource()->getSourceFieldValue($media);
-      $file = File::load($fid);
-      if ($file) {
-        return file_create_url($file->createFileUrl());
-      }
-    }
+  /** @var \Drupal\media\Entity\Media|NULL $media */
+  $media = civictheme_get_field_value($entity, $field_name, TRUE);
+  if ($media) {
+    return civictheme_media_get_url($media);
+  }
+
+  return FALSE;
+}
+
+/**
+ * Get the media source file url.
+ *
+ * @param \Drupal\media\MediaInterface $media
+ *   The media entity to derive the url from.
+ *
+ * @return string|false
+ *   The url for the source file or false.
+ */
+function civictheme_media_get_url(MediaInterface $media) {
+  $fid = $media->getSource()->getSourceFieldValue($media);
+  $file = File::load($fid);
+  if ($file) {
+    return file_create_url($file->createFileUrl());
   }
 
   return FALSE;
@@ -233,4 +246,154 @@ function civictheme_get_theme_value(FieldableEntityInterface $entity): ?string {
   }
 
   return $field_name !== FALSE && civictheme_field_has_value($entity, $field_name) && $entity->get($field_name)->getString() ? $entity->get($field_name)->getString() : NULL;
+}
+
+/**
+ * Gets values from fields that CivicTheme regularly uses.
+ *
+ * It is not a replacement for the field api system for getting values. It gets
+ * commonly required types of values by CivicTheme.
+ *
+ * @param \Drupal\Core\Entity\FieldableEntityInterface $entity
+ *   Entity to check field existence.
+ * @param string $field_name
+ *   Field name to get the value for.
+ * @param bool $only_first
+ *   Return only the first value of a multi-value field.
+ *
+ * @return mixed|null
+ *   Whether the field exists and is not empty.
+ */
+function civictheme_get_field_value(FieldableEntityInterface $entity, string $field_name, $only_first = FALSE) {
+  $value = NULL;
+  if (civictheme_field_has_value($entity, $field_name)) {
+    $field = $entity->get($field_name);
+    $field_type = $field->getFieldDefinition()->getType();
+    switch ($field_type) {
+      case 'boolean':
+        $value = (bool) $field->getString();
+        break;
+
+      case 'integer':
+        $value = (integer) $field->getString();
+        break;
+
+      case 'list_integer':
+        $value = (int) $field->getString();
+        break;
+
+      case 'list_string':
+      case 'string':
+      case 'string_long':
+        $value = $field->getString();
+        break;
+
+      // Field types where we want to return field item.
+      case 'datetime':
+      case 'daterange':
+      case 'image':
+      case 'link':
+        $list = reset($field);
+        if (!empty($list)) {
+          $value = $only_first ? reset($list) : $list;
+        }
+        break;
+
+      // Field types where we want to return entities.
+      case 'entity_reference':
+      case 'entity_reference_revisions':
+        $value = civictheme_get_field_referenced_entities($entity, $field_name, $only_first);
+        break;
+
+      // Opinionated - but we want to render field if single or allow view
+      // to handle it if it's all values.
+      case 'text_long':
+        if ($only_first) {
+          $field = $field->first();
+          $value = check_markup($field->get('value')->getString(), $field->get('format')->getString());
+          break;
+        }
+        $value = $field->view();
+        break;
+
+      default:
+        \Drupal::logger('civic_theme')->warning('civictheme_get_field_value has encountered an unknown field type "@field_type"', ['@field_type' => $field_type]);
+        $value = NULL;
+    }
+  }
+
+  return $value;
+}
+
+/**
+ * Gets the entity referenced entiites in a field of an entity.
+ *
+ * @param \Drupal\Core\Entity\FieldableEntityInterface $entity
+ *   The host entity.
+ * @param string $field_name
+ *   The entity reference field.
+ *
+ * @return \Drupal\Core\Entity\EntityInterface[]|EntityInterface|null
+ *   Referenced entities, or referenced entity if found.
+ */
+function civictheme_get_field_referenced_entities(FieldableEntityInterface $entity, string $field_name, bool $only_first = FALSE):array|EntityInterface|null {
+  $entities = NULL;
+
+  if (civictheme_field_has_value($entity, $field_name)) {
+    $entities = $entity->get($field_name)->referencedEntities();
+    $entities = $only_first ? reset($entities) : $entities;
+  }
+
+  return $entities;
+}
+
+/**
+ * Get the label of referenced entities in a field of an entity.
+ *
+ * @param \Drupal\Core\Entity\FieldableEntityInterface|null $entity
+ *   The host entity.
+ * @param string $field_name
+ *   The entity reference field.
+ *
+ * @return string[]
+ *   The label(s).
+ */
+function civictheme_get_referenced_entity_labels(FieldableEntityInterface $entity, string $field_name):array {
+  $labels = [];
+  $referenced_entities = civictheme_get_field_value($entity, $field_name) ?? [];
+  foreach ($referenced_entities as $referenced_entity) {
+    if ($referenced_entity instanceof EntityInterface) {
+      $labels[] = $referenced_entity->label();
+    }
+  }
+
+  return $labels;
+}
+
+/**
+ * Get raw multivalued field values from the entity.
+ *
+ * @param \Drupal\Core\Entity\EntityInterface $entity
+ *   The entity to get the values from.
+ * @param string $field_name
+ *   The field name.
+ * @param string $value_key
+ *   (optional) The value key. Default to 'value'.
+ *
+ * @return array
+ *   Array of field values. If field does not exist or incorrect $value_key
+ *   provided, empty array will be returned.
+ */
+function civictheme_get_entity_field_key_values(EntityInterface $entity, $field_name, $value_key = 'value') {
+  $values = [];
+
+  if ($entity->hasField($field_name)) {
+    foreach ($entity->get($field_name)->getValue() as $value) {
+      if (isset($value[$value_key])) {
+        $values[] = $value[$value_key];
+      }
+    }
+  }
+
+  return $values;
 }

--- a/docroot/themes/contrib/civictheme/includes/views.inc
+++ b/docroot/themes/contrib/civictheme/includes/views.inc
@@ -129,16 +129,16 @@ function civictheme_preprocess_views_view(&$variables) {
 function _civictheme_listing_preprocess_view($paragraph, ViewExecutable &$view) {
   $settings = [];
   if ($paragraph !== NULL) {
-    $link = civictheme_field_has_value($paragraph, 'field_c_p_link') ? $paragraph->get('field_c_p_link')->first() : NULL;
-    $link_data = $link !== NULL ? [
+    $link = civictheme_get_field_value($paragraph, 'field_c_p_link', TRUE);
+    $link_data = $link ? [
       'text' => $link->get('title')->getString(),
       'is_external' => $link->isExternal(),
       'is_new_window' => $link->isExternal(),
       'url' => $link->getUrl()->toString(),
     ] : [];
 
-    $read_more = civictheme_field_has_value($paragraph, 'field_c_p_read_more') ? $paragraph->get('field_c_p_read_more')->first() : NULL;
-    $read_more_data = $read_more !== NULL ? [
+    $read_more = civictheme_get_field_value($paragraph, 'field_c_p_read_more', TRUE);
+    $read_more_data = $read_more ? [
       'text' => $read_more->get('title')->getString(),
       'is_external' => $read_more->isExternal(),
       'is_new_window' => $read_more->isExternal(),
@@ -149,10 +149,10 @@ function _civictheme_listing_preprocess_view($paragraph, ViewExecutable &$view) 
       'theme' => civictheme_get_theme_value($paragraph) ?? CIVICTHEME_VIEWS_DEFAULT_THEME,
       'card_theme' => civictheme_field_has_value($paragraph, 'field_c_p_card_theme') ? $paragraph->get('field_c_p_card_theme')->getString() : CIVICTHEME_VIEWS_DEFAULT_THEME,
       'link' => $link_data,
-      'title' => civictheme_field_has_value($paragraph, 'field_c_p_title') ? $paragraph->get('field_c_p_title')->getString() : '',
-      'with_background' => civictheme_field_has_value($paragraph, 'field_c_p_background') ? (bool) $paragraph->get('field_c_p_background')->getString() : '',
-      'vertical_space' => civictheme_field_has_value($paragraph, 'field_c_p_space') ? $paragraph->get('field_c_p_space')->getString() : '',
-      'show_filters' => civictheme_field_has_value($paragraph, 'field_c_p_show_filters') ? (bool) $paragraph->get('field_c_p_show_filters')->getString() : TRUE,
+      'title' => civictheme_get_field_value($paragraph, 'field_c_p_title') ?? '',
+      'with_background' => civictheme_get_field_value($paragraph, 'field_c_p_background') ?? FALSE,
+      'vertical_space' => civictheme_get_field_value($paragraph, 'field_c_p_space') ?? '',
+      'show_filters' => civictheme_get_field_value($paragraph, 'field_c_p_show_filters') ?? TRUE,
       'read_more' => $read_more_data,
       'cache_tags' => $paragraph->getCacheTags(),
     ];
@@ -212,11 +212,10 @@ function _civictheme_get_listing_paragraph_from_route() {
   }
 
   if ($node && $node->bundle() == 'civictheme_page') {
-    if (civictheme_field_has_value($node, 'field_c_n_components')) {
-      foreach ($node->get('field_c_n_components')->referencedEntities() as $paragraph) {
-        if ($paragraph->getType() == 'civictheme_listing') {
-          return $paragraph;
-        }
+    $components = civictheme_get_field_referenced_entities($node, 'field_c_n_components');
+    foreach ($components as $component) {
+      if ($component->getType() == 'civictheme_listing') {
+        return $component;
       }
     }
   }

--- a/tests/behat/features/content_type.civictheme_alert.view.feature
+++ b/tests/behat/features/content_type.civictheme_alert.view.feature
@@ -52,6 +52,7 @@ Feature: CivicTheme alert rendering
     And I should not see the text "[TEST] Test dismissing alert body all pages"
     # Revisit same page - the banner should remain dismissed.
     When I visit "civictheme_page" "[TEST] Test alerts on pages"
+    And wait 3 seconds
     Then I should not see the text "[TEST] Test alert body Homepage only"
     And I should see the text "[TEST] Test alert body all pages"
     And I should not see the text "[TEST] Test dismissing alert body all pages"

--- a/tests/behat/features/paragraph.civictheme_event_card.view.feature
+++ b/tests/behat/features/paragraph.civictheme_event_card.view.feature
@@ -30,7 +30,7 @@ Feature: Tests the Event Card paragraph
       | field_c_p_header_link  | 0: View all events - 1: https://example.com |
       | field_c_p_fill_width   | 0                                           |
     And "field_c_p_cards" in "civictheme_card_container" "paragraph" with "field_c_p_title" of "[TEST] Event card container" has "civictheme_event_card" paragraph:
-      | field_c_p_date     | 2021-04-30                            |
+      | field_c_p_date     | 2021-04-29                            |
       | field_c_p_image    | [TEST] CivicTheme Image               |
       | field_c_p_link     | 0: Test link - 1: https://example.com |
       | field_c_p_summary  | Summary text                          |
@@ -48,7 +48,7 @@ Feature: Tests the Event Card paragraph
       | field_c_p_topic    | [TEST] Topic 2                              |
       | field_c_p_location | [TEST] Location 2                           |
     And "field_c_p_cards" in "civictheme_card_container" "paragraph" with "field_c_p_title" of "[TEST] Event card container" has "civictheme_event_card" paragraph:
-      | field_c_p_date     | 2022-05-30                                  |
+      | field_c_p_date     | 2022-05-29                                  |
       | field_c_p_image    | [TEST] CivicTheme Image                     |
       | field_c_p_link     | 0: Test link - 1: https://example.com/card2 |
       | field_c_p_summary  | Summary text 3                              |
@@ -57,7 +57,7 @@ Feature: Tests the Event Card paragraph
       | field_c_p_topic    | [TEST] Topic 1                              |
       | field_c_p_location | [TEST] Location 3                           |
     And "field_c_p_cards" in "civictheme_card_container" "paragraph" with "field_c_p_title" of "[TEST] Event card container" has "civictheme_event_card" paragraph:
-      | field_c_p_date     | 2023-06-30                                  |
+      | field_c_p_date     | 2023-06-29                                  |
       | field_c_p_image    | [TEST] CivicTheme Image                     |
       | field_c_p_link     | 0: Test link - 1: https://example.com/card3 |
       | field_c_p_summary  | Summary text 3                              |


### PR DESCRIPTION
CIVIC-732

### What has changed
1. Added `civictheme_get_field_value` provides field values from entities in the way CivicTheme expects

### Visual changes
1. [Fix to event card](https://app.diffy.website#/shared/MjAwMTk1MTgyODQ=/diffs/200195/single/17/640) - previously printing the entire body in card - fixed to be same as `civic_page` cards
2. [Added image styles to cards](https://app.diffy.website#/shared/MjAwMTk1MTgyODQ=/diffs/200195/single/0/640) - no longer printing out original image fitted by css but showing derivative image (causing slight change in visual)
3. [Added `is_external` to callout](https://app.diffy.website#/shared/MjAwMTk1MTgyODQ=/diffs/200195/single/1/640) - preprocessing external icon.
4. [Reference cards](https://github.com/salsadigitalauorg/civictheme_source/pull/529/files#r922913571) - should also have a visual change - as they are now deriving their theme from card container (previously there was a bug and the inverse theme was always dark due to their not being a theme)

### To come
1. Need to update rest of the paragraph preprocessing about 50% done.
5. Tests for the `civictheme_get_field_value`

### Design inconsistencies
1. Next step does not show external icon for external link
2. Reference slide does not select theme.