### PR TITLE
[CIVIC-960] Updated breadcrumb to show actual parent value on mobile.

### DIFF
--- a/docroot/themes/contrib/civictheme/civictheme_library/components/03-organisms/breadcrumb/breadcrumb.twig
+++ b/docroot/themes/contrib/civictheme/civictheme_library/components/03-organisms/breadcrumb/breadcrumb.twig
@@ -57,7 +57,7 @@
           } only %}
           {% include '@atoms/link/link.twig' with {
             theme: theme,
-            text: 'Parent',
+            text: parent.text,
             url: parent.url,
           } only %}
         </li>

--- a/tests/behat/features/breadcrumb.view.feature
+++ b/tests/behat/features/breadcrumb.view.feature
@@ -1,0 +1,16 @@
+@civictheme @breadcrumb
+Feature: Tests the CivicTheme breadcrumb
+
+  Ensure that the breadcrumb are displayed correctly.
+
+  Background:
+    Given "civictheme_page" content:
+      | title                              | status | path[0][pathauto] | path[0][alias]                          |
+      | [TEST] Page breadcrumb parent test | 1      | 0                 | /test-breadcrumb-parent                 |
+      | [TEST] Page breadcrumb test        | 1      | 0                 | /test-breadcrumb-parent/breadcrumb-test |
+
+  @api
+  Scenario: CivicTheme breadcrumb component shows the name of the parent item on the mobile.
+    Given I am an anonymous user
+    When I visit "civictheme_page" "[TEST] Page breadcrumb test"
+    Then I should see the link "[TEST] Page breadcrumb parent test" with "/test-breadcrumb-parent" in 'nav.civictheme-breadcrumb li.civictheme-breadcrumb__links--link.mobile-only'

--- a/tests/behat/features/breadcrumb.view.feature
+++ b/tests/behat/features/breadcrumb.view.feature
@@ -4,13 +4,23 @@ Feature: Tests the CivicTheme breadcrumb
   Ensure that the breadcrumb are displayed correctly.
 
   Background:
-    Given "civictheme_page" content:
-      | title                              | status | path[0][pathauto] | path[0][alias]                          |
-      | [TEST] Page breadcrumb parent test | 1      | 0                 | /test-breadcrumb-parent                 |
-      | [TEST] Page breadcrumb test        | 1      | 0                 | /test-breadcrumb-parent/breadcrumb-test |
+    Given civictheme_page content:
+      | title                              | status |
+      | [TEST] Page breadcrumb parent test | 1      |
+      | [TEST] Page breadcrumb test        | 1      |
 
   @api
   Scenario: CivicTheme breadcrumb component shows the name of the parent item on the mobile.
-    Given I am an anonymous user
-    When I visit "civictheme_page" "[TEST] Page breadcrumb test"
+    Given I am logged in as a user with the "Site Administrator" role
+    When I edit "civictheme_page" "[TEST] Page breadcrumb parent test"
+    And I uncheck the box "Generate automatic URL alias"
+    Then I fill in the following:
+        | edit-path-0-alias	    | /test-breadcrumb-parent |
+    And I press "Save"
+    Then I edit "civictheme_page" "[TEST] Page breadcrumb test"
+    And I uncheck the box "Generate automatic URL alias"
+    Then I fill in the following:
+        | edit-path-0-alias	    | /test-breadcrumb-parent/breadcrumb-test |
+    And I press "Save"
+    When I visit "/test-breadcrumb-parent/breadcrumb-test"
     Then I should see the link "[TEST] Page breadcrumb parent test" with "/test-breadcrumb-parent" in 'nav.civictheme-breadcrumb li.civictheme-breadcrumb__links--link.mobile-only'


### PR DESCRIPTION
https://salsadigital.atlassian.net/browse/CIVIC-960

## Checklist before requesting a review

- [x] I have formatted the subject to include ticket number as `[CIVIC-123] Verb in past tense with dot at the end.`
- [x] I have added a link to the JIRA ticket
- [x] I have provided information in `Changed` section about WHY something was done if this was not a normal implementation
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run new and existing relevant tests locally with my changes, and they passed
- [x] I have provided screenshots, where applicable

## Changed
1. Updated breadcrumb to show actual parent value on mobile

## Screenshots
![Screenshot 2022-08-23 at 11 00 02 AM](https://user-images.githubusercontent.com/83997348/186077443-168f429d-11f2-41cd-870e-0e4dd02aa514.png)
![Screenshot 2022-08-23 at 11 00 16 AM](https://user-images.githubusercontent.com/83997348/186077455-7f14a178-9a57-4799-a426-aab1de0dea7d.png)

