### PR TITLE
Remove use of reset of object in utilities.

### DIFF
--- a/docroot/themes/contrib/civictheme/includes/utilities.inc
+++ b/docroot/themes/contrib/civictheme/includes/utilities.inc
@@ -284,9 +284,9 @@ function civictheme_get_field_value(FieldableEntityInterface $entity, $field_nam
     case 'daterange':
     case 'image':
     case 'link':
-      $list = reset($field);
-      if (!empty($list)) {
-        $value = $only_first ? reset($list) : $list;
+      $list = $field;
+      if (!$list->isEmpty()) {
+        $value = $only_first ? $list->first() : $list;
       }
       break;
 


### PR DESCRIPTION
### Background

PHP8.1 deprecates using reset on an object (https://wiki.php.net/rfc/deprecations_php_8_1)

`civictheme_get_value` uses reset on ListItems to get the underlying array.

### What has changed
1. Using the `FieldItemList` rather than returning the underlying array