### PR TITLE
[CIVIC-976] Fixed missing menu block values added on build of a child theme.

### DIFF
--- a/docroot/modules/custom/civictheme_content/modules/civictheme_content_corporate/content/block_content/b7f36176-620f-4178-aadd-9b448c610986.yml
+++ b/docroot/modules/custom/civictheme_content/modules/civictheme_content_corporate/content/block_content/b7f36176-620f-4178-aadd-9b448c610986.yml
@@ -17,13 +17,13 @@ default:
   revision_translation_affected:
     -
       value: true
-  field_c_b_bottom_menu:
+  field_c_b_bottom:
     -
       target_id: civictheme_secondary_navigation
   field_c_b_theme:
     -
       value: light
-  field_c_b_top_menu:
+  field_c_b_top:
     -
       target_id: civictheme_primary_navigation
   field_c_b_trigger_text:

--- a/docroot/modules/custom/civictheme_content/modules/civictheme_content_default/content/block_content/b7f36176-620f-4178-aadd-9b448c610986.yml
+++ b/docroot/modules/custom/civictheme_content/modules/civictheme_content_default/content/block_content/b7f36176-620f-4178-aadd-9b448c610986.yml
@@ -17,13 +17,13 @@ default:
   revision_translation_affected:
     -
       value: true
-  field_c_b_bottom_menu:
+  field_c_b_bottom:
     -
       target_id: civictheme_secondary_navigation
   field_c_b_theme:
     -
       value: light
-  field_c_b_top_menu:
+  field_c_b_top:
     -
       target_id: civictheme_primary_navigation
   field_c_b_trigger_text:

--- a/docroot/themes/contrib/civictheme/civictheme.info.yml
+++ b/docroot/themes/contrib/civictheme/civictheme.info.yml
@@ -228,9 +228,9 @@ config_devel:
     - field.field.block_content.civictheme_banner.field_c_b_background_image
     - field.field.block_content.civictheme_banner.field_c_b_theme
     - field.field.block_content.civictheme_component_block.field_c_b_components
-    - field.field.block_content.civictheme_mobile_navigation.field_c_b_bottom_menu
+    - field.field.block_content.civictheme_mobile_navigation.field_c_b_bottom
     - field.field.block_content.civictheme_mobile_navigation.field_c_b_theme
-    - field.field.block_content.civictheme_mobile_navigation.field_c_b_top_menu
+    - field.field.block_content.civictheme_mobile_navigation.field_c_b_top
     - field.field.block_content.civictheme_mobile_navigation.field_c_b_trigger_text
     - field.field.block_content.civictheme_mobile_navigation.field_c_b_trigger_theme
     - field.field.block_content.civictheme_search.field_c_b_link
@@ -431,12 +431,12 @@ config_devel:
     - field.field.paragraph.civictheme_webform.field_c_p_theme
     - field.field.paragraph.civictheme_webform.field_c_p_webform
     - field.storage.block_content.field_c_b_background_image
-    - field.storage.block_content.field_c_b_bottom_menu
+    - field.storage.block_content.field_c_b_bottom
     - field.storage.block_content.field_c_b_components
     - field.storage.block_content.field_c_b_link
     - field.storage.block_content.field_c_b_social_icons
     - field.storage.block_content.field_c_b_theme
-    - field.storage.block_content.field_c_b_top_menu
+    - field.storage.block_content.field_c_b_top
     - field.storage.block_content.field_c_b_trigger_text
     - field.storage.block_content.field_c_b_trigger_theme
     - field.storage.block_content.field_c_b_with_border

--- a/docroot/themes/contrib/civictheme/civictheme_library/components/03-organisms/mobile-navigation/mobile-navigation.stories.js
+++ b/docroot/themes/contrib/civictheme/civictheme_library/components/03-organisms/mobile-navigation/mobile-navigation.stories.js
@@ -13,8 +13,8 @@ export default {
 
 export const MobileNavigation = () => {
   const generalKnobTab = 'Menu';
-  const topMenuKnobTab = 'Top menu';
-  const bottomMenuKnobTab = 'Bottom menu';
+  const topMenuKnobTab = 'Top block';
+  const bottomMenuKnobTab = 'Bottom block';
 
   const { icons } = ICONS;
   const defaultIcon = icons.indexOf('content_justifyalignment');

--- a/docroot/themes/contrib/civictheme/civictheme_library/components/03-organisms/mobile-navigation/mobile-navigation.stories.js
+++ b/docroot/themes/contrib/civictheme/civictheme_library/components/03-organisms/mobile-navigation/mobile-navigation.stories.js
@@ -13,8 +13,8 @@ export default {
 
 export const MobileNavigation = () => {
   const generalKnobTab = 'Menu';
-  const topMenuKnobTab = 'Top block';
-  const bottomMenuKnobTab = 'Bottom block';
+  const topMenuKnobTab = 'Top menu';
+  const bottomMenuKnobTab = 'Bottom menu';
 
   const { icons } = ICONS;
   const defaultIcon = icons.indexOf('content_justifyalignment');

--- a/docroot/themes/contrib/civictheme/config/install/core.entity_form_display.block_content.civictheme_mobile_navigation.default.yml
+++ b/docroot/themes/contrib/civictheme/config/install/core.entity_form_display.block_content.civictheme_mobile_navigation.default.yml
@@ -3,9 +3,9 @@ status: true
 dependencies:
   config:
     - block_content.type.civictheme_mobile_navigation
-    - field.field.block_content.civictheme_mobile_navigation.field_c_b_bottom_menu
+    - field.field.block_content.civictheme_mobile_navigation.field_c_b_bottom
     - field.field.block_content.civictheme_mobile_navigation.field_c_b_theme
-    - field.field.block_content.civictheme_mobile_navigation.field_c_b_top_menu
+    - field.field.block_content.civictheme_mobile_navigation.field_c_b_top
     - field.field.block_content.civictheme_mobile_navigation.field_c_b_trigger_text
     - field.field.block_content.civictheme_mobile_navigation.field_c_b_trigger_theme
   module:
@@ -33,7 +33,7 @@ targetEntityType: block_content
 bundle: civictheme_mobile_navigation
 mode: default
 content:
-  field_c_b_bottom_menu:
+  field_c_b_bottom:
     weight: 2
     settings:
       match_operator: CONTAINS
@@ -49,7 +49,7 @@ content:
     third_party_settings: {  }
     type: options_buttons
     region: content
-  field_c_b_top_menu:
+  field_c_b_top:
     weight: 1
     settings:
       match_operator: CONTAINS

--- a/docroot/themes/contrib/civictheme/config/install/core.entity_view_display.block_content.civictheme_mobile_navigation.default.yml
+++ b/docroot/themes/contrib/civictheme/config/install/core.entity_view_display.block_content.civictheme_mobile_navigation.default.yml
@@ -3,9 +3,9 @@ status: true
 dependencies:
   config:
     - block_content.type.civictheme_mobile_navigation
-    - field.field.block_content.civictheme_mobile_navigation.field_c_b_bottom_menu
+    - field.field.block_content.civictheme_mobile_navigation.field_c_b_bottom
     - field.field.block_content.civictheme_mobile_navigation.field_c_b_theme
-    - field.field.block_content.civictheme_mobile_navigation.field_c_b_top_menu
+    - field.field.block_content.civictheme_mobile_navigation.field_c_b_top
     - field.field.block_content.civictheme_mobile_navigation.field_c_b_trigger_text
     - field.field.block_content.civictheme_mobile_navigation.field_c_b_trigger_theme
   module:
@@ -15,7 +15,7 @@ targetEntityType: block_content
 bundle: civictheme_mobile_navigation
 mode: default
 content:
-  field_c_b_bottom_menu:
+  field_c_b_bottom:
     weight: 5
     label: above
     settings:
@@ -30,7 +30,7 @@ content:
     third_party_settings: {  }
     type: list_default
     region: content
-  field_c_b_top_menu:
+  field_c_b_top:
     weight: 6
     label: above
     settings:

--- a/docroot/themes/contrib/civictheme/config/install/field.field.block_content.civictheme_mobile_navigation.field_c_b_bottom.yml
+++ b/docroot/themes/contrib/civictheme/config/install/field.field.block_content.civictheme_mobile_navigation.field_c_b_bottom.yml
@@ -3,12 +3,12 @@ status: true
 dependencies:
   config:
     - block_content.type.civictheme_mobile_navigation
-    - field.storage.block_content.field_c_b_bottom_menu
-id: block_content.civictheme_mobile_navigation.field_c_b_bottom_menu
-field_name: field_c_b_bottom_menu
+    - field.storage.block_content.field_c_b_bottom
+id: block_content.civictheme_mobile_navigation.field_c_b_bottom
+field_name: field_c_b_bottom
 entity_type: block_content
 bundle: civictheme_mobile_navigation
-label: 'Bottom menu'
+label: 'Bottom block'
 description: ''
 required: false
 translatable: false

--- a/docroot/themes/contrib/civictheme/config/install/field.field.block_content.civictheme_mobile_navigation.field_c_b_top.yml
+++ b/docroot/themes/contrib/civictheme/config/install/field.field.block_content.civictheme_mobile_navigation.field_c_b_top.yml
@@ -3,12 +3,12 @@ status: true
 dependencies:
   config:
     - block_content.type.civictheme_mobile_navigation
-    - field.storage.block_content.field_c_b_top_menu
-id: block_content.civictheme_mobile_navigation.field_c_b_top_menu
-field_name: field_c_b_top_menu
+    - field.storage.block_content.field_c_b_top
+id: block_content.civictheme_mobile_navigation.field_c_b_top
+field_name: field_c_b_top
 entity_type: block_content
 bundle: civictheme_mobile_navigation
-label: 'Top menu'
+label: 'Top block'
 description: ''
 required: false
 translatable: false

--- a/docroot/themes/contrib/civictheme/config/install/field.storage.block_content.field_c_b_bottom.yml
+++ b/docroot/themes/contrib/civictheme/config/install/field.storage.block_content.field_c_b_bottom.yml
@@ -4,8 +4,8 @@ dependencies:
   module:
     - block
     - block_content
-id: block_content.field_c_b_bottom_menu
-field_name: field_c_b_bottom_menu
+id: block_content.field_c_b_bottom
+field_name: field_c_b_bottom
 entity_type: block_content
 type: entity_reference
 settings:

--- a/docroot/themes/contrib/civictheme/config/install/field.storage.block_content.field_c_b_top.yml
+++ b/docroot/themes/contrib/civictheme/config/install/field.storage.block_content.field_c_b_top.yml
@@ -4,8 +4,8 @@ dependencies:
   module:
     - block
     - block_content
-id: block_content.field_c_b_top_menu
-field_name: field_c_b_top_menu
+id: block_content.field_c_b_top
+field_name: field_c_b_top
 entity_type: block_content
 type: entity_reference
 settings:

--- a/docroot/themes/contrib/civictheme/includes/mobile_navigation.inc
+++ b/docroot/themes/contrib/civictheme/includes/mobile_navigation.inc
@@ -24,8 +24,8 @@ function _civictheme_preprocess_block__civictheme_mobile_navigation(&$variables)
   }
 
   $menu_fields = [
-    'top_menu' => 'field_c_b_top_menu',
-    'bottom_menu' => 'field_c_b_bottom_menu',
+    'top_menu' => 'field_c_b_top',
+    'bottom_menu' => 'field_c_b_bottom',
   ];
 
   // Get primary and secondary menu links by building menu tree based on

--- a/docroot/themes/contrib/civictheme/theme-settings.provision.inc
+++ b/docroot/themes/contrib/civictheme/theme-settings.provision.inc
@@ -689,8 +689,8 @@ function _civictheme_provision__blocks__mobile_navigation(array $block) {
   $context_theme = theme_get_setting('components.header.theme') ?? CIVICTHEME_HEADER_THEME_DEFAULT;
 
   $block_content = civictheme_provision_create_block_content($block['type'], $block['name'], $block['uuid']);
-  $block_content->field_c_b_top_menu = "{$theme_name}_primary_navigation";
-  $block_content->field_c_b_bottom_menu = "{$theme_name}_secondary_navigation";
+  $block_content->field_c_b_top = "{$theme_name}_primary_navigation";
+  $block_content->field_c_b_bottom = "{$theme_name}_secondary_navigation";
   $block_content->field_c_b_trigger_text = 'Menu';
   $block_content->field_c_b_trigger_theme = $context_theme;
   $block_content->save();

--- a/tests/behat/features/block_type.civictheme_mobile_navigation.fields.feature
+++ b/tests/behat/features/block_type.civictheme_mobile_navigation.fields.feature
@@ -11,8 +11,8 @@ Feature: Tests the CivicTheme Mobile Navigation
   Scenario: CivicTheme Component block type exists with fields.
     Given I am logged in as a user with the "Administrator" role
     When I go to "admin/structure/block/block-content/manage/civictheme_mobile_navigation/fields"
-    Then I should see the text "Bottom menu" in the "field_c_b_bottom_menu" row
-    Then I should see the text "Top menu" in the "field_c_b_top_menu" row
+    Then I should see the text "Bottom block" in the "field_c_b_bottom" row
+    Then I should see the text "Top block" in the "field_c_b_top" row
     Then I should see the text "Theme" in the "field_c_b_theme" row
     Then I should see the text "Trigger text" in the "field_c_b_trigger_text" row
     Then I should see the text "Trigger theme" in the "field_c_b_trigger_theme" row


### PR DESCRIPTION
https://salsadigital.atlassian.net/browse/CIVIC-976

## Checklist before requesting a review

- [x] I have formatted the subject to include ticket number as `[CIVIC-123] Verb in past tense with dot at the end.`
- [x] I have added a link to the JIRA ticket
- [x] I have provided information in `Changed` section about WHY something was done if this was not a normal implementation
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run new and existing relevant tests locally with my changes, and they passed
- [x] I have provided screenshots, where applicable

## Changed
1. Renamed Top menu (field_c_b_top_menu) to Top block (field_c_b_top).
2. Renamed Bottom menu (field_c_b_bottom_menu) to Bottom block (field_c_b_bottom).
3. Updated tests.
4. Updated generated content.
5. Fixed provisioning to add Primary navigation to the Top block and Secondary navigation to the Bottom block.

## Screenshots
![Screenshot 2022-08-26 at 8 50 09 AM](https://user-images.githubusercontent.com/83997348/186811177-e213281a-dd48-400f-be01-825cf65d9d90.png)
![Screenshot 2022-08-26 at 8 54 57 AM](https://user-images.githubusercontent.com/83997348/186811181-58d336d0-32ac-4526-8e90-4a754f783c98.png)

