### PR TITLE
[CIVIC-779] Implemented support to provide alt text if the icon is rendered in HTML mode.

### DIFF
--- a/docroot/themes/contrib/civictheme/civictheme_library/components/01-atoms/icon/icon.stories.js
+++ b/docroot/themes/contrib/civictheme/civictheme_library/components/01-atoms/icon/icon.stories.js
@@ -1,5 +1,5 @@
 // phpcs:ignoreFile
-import { radios, select } from '@storybook/addon-knobs';
+import { radios, select, text } from '@storybook/addon-knobs';
 
 import CivicThemeIcon from './icon.twig';
 
@@ -21,5 +21,6 @@ export const Icon = (knobTab) => {
   return CivicThemeIcon({
     symbol: select('Symbol', Object.values(ICONS), Object.values(ICONS)[0], generalKnobTab),
     size: radios('Size', sizes, sizes[2], generalKnobTab),
+    alt: text('Icon alt text', 'Alternative text', generalKnobTab),
   });
 };

--- a/docroot/themes/contrib/civictheme/civictheme_library/components/01-atoms/icon/icon.twig
+++ b/docroot/themes/contrib/civictheme/civictheme_library/components/01-atoms/icon/icon.twig
@@ -7,6 +7,7 @@
  * - symbol: [string] Icon name as per map.
  * - size: [string] Icon size.
  * - modifier_class: [string] Additional classes.
+ * - alt: [string] Alternate text of the image.
  */
 #}
 
@@ -14,7 +15,7 @@
   {% set modifier_class = '%s %s %s'|format((symbol ? 'civictheme-icon--' ~ symbol : ''),(size ? 'civictheme-icon--size-' ~ size : ''), modifier_class|default('')) %}
 
   {% if symbol is defined %}
-    <span class="civictheme-icon {{ modifier_class }}"></span>
+    <span class="civictheme-icon {{ modifier_class }}" {% if alt is not null %}alt="{{ alt }}"{% endif %}></span>
   {% endif %}
 
 {% endblock %}


### PR DESCRIPTION
https://salsadigital.atlassian.net/browse/CIVIC-779

## Checklist before requesting a review

- [x] I have formatted the subject to include ticket number as `[CIVIC-123] Verb in past tense with dot at the end.`
- [x] I have added a link to the JIRA ticket
- [x] I have provided information in `Changed` section about WHY something was done if this was not a normal implementation
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run new and existing relevant tests locally with my changes, and they passed
- [x] I have provided screenshots, where applicable

## Changed
1. Implemented support to provide alt text if the icon is rendered in HTML mode.

## Screenshots
![Screenshot 2022-09-05 at 11 51 57 PM](https://user-images.githubusercontent.com/83997348/188499968-70061e91-0be9-441a-b0dd-5d6cd96a4ea3.png)