### PR TITLE
[CIVIC-1019] Added background image blend mode selection for Banner paragraph and block

### DIFF
--- a/docroot/themes/contrib/civictheme/civictheme.info.yml
+++ b/docroot/themes/contrib/civictheme/civictheme.info.yml
@@ -226,6 +226,7 @@ config_devel:
     - core.entity_view_mode.node.civictheme_subject_card
     - editor.editor.civictheme_rich_text
     - field.field.block_content.civictheme_banner.field_c_b_background_image
+    - field.field.block_content.civictheme_banner.field_c_b_blend_mode
     - field.field.block_content.civictheme_banner.field_c_b_theme
     - field.field.block_content.civictheme_component_block.field_c_b_components
     - field.field.block_content.civictheme_mobile_navigation.field_c_b_bottom
@@ -431,6 +432,7 @@ config_devel:
     - field.field.paragraph.civictheme_webform.field_c_p_theme
     - field.field.paragraph.civictheme_webform.field_c_p_webform
     - field.storage.block_content.field_c_b_background_image
+    - field.storage.block_content.field_c_b_blend_mode
     - field.storage.block_content.field_c_b_bottom
     - field.storage.block_content.field_c_b_components
     - field.storage.block_content.field_c_b_link

--- a/docroot/themes/contrib/civictheme/civictheme_library/components/00-base/background/background.stories.js
+++ b/docroot/themes/contrib/civictheme/civictheme_library/components/00-base/background/background.stories.js
@@ -12,6 +12,28 @@ export const Background = (knobTab) => {
   const generalKnobTab = typeof knobTab === 'string' ? knobTab : 'General';
 
   const bg = select('Background', Object.keys(BACKGROUNDS), Object.keys(BACKGROUNDS)[0], generalKnobTab);
+  const blendMode = select(
+    'Blend mode', {
+      Color: 'color',
+      'Color burn': 'color-burn',
+      'Color dodge': 'color-dodge',
+      Darken: 'darken',
+      Difference: 'difference',
+      Exclusion: 'exclusion',
+      'Hard light': 'hard-light',
+      Hue: 'hue',
+      Lighten: 'lighten',
+      Luminosity: 'luminosity',
+      Multiply: 'multiply',
+      Normal: 'normal',
+      Overlay: 'overlay',
+      Saturation: 'saturation',
+      Screen: 'screen',
+      'Soft light': 'soft-light',
+    },
+    'normal',
+    generalKnobTab,
+  );
 
-  return `<div class="story-background-wrapper story-wrapper-size--large" style="background-image: url('${BACKGROUNDS[bg]}')"></div>`;
+  return `<div class="story-background-wrapper story-wrapper-size--large civictheme-background--${blendMode}" style="background-image: url('${BACKGROUNDS[bg]}')"></div>`;
 };

--- a/docroot/themes/contrib/civictheme/config/install/core.entity_form_display.block_content.civictheme_banner.default.yml
+++ b/docroot/themes/contrib/civictheme/config/install/core.entity_form_display.block_content.civictheme_banner.default.yml
@@ -4,6 +4,7 @@ dependencies:
   config:
     - block_content.type.civictheme_banner
     - field.field.block_content.civictheme_banner.field_c_b_background_image
+    - field.field.block_content.civictheme_banner.field_c_b_blend_mode
     - field.field.block_content.civictheme_banner.field_c_b_theme
   module:
     - media_library
@@ -15,16 +16,22 @@ content:
   field_c_b_background_image:
     type: media_library_widget
     weight: 27
+    region: content
     settings:
       media_types: {  }
     third_party_settings: {  }
+  field_c_b_blend_mode:
+    type: options_select
+    weight: 28
     region: content
-  field_c_b_theme:
-    weight: 26
     settings: {  }
     third_party_settings: {  }
+  field_c_b_theme:
     type: options_buttons
+    weight: 26
     region: content
+    settings: {  }
+    third_party_settings: {  }
   info:
     type: string_textfield
     weight: -5

--- a/docroot/themes/contrib/civictheme/config/install/core.entity_view_display.block_content.civictheme_banner.default.yml
+++ b/docroot/themes/contrib/civictheme/config/install/core.entity_view_display.block_content.civictheme_banner.default.yml
@@ -4,6 +4,7 @@ dependencies:
   config:
     - block_content.type.civictheme_banner
     - field.field.block_content.civictheme_banner.field_c_b_background_image
+    - field.field.block_content.civictheme_banner.field_c_b_blend_mode
     - field.field.block_content.civictheme_banner.field_c_b_theme
 id: block_content.civictheme_banner.default
 targetEntityType: block_content
@@ -12,12 +13,13 @@ mode: default
 content:
   field_c_b_background_image:
     type: entity_reference_entity_view
-    weight: 0
     label: hidden
     settings:
       view_mode: default
       link: false
     third_party_settings: {  }
+    weight: 0
     region: content
 hidden:
+  field_c_b_blend_mode: true
   field_c_b_theme: true

--- a/docroot/themes/contrib/civictheme/config/install/field.field.block_content.civictheme_banner.field_c_b_blend_mode.yml
+++ b/docroot/themes/contrib/civictheme/config/install/field.field.block_content.civictheme_banner.field_c_b_blend_mode.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.civictheme_banner
+    - field.storage.block_content.field_c_b_blend_mode
+  module:
+    - options
+id: block_content.civictheme_banner.field_c_b_blend_mode
+field_name: field_c_b_blend_mode
+entity_type: block_content
+bundle: civictheme_banner
+label: 'Blend mode'
+description: ''
+required: false
+translatable: false
+default_value:
+  -
+    value: normal
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/docroot/themes/contrib/civictheme/config/install/field.storage.block_content.field_c_b_blend_mode.yml
+++ b/docroot/themes/contrib/civictheme/config/install/field.storage.block_content.field_c_b_blend_mode.yml
@@ -1,0 +1,68 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - block_content
+    - options
+id: block_content.field_c_b_blend_mode
+field_name: field_c_b_blend_mode
+entity_type: block_content
+type: list_string
+settings:
+  allowed_values:
+    -
+      value: color
+      label: Color
+    -
+      value: color-burn
+      label: 'Color burn'
+    -
+      value: color-dodge
+      label: 'Color dodge'
+    -
+      value: darken
+      label: Darken
+    -
+      value: difference
+      label: Difference
+    -
+      value: exclusion
+      label: Exclusion
+    -
+      value: hard-light
+      label: 'Hard light'
+    -
+      value: hue
+      label: Hue
+    -
+      value: lighten
+      label: Lighten
+    -
+      value: luminosity
+      label: Luminosity
+    -
+      value: multiply
+      label: Multiply
+    -
+      value: normal
+      label: Normal
+    -
+      value: overlay
+      label: Overlay
+    -
+      value: saturation
+      label: Saturation
+    -
+      value: screen
+      label: Screen
+    -
+      value: soft-light
+      label: 'Soft light'
+  allowed_values_function: ''
+module: options
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/themes/contrib/civictheme/includes/banner.inc
+++ b/docroot/themes/contrib/civictheme/includes/banner.inc
@@ -40,6 +40,14 @@ function _civictheme_preprocess_block__civictheme_banner(&$variables) {
 
   if (civictheme_field_has_value($entity, 'field_c_b_background_image')) {
     $variables['background_image'] = civictheme_media_get_url_from_field($entity, 'field_c_b_background_image');
+
+    if (civictheme_field_has_value($entity, 'field_c_b_blend_mode')) {
+      $blend_mode = civictheme_get_field_value($entity, 'field_c_b_blend_mode', TRUE);
+      if (!array_key_exists('modifier_class', $variables)) {
+        $variables['modifier_class'] = '';
+      }
+      $variables['modifier_class'] .= ' civictheme-background--' . $blend_mode;
+    }
   }
 
   _civictheme_preprocess_civictheme_banner_title($variables);


### PR DESCRIPTION
https://salsadigital.atlassian.net/browse/CIVIC-1019

## Checklist before requesting a review

- [ ] I have formatted the subject to include ticket number as `[CIVIC-123] Verb in past tense with dot at the end.`
- [ ] I have added a link to the JIRA ticket
- [ ] I have provided information in `Changed` section about WHY something was done if this was not a normal implementation
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run new and existing relevant tests locally with my changes, and they passed
- [ ] I have provided screenshots, where applicable

## Changed
1. Updated Background component in Storybook to accept a list of blend modes added as CSS class.
2. Exposed the property for the Background component to allow selecting the modes as select with name Blend mode and default value of normal.
3. Created a list field Blend mode with values.
4. Added preprocess to plant the civictheme-background--[mode]  class on Banner.

## Screenshots
![Screenshot 2022-09-14 at 7 36 48 PM](https://user-images.githubusercontent.com/83997348/190176715-64a35a48-d5b3-4d94-b93f-5fa3cb959fde.png)
![Screenshot 2022-09-14 at 7 37 11 PM](https://user-images.githubusercontent.com/83997348/190176814-2433eb6a-0538-47c1-bf26-357f4c5c9d12.png)
![Screenshot 2022-09-14 at 7 37 21 PM](https://user-images.githubusercontent.com/83997348/190176853-52fccd10-720c-4c06-a253-37b9312bd3d2.png)

