### PR TITLE
[CIVIC-957] Added Size field to Navigation card paragraph.

### DIFF
--- a/docroot/themes/contrib/civictheme/civictheme.info.yml
+++ b/docroot/themes/contrib/civictheme/civictheme.info.yml
@@ -357,6 +357,7 @@ config_devel:
     - field.field.paragraph.civictheme_map.field_c_p_view_link
     - field.field.paragraph.civictheme_navigation_card.field_c_p_image
     - field.field.paragraph.civictheme_navigation_card.field_c_p_link
+    - field.field.paragraph.civictheme_navigation_card.field_c_p_size
     - field.field.paragraph.civictheme_navigation_card.field_c_p_summary
     - field.field.paragraph.civictheme_navigation_card.field_c_p_theme
     - field.field.paragraph.civictheme_navigation_card.field_c_p_title

--- a/docroot/themes/contrib/civictheme/config/install/core.entity_form_display.paragraph.civictheme_navigation_card.default.yml
+++ b/docroot/themes/contrib/civictheme/config/install/core.entity_form_display.paragraph.civictheme_navigation_card.default.yml
@@ -4,6 +4,7 @@ dependencies:
   config:
     - field.field.paragraph.civictheme_navigation_card.field_c_p_image
     - field.field.paragraph.civictheme_navigation_card.field_c_p_link
+    - field.field.paragraph.civictheme_navigation_card.field_c_p_size
     - field.field.paragraph.civictheme_navigation_card.field_c_p_summary
     - field.field.paragraph.civictheme_navigation_card.field_c_p_theme
     - field.field.paragraph.civictheme_navigation_card.field_c_p_title
@@ -19,40 +20,46 @@ content:
   field_c_p_image:
     type: media_library_widget
     weight: 1
+    region: content
     settings:
       media_types: {  }
     third_party_settings: {  }
-    region: content
   field_c_p_link:
+    type: link_default
     weight: 3
+    region: content
     settings:
       placeholder_url: ''
       placeholder_title: ''
     third_party_settings: {  }
-    type: link_default
+  field_c_p_size:
+    type: options_select
+    weight: 4
     region: content
+    settings: {  }
+    third_party_settings: {  }
   field_c_p_summary:
+    type: string_textarea
     weight: 2
+    region: content
     settings:
       rows: 5
       placeholder: ''
     third_party_settings: {  }
-    type: string_textarea
-    region: content
   field_c_p_theme:
-    weight: 4
+    type: options_select
+    weight: 5
+    region: content
     settings: {  }
     third_party_settings: {  }
-    type: options_select
-    region: content
   field_c_p_title:
+    type: string_textfield
     weight: 0
+    region: content
     settings:
       size: 60
       placeholder: ''
     third_party_settings: {  }
-    type: string_textfield
-    region: content
 hidden:
   created: true
   status: true

--- a/docroot/themes/contrib/civictheme/config/install/core.entity_view_display.paragraph.civictheme_navigation_card.default.yml
+++ b/docroot/themes/contrib/civictheme/config/install/core.entity_view_display.paragraph.civictheme_navigation_card.default.yml
@@ -4,6 +4,7 @@ dependencies:
   config:
     - field.field.paragraph.civictheme_navigation_card.field_c_p_image
     - field.field.paragraph.civictheme_navigation_card.field_c_p_link
+    - field.field.paragraph.civictheme_navigation_card.field_c_p_size
     - field.field.paragraph.civictheme_navigation_card.field_c_p_summary
     - field.field.paragraph.civictheme_navigation_card.field_c_p_theme
     - field.field.paragraph.civictheme_navigation_card.field_c_p_title
@@ -18,15 +19,15 @@ mode: default
 content:
   field_c_p_image:
     type: entity_reference_entity_view
-    weight: 0
     label: hidden
     settings:
       view_mode: default
       link: false
     third_party_settings: {  }
+    weight: 0
     region: content
   field_c_p_link:
-    weight: 4
+    type: link
     label: hidden
     settings:
       trim_length: 80
@@ -35,28 +36,35 @@ content:
       rel: ''
       target: ''
     third_party_settings: {  }
-    type: link
+    weight: 4
+    region: content
+  field_c_p_size:
+    type: list_default
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 5
     region: content
   field_c_p_summary:
-    weight: 2
+    type: basic_string
     label: hidden
     settings: {  }
     third_party_settings: {  }
-    type: basic_string
+    weight: 2
     region: content
   field_c_p_theme:
-    weight: 3
+    type: list_default
     label: hidden
     settings: {  }
     third_party_settings: {  }
-    type: list_default
+    weight: 3
     region: content
   field_c_p_title:
-    weight: 1
+    type: string
     label: hidden
     settings:
       link_to_entity: false
     third_party_settings: {  }
-    type: string
+    weight: 1
     region: content
 hidden: {  }

--- a/docroot/themes/contrib/civictheme/config/install/field.field.paragraph.civictheme_navigation_card.field_c_p_size.yml
+++ b/docroot/themes/contrib/civictheme/config/install/field.field.paragraph.civictheme_navigation_card.field_c_p_size.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_c_p_size
+    - paragraphs.paragraphs_type.civictheme_navigation_card
+  module:
+    - options
+id: paragraph.civictheme_navigation_card.field_c_p_size
+field_name: field_c_p_size
+entity_type: paragraph
+bundle: civictheme_navigation_card
+label: Size
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: large
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/docroot/themes/contrib/civictheme/includes/navigation_card.inc
+++ b/docroot/themes/contrib/civictheme/includes/navigation_card.inc
@@ -17,4 +17,7 @@ function civictheme_preprocess_paragraph__civictheme_navigation_card(&$variables
     $variables['url'] = $link->getUrl()->toString();
     $variables['is_external'] = $link->isExternal();
   }
+
+  // Navigation card size.
+  $variables['size'] = civictheme_get_field_value($paragraph, 'field_c_p_size');
 }

--- a/tests/behat/features/paragraph.civictheme_navigation_card.fields.feature
+++ b/tests/behat/features/paragraph.civictheme_navigation_card.fields.feature
@@ -17,6 +17,7 @@ Feature: Tests the Card container paragraph
     And I should see the text "field_c_p_title" in the "Title" row
     And I should see the text "field_c_p_image" in the "Image" row
     And I should see the text "field_c_p_link" in the "Link" row
+    And I should see the text "field_c_p_size" in the "Size" row
     And I should see the text "field_c_p_summary" in the "Summary" row
 
   @api
@@ -49,6 +50,8 @@ Feature: Tests the Card container paragraph
     And I wait for AJAX to finish
     Then select "field_c_n_components[0][subform][field_c_p_cards][0][subform][field_c_p_theme]" should have an option "light"
     And the option "Light" from select "Theme" is selected
+    Then select "field_c_n_components[0][subform][field_c_p_cards][0][subform][field_c_p_size]" should have an option "Large"
+    And the option "Large" from select "Size" is selected
     And I should see an "input[name='field_c_n_components[0][subform][field_c_p_cards][0][subform][field_c_p_title][0][value]']" element
     And I should see an "input[name='field_c_n_components[0][subform][field_c_p_cards][0][subform][field_c_p_title][0][value]'].required" element
     And I should see an "textarea[name='field_c_n_components[0][subform][field_c_p_cards][0][subform][field_c_p_summary][0][value]']" element


### PR DESCRIPTION
https://salsadigital.atlassian.net/browse/CIVIC-957

## Checklist before requesting a review

- [x] I have formatted the subject to include ticket number as `[CIVIC-123] Verb in past tense with dot at the end.`
- [x] I have added a link to the JIRA ticket
- [x] I have provided information in `Changed` section about WHY something was done if this was not a normal implementation
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run new and existing relevant tests locally with my changes, and they passed
- [x] I have provided screenshots, where applicable

## Changed
1. Added Size field to Navigation card paragraph.
2. Added preprocess variable to extract the size value.

## Screenshots
![Screenshot 2022-08-23 at 12 48 44 PM](https://user-images.githubusercontent.com/83997348/186095785-1a9d2153-e87e-4ae0-a061-50e247460008.png)

