### PR TITLE
[CIVIC-723] Added "Last updated date" as a custom date for Page content type.

### DIFF
--- a/docroot/modules/custom/cs_generated_content/generated_content/node/civictheme_page.inc
+++ b/docroot/modules/custom/cs_generated_content/generated_content/node/civictheme_page.inc
@@ -99,6 +99,14 @@ function _cs_generated_content_create_node_civictheme_page__variation_to_fields(
     $node->field_c_n_space = $variation['space'];
   }
 
+  if (isset($variation['show_last_updated']) && $node->hasField('field_c_n_show_last_updated')) {
+    $node->field_c_n_show_last_updated = $variation['show_last_updated'];
+  }
+
+  if (isset($variation['custom_updated_date']) && $node->hasField('field_c_n_custom_last_updated')) {
+    $node->field_c_n_custom_last_updated = $variation['custom_updated_date'];
+  }
+
   // Banner.
   if (!empty($variation['banner_type']) && $node->hasField('field_c_n_banner_type')) {
     $node->field_c_n_banner_type = $variation['banner_type'];

--- a/docroot/modules/custom/cs_generated_content/generated_content/node/civictheme_page_variations/03.general.inc
+++ b/docroot/modules/custom/cs_generated_content/generated_content/node/civictheme_page_variations/03.general.inc
@@ -62,7 +62,7 @@ function _cs_generated_content_create_node_civictheme_page__variations__general(
       'thumbnail' => $helper::staticMediaItem('civictheme_image'),
       'space' => $helper::civicthemeSpaceTypeBoth(),
       'show_last_updated' => TRUE,
-      'custom_updated_date' => $helper::randomDate('last month'),
+      'custom_updated_date' => '2022-07-01',
       'components' => _cs_generated_content_create_node_civictheme_page__variations_components_content_default(),
     ],
     [
@@ -81,7 +81,7 @@ function _cs_generated_content_create_node_civictheme_page__variations__general(
       'thumbnail' => $helper::staticMediaItem('civictheme_image'),
       'space' => $helper::civicthemeSpaceTypeBoth(),
       'show_last_updated' => FALSE,
-      'custom_updated_date' => $helper::randomDate('last month', 'now'),
+      'custom_updated_date' => '2022-07-01',
       'components' => _cs_generated_content_create_node_civictheme_page__variations_components_content_default(),
     ],
   ];

--- a/docroot/modules/custom/cs_generated_content/generated_content/node/civictheme_page_variations/03.general.inc
+++ b/docroot/modules/custom/cs_generated_content/generated_content/node/civictheme_page_variations/03.general.inc
@@ -55,6 +55,35 @@ function _cs_generated_content_create_node_civictheme_page__variations__general(
       'space' => $helper::civicthemeSpaceTypeBoth(),
       'components' => _cs_generated_content_create_node_civictheme_page__variations_components_content_default(),
     ],
+    [
+      'title' => 'Demo Page, Summary, Topics (1), Thumbnail, Both spaces, Content, Show Last Updated Date, Not Custom Date',
+      'summary' => $helper::staticPlainParagraph(),
+      'topics' => $helper::staticTerms('civictheme_topics', 1),
+      'thumbnail' => $helper::staticMediaItem('civictheme_image'),
+      'space' => $helper::civicthemeSpaceTypeBoth(),
+      'show_last_updated' => TRUE,
+      'custom_updated_date' => $helper::randomDate('last month'),
+      'components' => _cs_generated_content_create_node_civictheme_page__variations_components_content_default(),
+    ],
+    [
+      'title' => 'Demo Page, Summary, Topics (1), Thumbnail, Both spaces, Content, Show Last Updated Date',
+      'summary' => $helper::staticPlainParagraph(),
+      'topics' => $helper::staticTerms('civictheme_topics', 1),
+      'thumbnail' => $helper::staticMediaItem('civictheme_image'),
+      'space' => $helper::civicthemeSpaceTypeBoth(),
+      'show_last_updated' => TRUE,
+      'components' => _cs_generated_content_create_node_civictheme_page__variations_components_content_default(),
+    ],
+    [
+      'title' => 'Demo Page, Summary, Topics (1), Thumbnail, Both spaces, Content, Uncheck Last Updated Date, Shows Custom Date',
+      'summary' => $helper::staticPlainParagraph(),
+      'topics' => $helper::staticTerms('civictheme_topics', 1),
+      'thumbnail' => $helper::staticMediaItem('civictheme_image'),
+      'space' => $helper::civicthemeSpaceTypeBoth(),
+      'show_last_updated' => FALSE,
+      'custom_updated_date' => $helper::randomDate('last month', 'now'),
+      'components' => _cs_generated_content_create_node_civictheme_page__variations_components_content_default(),
+    ],
   ];
 
   return $variations;

--- a/docroot/themes/contrib/civictheme/civictheme.info.yml
+++ b/docroot/themes/contrib/civictheme/civictheme.info.yml
@@ -269,6 +269,7 @@ config_devel:
     - field.field.node.civictheme_page.field_c_n_banner_title
     - field.field.node.civictheme_page.field_c_n_banner_type
     - field.field.node.civictheme_page.field_c_n_components
+    - field.field.node.civictheme_page.field_c_n_custom_last_updated
     - field.field.node.civictheme_page.field_c_n_hide_sidebar
     - field.field.node.civictheme_page.field_c_n_show_last_updated
     - field.field.node.civictheme_page.field_c_n_show_toc
@@ -455,6 +456,7 @@ config_devel:
     - field.storage.node.field_c_n_banner_type
     - field.storage.node.field_c_n_body
     - field.storage.node.field_c_n_components
+    - field.storage.node.field_c_n_custom_last_updated
     - field.storage.node.field_c_n_date
     - field.storage.node.field_c_n_date_range
     - field.storage.node.field_c_n_hide_sidebar

--- a/docroot/themes/contrib/civictheme/config/install/core.entity_form_display.node.civictheme_page.default.yml
+++ b/docroot/themes/contrib/civictheme/config/install/core.entity_form_display.node.civictheme_page.default.yml
@@ -11,6 +11,7 @@ dependencies:
     - field.field.node.civictheme_page.field_c_n_banner_title
     - field.field.node.civictheme_page.field_c_n_banner_type
     - field.field.node.civictheme_page.field_c_n_components
+    - field.field.node.civictheme_page.field_c_n_custom_last_updated
     - field.field.node.civictheme_page.field_c_n_hide_sidebar
     - field.field.node.civictheme_page.field_c_n_show_last_updated
     - field.field.node.civictheme_page.field_c_n_show_toc
@@ -20,7 +21,7 @@ dependencies:
     - field.field.node.civictheme_page.field_c_n_topics
     - node.type.civictheme_page
   module:
-    - content_moderation
+    - datetime
     - field_group
     - media_library
     - paragraphs
@@ -86,6 +87,7 @@ third_party_settings:
         - field_c_n_space
         - field_c_n_hide_sidebar
         - field_c_n_show_last_updated
+        - field_c_n_custom_last_updated
       label: General
       region: content
       parent_name: group_civictheme_tabs
@@ -117,7 +119,7 @@ content:
     third_party_settings: {  }
   field_c_n_banner_components:
     type: paragraphs
-    weight: 16
+    weight: 17
     region: content
     settings:
       title: Paragraph
@@ -136,7 +138,7 @@ content:
     third_party_settings: {  }
   field_c_n_banner_components_bott:
     type: paragraphs
-    weight: 17
+    weight: 18
     region: content
     settings:
       title: Paragraph
@@ -205,6 +207,12 @@ content:
         add_above: '0'
         collapse_edit_all: collapse_edit_all
         duplicate: duplicate
+    third_party_settings: {  }
+  field_c_n_custom_last_updated:
+    type: datetime_default
+    weight: 9
+    region: content
+    settings: {  }
     third_party_settings: {  }
   field_c_n_hide_sidebar:
     type: boolean_checkbox
@@ -279,7 +287,7 @@ content:
     third_party_settings: {  }
   status:
     type: boolean_checkbox
-    weight: 8
+    weight: 7
     region: content
     settings:
       display_label: true
@@ -310,7 +318,7 @@ content:
       placeholder: ''
     third_party_settings: {  }
   url_redirects:
-    weight: 50
+    weight: 9
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/docroot/themes/contrib/civictheme/config/install/core.entity_view_display.node.civictheme_page.civictheme_navigation_card.yml
+++ b/docroot/themes/contrib/civictheme/config/install/core.entity_view_display.node.civictheme_page.civictheme_navigation_card.yml
@@ -12,6 +12,7 @@ dependencies:
     - field.field.node.civictheme_page.field_c_n_banner_title
     - field.field.node.civictheme_page.field_c_n_banner_type
     - field.field.node.civictheme_page.field_c_n_components
+    - field.field.node.civictheme_page.field_c_n_custom_last_updated
     - field.field.node.civictheme_page.field_c_n_hide_sidebar
     - field.field.node.civictheme_page.field_c_n_show_last_updated
     - field.field.node.civictheme_page.field_c_n_show_toc
@@ -57,6 +58,7 @@ hidden:
   field_c_n_banner_title: true
   field_c_n_banner_type: true
   field_c_n_components: true
+  field_c_n_custom_last_updated: true
   field_c_n_hide_sidebar: true
   field_c_n_show_last_updated: true
   field_c_n_show_toc: true

--- a/docroot/themes/contrib/civictheme/config/install/core.entity_view_display.node.civictheme_page.civictheme_promo_card.yml
+++ b/docroot/themes/contrib/civictheme/config/install/core.entity_view_display.node.civictheme_page.civictheme_promo_card.yml
@@ -12,6 +12,7 @@ dependencies:
     - field.field.node.civictheme_page.field_c_n_banner_title
     - field.field.node.civictheme_page.field_c_n_banner_type
     - field.field.node.civictheme_page.field_c_n_components
+    - field.field.node.civictheme_page.field_c_n_custom_last_updated
     - field.field.node.civictheme_page.field_c_n_hide_sidebar
     - field.field.node.civictheme_page.field_c_n_show_last_updated
     - field.field.node.civictheme_page.field_c_n_show_toc
@@ -62,6 +63,7 @@ hidden:
   field_c_n_banner_title: true
   field_c_n_banner_type: true
   field_c_n_components: true
+  field_c_n_custom_last_updated: true
   field_c_n_hide_sidebar: true
   field_c_n_show_last_updated: true
   field_c_n_show_toc: true

--- a/docroot/themes/contrib/civictheme/config/install/core.entity_view_display.node.civictheme_page.civictheme_slider_slide.yml
+++ b/docroot/themes/contrib/civictheme/config/install/core.entity_view_display.node.civictheme_page.civictheme_slider_slide.yml
@@ -12,6 +12,7 @@ dependencies:
     - field.field.node.civictheme_page.field_c_n_banner_title
     - field.field.node.civictheme_page.field_c_n_banner_type
     - field.field.node.civictheme_page.field_c_n_components
+    - field.field.node.civictheme_page.field_c_n_custom_last_updated
     - field.field.node.civictheme_page.field_c_n_hide_sidebar
     - field.field.node.civictheme_page.field_c_n_show_last_updated
     - field.field.node.civictheme_page.field_c_n_show_toc
@@ -58,6 +59,7 @@ hidden:
   field_c_n_banner_title: true
   field_c_n_banner_type: true
   field_c_n_components: true
+  field_c_n_custom_last_updated: true
   field_c_n_hide_sidebar: true
   field_c_n_show_last_updated: true
   field_c_n_show_toc: true

--- a/docroot/themes/contrib/civictheme/config/install/core.entity_view_display.node.civictheme_page.civictheme_subject_card.yml
+++ b/docroot/themes/contrib/civictheme/config/install/core.entity_view_display.node.civictheme_page.civictheme_subject_card.yml
@@ -12,6 +12,7 @@ dependencies:
     - field.field.node.civictheme_page.field_c_n_banner_title
     - field.field.node.civictheme_page.field_c_n_banner_type
     - field.field.node.civictheme_page.field_c_n_components
+    - field.field.node.civictheme_page.field_c_n_custom_last_updated
     - field.field.node.civictheme_page.field_c_n_hide_sidebar
     - field.field.node.civictheme_page.field_c_n_show_last_updated
     - field.field.node.civictheme_page.field_c_n_show_toc
@@ -51,6 +52,7 @@ hidden:
   field_c_n_banner_title: true
   field_c_n_banner_type: true
   field_c_n_components: true
+  field_c_n_custom_last_updated: true
   field_c_n_hide_sidebar: true
   field_c_n_show_last_updated: true
   field_c_n_show_toc: true

--- a/docroot/themes/contrib/civictheme/config/install/core.entity_view_display.node.civictheme_page.default.yml
+++ b/docroot/themes/contrib/civictheme/config/install/core.entity_view_display.node.civictheme_page.default.yml
@@ -11,6 +11,7 @@ dependencies:
     - field.field.node.civictheme_page.field_c_n_banner_title
     - field.field.node.civictheme_page.field_c_n_banner_type
     - field.field.node.civictheme_page.field_c_n_components
+    - field.field.node.civictheme_page.field_c_n_custom_last_updated
     - field.field.node.civictheme_page.field_c_n_hide_sidebar
     - field.field.node.civictheme_page.field_c_n_show_last_updated
     - field.field.node.civictheme_page.field_c_n_show_toc
@@ -20,6 +21,7 @@ dependencies:
     - field.field.node.civictheme_page.field_c_n_topics
     - node.type.civictheme_page
   module:
+    - datetime
     - entity_reference_revisions
     - layout_builder
     - layout_builder_restrictions
@@ -56,6 +58,23 @@ third_party_settings:
                   view_mode: default
                 third_party_settings: {  }
             weight: 0
+            additional: {  }
+          c1f9f850-f470-4069-8711-9c7edaffde7e:
+            uuid: c1f9f850-f470-4069-8711-9c7edaffde7e
+            region: content
+            configuration:
+              id: 'field_block:node:civictheme_page:field_c_n_custom_last_updated'
+              label_display: '0'
+              context_mapping:
+                entity: layout_builder.entity
+              formatter:
+                type: datetime_default
+                label: above
+                settings:
+                  timezone_override: ''
+                  format_type: medium
+                third_party_settings: {  }
+            weight: 1
             additional: {  }
         third_party_settings: {  }
   layout_builder_restrictions:
@@ -97,6 +116,15 @@ content:
       link: ''
     third_party_settings: {  }
     weight: 0
+    region: content
+  field_c_n_custom_last_updated:
+    type: datetime_default
+    label: above
+    settings:
+      timezone_override: ''
+      format_type: medium
+    third_party_settings: {  }
+    weight: 6
     region: content
   field_c_n_show_last_updated:
     type: boolean

--- a/docroot/themes/contrib/civictheme/config/install/field.field.node.civictheme_page.field_c_n_custom_last_updated.yml
+++ b/docroot/themes/contrib/civictheme/config/install/field.field.node.civictheme_page.field_c_n_custom_last_updated.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_c_n_custom_last_updated
+    - node.type.civictheme_page
+  module:
+    - datetime
+id: node.civictheme_page.field_c_n_custom_last_updated
+field_name: field_c_n_custom_last_updated
+entity_type: node
+bundle: civictheme_page
+label: 'Custom last updated date'
+description: 'Override system content last updated date. If left empty - system last updated date will be used.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: datetime

--- a/docroot/themes/contrib/civictheme/config/install/field.storage.node.field_c_n_custom_last_updated.yml
+++ b/docroot/themes/contrib/civictheme/config/install/field.storage.node.field_c_n_custom_last_updated.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - datetime
+    - node
+id: node.field_c_n_custom_last_updated
+field_name: field_c_n_custom_last_updated
+entity_type: node
+type: datetime
+settings:
+  datetime_type: date
+module: datetime
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/themes/contrib/civictheme/includes/banner.inc
+++ b/docroot/themes/contrib/civictheme/includes/banner.inc
@@ -176,12 +176,12 @@ function _civictheme_preprocess_civictheme_banner_node(&$variables) {
  */
 function _civictheme_preprocess_civictheme_banner_last_updated(&$variables, $node) {
   $last_updated = civictheme_get_field_value($node, 'field_c_n_show_last_updated');
-  $custom_updated = civictheme_get_field_value($node, 'field_c_n_custom_last_updated');
+  $custom_updated = civictheme_get_field_value($node, 'field_c_n_custom_last_updated', TRUE);
   if ($last_updated && $custom_updated) {
     $variables['content_middle'][] = [
       '#theme' => 'civictheme_basic_content',
       '#component_theme' => $variables['theme'] ?? NULL,
-      '#content' => '<p class="civictheme-banner__last_updated">Last updated: ' . \Drupal::service('date.formatter')->format($custom_updated[0]->date->getTimestamp(), 'civictheme_short_date') . '<p>',
+      '#content' => '<p class="civictheme-banner__last_updated">Last updated: ' . civictheme_format_short_date($custom_updated->get('value')->getDateTime()) . '<p>',
     ];
     return;
   }

--- a/docroot/themes/contrib/civictheme/includes/banner.inc
+++ b/docroot/themes/contrib/civictheme/includes/banner.inc
@@ -177,19 +177,20 @@ function _civictheme_preprocess_civictheme_banner_node(&$variables) {
 function _civictheme_preprocess_civictheme_banner_last_updated(&$variables, $node) {
   $last_updated = civictheme_get_field_value($node, 'field_c_n_show_last_updated');
   $custom_updated = civictheme_get_field_value($node, 'field_c_n_custom_last_updated', TRUE);
+
   if ($last_updated && $custom_updated) {
-    $variables['content_middle'][] = [
-      '#theme' => 'civictheme_basic_content',
-      '#component_theme' => $variables['theme'] ?? NULL,
-      '#content' => '<p class="civictheme-banner__last_updated">Last updated: ' . civictheme_format_short_date($custom_updated->get('value')->getDateTime()) . '<p>',
-    ];
-    return;
+    $final_date = civictheme_format_short_date($custom_updated->get('value')->getDateTime());
   }
-  if ($last_updated) {
+
+  elseif ($last_updated) {
+    $final_date = \Drupal::service('date.formatter')->format($node->getChangedTime(), 'civictheme_short_date');
+  }
+
+  if (isset($final_date)) {
     $variables['content_middle'][] = [
       '#theme' => 'civictheme_basic_content',
       '#component_theme' => $variables['theme'] ?? NULL,
-      '#content' => '<p class="civictheme-banner__last_updated">Last updated: ' . \Drupal::service('date.formatter')->format($node->getChangedTime(), 'civictheme_short_date') . '<p>',
+      '#content' => '<p class="civictheme-banner__last_updated">Last updated: ' . $final_date . '<p>',
     ];
   }
 }

--- a/docroot/themes/contrib/civictheme/includes/banner.inc
+++ b/docroot/themes/contrib/civictheme/includes/banner.inc
@@ -176,6 +176,15 @@ function _civictheme_preprocess_civictheme_banner_node(&$variables) {
  */
 function _civictheme_preprocess_civictheme_banner_last_updated(&$variables, $node) {
   $last_updated = civictheme_get_field_value($node, 'field_c_n_show_last_updated');
+  $custom_updated = civictheme_get_field_value($node, 'field_c_n_custom_last_updated');
+  if ($last_updated && $custom_updated) {
+    $variables['content_middle'][] = [
+      '#theme' => 'civictheme_basic_content',
+      '#component_theme' => $variables['theme'] ?? NULL,
+      '#content' => '<p class="civictheme-banner__last_updated">Last updated: ' . \Drupal::service('date.formatter')->format($custom_updated[0]->date->getTimestamp(), 'civictheme_short_date') . '<p>',
+    ];
+    return;
+  }
   if ($last_updated) {
     $variables['content_middle'][] = [
       '#theme' => 'civictheme_basic_content',

--- a/tests/behat/features/content_type.civictheme_page.fields.feature
+++ b/tests/behat/features/content_type.civictheme_page.fields.feature
@@ -68,6 +68,9 @@ Feature: Fields on Page content type
     And I should see text matching "Show last updated date"
     And should see an "input[name='field_c_n_show_last_updated[value]']" element
 
+    And I should see text matching "Custom last updated date"
+    And should see an "input[name='field_c_n_custom_last_updated[0][value][date]']" element
+
     And I should see text matching "Show Table of Contents"
     And should see an "input[name='field_c_n_show_toc[value]']" element
 

--- a/tests/behat/features/content_type.civictheme_page.view.feature
+++ b/tests/behat/features/content_type.civictheme_page.view.feature
@@ -299,13 +299,34 @@ Feature: View of Page content type
     And I should see an "nav.civictheme-breadcrumb.civictheme-theme-dark" element
     And I should not see an "nav.civictheme-breadcrumb.civictheme-theme-light" element
 
+  @api @lastcustomupdated
+  Scenario: CivicTheme page content type page can configure Last updated date display
+    Given I am an anonymous user
+    And "civictheme_page" content:
+      | title                                       | status | field_c_n_show_last_updated | field_c_n_custom_last_updated |
+      | [TEST] Page with date                       | 1      | 1                           | 2022-07-01                    |
+      | [TEST] Page with last updated date checked  | 1      | 1                           |                               |
+      | [TEST] Page without date                    | 1      | 0                           | 2022-07-14                    |
+
+    When I visit "civictheme_page" "[TEST] Page with date"
+    And I should see the text "[TEST] Page with date"
+    And I should see an "div.civictheme-banner__content-middle" element
+    And I should see the text "Last updated: 1 Jul 2022"
+    When I visit "civictheme_page" "[TEST] Page with last updated date checked"
+    And I should see the text "[TEST] Page with last updated date checked"
+    And I should see an "div.civictheme-banner__content-middle" element
+    And I should see the text "Last updated"
+    When I visit "civictheme_page" "[TEST] Page without date"
+    And I should see the text "[TEST] Page without date"
+    And I should not see the text "Last updated"
+
   @api @lastupdated
   Scenario: CivicTheme page content type page can configure Last updated date display
     Given I am an anonymous user
     And "civictheme_page" content:
-      | title                    | status | field_c_n_show_last_updated |
-      | [TEST] Page with date    | 1      | 1                           |
-      | [TEST] Page without date | 1      | 0                           |
+      | title                                       | status | field_c_n_show_last_updated |
+      | [TEST] Page with date                       | 1      | 1                           |
+      | [TEST] Page without date                    | 1      | 0                           |
 
     When I visit "civictheme_page" "[TEST] Page with date"
     And I should see the text "[TEST] Page with date"

--- a/tests/behat/features/content_type.civictheme_page.view.feature
+++ b/tests/behat/features/content_type.civictheme_page.view.feature
@@ -324,9 +324,9 @@ Feature: View of Page content type
   Scenario: CivicTheme page content type page can configure Last updated date display
     Given I am an anonymous user
     And "civictheme_page" content:
-      | title                                       | status | field_c_n_show_last_updated |
-      | [TEST] Page with date                       | 1      | 1                           |
-      | [TEST] Page without date                    | 1      | 0                           |
+      | title                    | status | field_c_n_show_last_updated |
+      | [TEST] Page with date    | 1      | 1                           |
+      | [TEST] Page without date | 1      | 0                           |
 
     When I visit "civictheme_page" "[TEST] Page with date"
     And I should see the text "[TEST] Page with date"


### PR DESCRIPTION
<!--
Please follow these rules:
1. SUBJECT: use format [PRJ-123] Verb in past tense with dot at the end.
   - This subject will be used as a commit message after PR is merged.
   - Verbs are usually one of these: Updated, Refactored, Removed, Changed, Added.
   - If there is no ticket - do not put [NOTICKET].

2. BODY: fill-in the template below.

3. CONFLICTS: Make sure that there are no conflicts in your PR. Resolve them before submitting PR for review.

4. COMMENTS: Scan through your PR yourself and comment on the lines that does not look clear enough. This will save SIGNIFICANT time for reviewer to approve the PR.

5. LABEL: Assign 'Needs review' label as soon as you ready to have this reviewed.

6. ASSIGNEE: Assign at least 2 reviewers.     

7. SLACK: Post a link to this PR to #developers channel.

No need to remove these lines - they are comments.
-->

**Issue URL:** https://salsadigital.atlassian.net/browse/CIVIC-723

### Changed
<!--
Provide a list of what was added/changed/removed etc. 

Start with a verb so that it is clear what has happened:Added/ Updated/Removed/Refactored etc.

Also, explain WHY something was done if this was not a normal implementation.
-->
1.  Added a new date field "field_c_n_custom_last_updated" to Page Content type.
2. Added logic to show/hide this new field based on different variations of selecting "field_c_n_show_last_updated".
3. Added behat tests.
4. Updated generated content to include variations of all AC.

You will notice I used `$helper::randomDate('last month', 'now'),` because if I had used `$helper::randomDate()`, then the random date generated will always be today's date. There is a bug is the randomDate() function in the generated_content module. The bug is: The default for $start and $finish are both set to 'now'.

### Screenshots

<!--
Provide as many screenshots as required to make reviewers understand what was changed.
-->

![image](https://user-images.githubusercontent.com/10050233/181491639-00740f89-d16c-4634-b30e-e0b920438046.png)

