### PR TITLE
[CIVIC-1002] Fixed not rendering exposed text filters  on views

### DIFF
--- a/docroot/themes/contrib/civictheme/includes/views.inc
+++ b/docroot/themes/contrib/civictheme/includes/views.inc
@@ -99,9 +99,8 @@ function _civictheme_filter_views_exposed_form_alter(&$form, FormStateInterface 
   $listing_filters = NULL;
   if (!empty($view->civictheme_listing_entity)) {
     $listing_show_filters = civictheme_get_field_value($view->civictheme_listing_entity, 'field_c_p_listing_show_filters');
-    $exposed_listing_filters = civictheme_get_field_value($view->civictheme_listing_entity, 'field_c_p_listing_filters_exp');
-    if ($listing_show_filters && $exposed_listing_filters) {
-      $listing_filters = explode(', ', $exposed_listing_filters);
+    if ($listing_show_filters) {
+      $listing_filters = explode(', ', civictheme_get_field_value($view->civictheme_listing_entity, 'field_c_p_listing_filters_exp', FALSE, ''));
     }
   }
 

--- a/docroot/themes/contrib/civictheme/includes/views.inc
+++ b/docroot/themes/contrib/civictheme/includes/views.inc
@@ -99,8 +99,9 @@ function _civictheme_filter_views_exposed_form_alter(&$form, FormStateInterface 
   $listing_filters = NULL;
   if (!empty($view->civictheme_listing_entity)) {
     $listing_show_filters = civictheme_get_field_value($view->civictheme_listing_entity, 'field_c_p_listing_show_filters');
-    if ($listing_show_filters) {
-      $listing_filters = explode(', ', civictheme_get_field_value($view->civictheme_listing_entity, 'field_c_p_listing_filters_exp', FALSE, ''));
+    $exposed_listing_filters = civictheme_get_field_value($view->civictheme_listing_entity, 'field_c_p_listing_filters_exp');
+    if ($listing_show_filters && $exposed_listing_filters) {
+      $listing_filters = explode(', ', $exposed_listing_filters);
     }
   }
 

--- a/docroot/themes/contrib/civictheme/includes/views.inc
+++ b/docroot/themes/contrib/civictheme/includes/views.inc
@@ -190,25 +190,28 @@ function _civictheme_get_views_exposed_form_elements_keys($form) {
  * Alter form elements to work within Large and Basic filters.
  */
 function _civictheme_filter_views_exposed_form_alter__process_elements(&$element, $form, $is_large_filter) {
-  // Convert select to either radio buttons or checkboxes.
-  if (isset($element['#type']) && $element['#type'] === 'select') {
-    $element['#type'] = 'radios';
+  $valid_process_element_types = ['select', 'radios', 'checkboxes'];
+  if (isset($element['#type']) && in_array($element['#type'], $valid_process_element_types)) {
+    // Convert select to either radio buttons or checkboxes.
+    if (isset($element['#type']) && $element['#type'] === 'select') {
+      $element['#type'] = 'radios';
 
-    if (!empty($element['#multiple'])) {
-      $element['#type'] = 'checkboxes';
-      unset($element['#multiple']);
+      if (!empty($element['#multiple'])) {
+        $element['#type'] = 'checkboxes';
+        unset($element['#multiple']);
+      }
+
+      _civictheme_filter_views_exposed_form_alter__modify_element_callbacks($element);
     }
 
-    _civictheme_filter_views_exposed_form_alter__modify_element_callbacks($element);
+    // Only radio buttons and checkboxes work with filter chips.
+    $filter_key = !$is_large_filter && in_array($element['#type'] ?? NULL, [
+      'radios',
+      'checkboxes',
+    ]) ? '#civictheme-basic-filter' : '#civictheme-large-filter';
+    $element[$filter_key] = $form['#id'];
+    $element['#attributes'][$filter_key] = $form['#id'];
   }
-
-  // Only radio buttons and checkboxes work with filter chips.
-  $filter_key = !$is_large_filter && in_array($element['#type'] ?? NULL, [
-    'radios',
-    'checkboxes',
-  ]) ? '#civictheme-basic-filter' : '#civictheme-large-filter';
-  $element[$filter_key] = $form['#id'];
-  $element['#attributes'][$filter_key] = $form['#id'];
 }
 
 /**

--- a/tests/behat/features/paragraph.civictheme_listing.view.feature
+++ b/tests/behat/features/paragraph.civictheme_listing.view.feature
@@ -196,8 +196,10 @@ Feature: View of Page content with Listing component
 
     And "field_c_n_components" in "civictheme_page" "node" with "title" of "Page Listing component" has "civictheme_listing" paragraph:
       # Selection.
-      | field_c_p_listing_limit_type | unlimited |
-      | field_c_p_listing_limit      | 6         |
+      | field_c_p_listing_limit_type   | unlimited |
+      | field_c_p_listing_limit        | 6         |
+      | field_c_p_listing_show_filters | 1         |
+      | field_c_p_listing_filters_exp  | title     |
     When I visit "civictheme_page" "Page Listing component"
     Then I should see an ".civictheme-listing .civictheme-card-container__cards" element
     And I should see 6 ".civictheme-card-container__card" elements
@@ -222,3 +224,7 @@ Feature: View of Page content with Listing component
     Then I should see an ".civictheme-listing .civictheme-card-container__cards" element
     And I should see 2 ".civictheme-card-container__card" elements
     And I should not see an ".civictheme-listing__results-below .civictheme-pager" element
+
+    And I see field "Title"
+    And should see an "input[name='title']" element
+    And should not see an "input[name='title'].required" element

--- a/tests/behat/features/view.civictheme_listing_examples.feature
+++ b/tests/behat/features/view.civictheme_listing_examples.feature
@@ -169,3 +169,12 @@ Feature: CivicTheme listing renders on views pages with filters
       | civictheme-no-sidebar/listing-one-filter-multi-select-exposed-block |
       | civictheme-no-sidebar/listing-multiple-filters                      |
       | civictheme-no-sidebar/listing-multiple-filters-exposed-block        |
+
+  @api @testmode
+  Scenario: Listing example - Title filter
+    Given I am an anonymous user
+    When I go to "civictheme-no-sidebar/listing-multiple-filters"
+    Then the response status code should be 200
+    And I see field "Title"
+    And should see an "input[name='title']" element
+    And should not see an "input[name='title'].required" element


### PR DESCRIPTION
https://salsadigital.atlassian.net/browse/CIVIC-1002

## Checklist before requesting a review

- [x] I have formatted the subject to include ticket number as `[CIVIC-123] Verb in past tense with dot at the end.`
- [x] I have added a link to the JIRA ticket
- [x] I have provided information in `Changed` section about WHY something was done if this was not a normal implementation
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run new and existing relevant tests locally with my changes, and they passed
- [x] I have provided screenshots, where applicable

## Changed
1. Updated behat test to check for exposed filters.
2. Changed to support only select, radios and checkboxes using CivicTheme’s components and render other types as-is.

## Screenshots
![Screenshot 2022-09-07 at 10 26 03 AM](https://user-images.githubusercontent.com/83997348/188791930-67042d85-be93-424d-9924-1984c3a3d7bb.png)
![Screenshot 2022-09-07 at 10 26 16 AM](https://user-images.githubusercontent.com/83997348/188791955-a318ed7f-a684-4b6c-841b-df9f579020ff.png)
