### PR TITLE
[CIVIC-998] Fixed Icon colour to match the border colour of the Field message.

### DIFF
--- a/docroot/themes/contrib/civictheme/civictheme_library/components/01-atoms/field-message/field-message.scss
+++ b/docroot/themes/contrib/civictheme/civictheme_library/components/01-atoms/field-message/field-message.scss
@@ -61,6 +61,7 @@
 
           @if $theme == 'light' {
             color: $civictheme-field-message-light-color;
+
             .civictheme-icon {
               background-color: map.get($values, 'border-color');
             }

--- a/docroot/themes/contrib/civictheme/civictheme_library/components/01-atoms/field-message/field-message.scss
+++ b/docroot/themes/contrib/civictheme/civictheme_library/components/01-atoms/field-message/field-message.scss
@@ -61,15 +61,12 @@
 
           @if $theme == 'light' {
             color: $civictheme-field-message-light-color;
+            .civictheme-icon {
+              background-color: map.get($values, 'border-color');
+            }
           }
           @else if $theme == 'dark' {
             color: $civictheme-field-message-dark-color;
-          }
-        }
-
-        @if $theme == 'light' {
-          .civictheme-icon {
-            background-color: map.get($values, 'border-color');
           }
         }
       }


### PR DESCRIPTION
https://salsadigital.atlassian.net/browse/CIVIC-998

## Checklist before requesting a review

- [x] I have formatted the subject to include ticket number as `[CIVIC-123] Verb in past tense with dot at the end.`
- [x] I have added a link to the JIRA ticket
- [x] I have provided information in `Changed` section about WHY something was done if this was not a normal implementation
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run new and existing relevant tests locally with my changes, and they passed
- [x] I have provided screenshots, where applicable

## Changed
1. Fixed Icon colour to match the border colour of the Field message.

## Screenshots
![Screenshot 2022-09-05 at 3 47 49 PM](https://user-images.githubusercontent.com/83997348/188426781-1ec5540f-cd88-43b0-b27c-3ad2c55f8958.png)
![Screenshot 2022-09-05 at 3 47 43 PM](https://user-images.githubusercontent.com/83997348/188426791-ebaf31e0-1dc3-46c5-b581-3227ed99a932.png)

