### PR TITLE
[CIVIC] Added support for empty string as alt attribute value on image component.

### DIFF
--- a/docroot/themes/contrib/civictheme/civictheme_library/components/01-atoms/image/image.twig
+++ b/docroot/themes/contrib/civictheme/civictheme_library/components/01-atoms/image/image.twig
@@ -21,7 +21,7 @@
   <img
     class="civictheme-image {{ modifier_class }}"
     src="{{ src }}"
-    {% if alt is not empty %}alt="{{ alt }}"{% endif %}
+    {% if alt is not null %}alt="{{ alt }}"{% endif %}
     {% if width is not empty %}width="{{ width }}"{% endif %}
     {% if height is not empty %}height="{{ height }}"{% endif %}
     {% if attributes is not empty %}{{ attributes|raw }}{% endif %}/>


### PR DESCRIPTION
I have added support for empty quotes as the alt attribute on the image component as this is an accessibility requirement: 
https://www.w3.org/WAI/tutorials/images/decorative/#:~:text=In%20these%20cases%2C%20a%20null,from%20that%20in%20adjacent%20text.

Current support for `role="presentation"` for delineating decorative images is not currently widely supported. An empty alt tag explicitly defined (e.g. `alt=""`) is more widely supported by screen readers. My change allows for empty string as an alt tag. 

## Changed
1. Changed test from `is not empty` to `is not null` for outputting alt tags on images to support explicitly defining empty strings as alt tag attribute on image component.


## Screenshots
Example test with empty alt tag versus no alt tag:

<img width="1904" alt="Screen Shot 2022-08-09 at 7 56 08 pm" src="https://user-images.githubusercontent.com/520440/183620830-5e526327-96cf-4ce3-89e1-63de464c4ca9.png">

<img width="1904" alt="Screen Shot 2022-08-09 at 7 55 52 pm" src="https://user-images.githubusercontent.com/520440/183620867-390d29ee-16df-49ad-a049-7aa42a5e2d40.png">


