### PR TITLE
Added handling of non fully qualified urls in anchor tags.

### DIFF
--- a/docroot/themes/contrib/civictheme/includes/link.inc
+++ b/docroot/themes/contrib/civictheme/includes/link.inc
@@ -106,7 +106,13 @@ function civictheme_url_is_external($url, $base_url, array $override_domains = [
         continue;
       }
 
-      if (UrlHelper::externalIsLocal($url, $override_domain)) {
+      // UrlHelper throws exception on telephone URIs.
+      try {
+        if (UrlHelper::externalIsLocal($url, $override_domain)) {
+          return FALSE;
+        }
+      }
+      catch (\InvalidArgumentException $exception) {
         return FALSE;
       }
     }

--- a/tests/behat/features/links.feature
+++ b/tests/behat/features/links.feature
@@ -35,6 +35,18 @@ Feature: Check that content links have the correct classes.
       | field_c_p_content:value  | <a href="http://exampleoverridden.com/external-dark-link">External dark link from overridden domain</a> |
       | field_c_p_content:format | civictheme_rich_text                                                                                    |
       | field_c_p_theme          | dark                                                                                                    |
+    And "field_c_n_components" in "civictheme_page" "node" with "title" of "[TEST] Page 1" has "civictheme_content" paragraph:
+      | field_c_p_content:value  | <a href="tel:123412341234">Telephone link</a> |
+      | field_c_p_content:format | civictheme_rich_text                          |
+      | field_c_p_theme          | dark                                                                                                    |
+    And "field_c_n_components" in "civictheme_page" "node" with "title" of "[TEST] Page 1" has "civictheme_content" paragraph:
+      | field_c_p_content:value  | <a href="no-slash">Telephone link</a> |
+      | field_c_p_content:format | civictheme_rich_text                               |
+      | field_c_p_theme          | dark                                               |
+    And "field_c_n_components" in "civictheme_page" "node" with "title" of "[TEST] Page 1" has "civictheme_content" paragraph:
+      | field_c_p_content:value  | <a href="mailto:test@example.com">Telephone link</a> |
+      | field_c_p_content:format | civictheme_rich_text                               |
+      | field_c_p_theme          | dark                                                                                                    |
 
     And I am logged in as a user with the "Site Administrator" role
     And I visit "/admin/appearance/settings/civictheme_demo"


### PR DESCRIPTION
### Issue link: https://github.com/salsadigitalauorg/civictheme_source/issues/643

### Background

UrlHelper::externalIsLocal is for seeing whether URLS are local or not. By default, mailto and tel are not links to web resources and so it throws an exception

### What has changed
1. Added handling for invalid path exception. Returning false for mailto and telephone links to fix the page breaking bug.