### PR TITLE
[CIVIC-992] Fixed layout classes for mobile.

### DIFF
--- a/docroot/themes/contrib/civictheme/civictheme_library/components/00-base/grid/grid.stories.js
+++ b/docroot/themes/contrib/civictheme/civictheme_library/components/00-base/grid/grid.stories.js
@@ -12,41 +12,41 @@ export const Grid = () => `
     <div class="story-grid-wrapper">
       <div class="container">
         <div class="row">
-          <div class="col-xs-1"><span>1</span></div>
-          <div class="col-xs-1"><span>1</span></div>
-          <div class="col-xs-1"><span>1</span></div>
-          <div class="col-xs-1"><span>1</span></div>
-          <div class="col-xs-1"><span>1</span></div>
-          <div class="col-xs-1"><span>1</span></div>
-          <div class="col-xs-1"><span>1</span></div>
-          <div class="col-xs-1"><span>1</span></div>
-          <div class="col-xs-1"><span>1</span></div>
-          <div class="col-xs-1"><span>1</span></div>
-          <div class="col-xs-1"><span>1</span></div>
-          <div class="col-xs-1"><span>1</span></div>
+          <div class="col-xxs-1"><span>1</span></div>
+          <div class="col-xxs-1"><span>1</span></div>
+          <div class="col-xxs-1"><span>1</span></div>
+          <div class="col-xxs-1"><span>1</span></div>
+          <div class="col-xxs-1"><span>1</span></div>
+          <div class="col-xxs-1"><span>1</span></div>
+          <div class="col-xxs-1"><span>1</span></div>
+          <div class="col-xxs-1"><span>1</span></div>
+          <div class="col-xxs-1"><span>1</span></div>
+          <div class="col-xxs-1"><span>1</span></div>
+          <div class="col-xxs-1"><span>1</span></div>
+          <div class="col-xxs-1"><span>1</span></div>
         </div>
         <div class="row">
-          <div class="col-xs-2"><span>2</span></div>
-          <div class="col-xs-2"><span>2</span></div>
-          <div class="col-xs-2"><span>2</span></div>
-          <div class="col-xs-2"><span>2</span></div>
-          <div class="col-xs-2"><span>2</span></div>
-          <div class="col-xs-2"><span>2</span></div>
+          <div class="col-xxs-2"><span>2</span></div>
+          <div class="col-xxs-2"><span>2</span></div>
+          <div class="col-xxs-2"><span>2</span></div>
+          <div class="col-xxs-2"><span>2</span></div>
+          <div class="col-xxs-2"><span>2</span></div>
+          <div class="col-xxs-2"><span>2</span></div>
         </div>
         <div class="row">
-          <div class="col-xs-3"><span>3</span></div>
-          <div class="col-xs-3"><span>3</span></div>
-          <div class="col-xs-3"><span>3</span></div>
-          <div class="col-xs-3"><span>3</span></div>
+          <div class="col-xxs-3"><span>3</span></div>
+          <div class="col-xxs-3"><span>3</span></div>
+          <div class="col-xxs-3"><span>3</span></div>
+          <div class="col-xxs-3"><span>3</span></div>
         </div>
         <div class="row">
-          <div class="col-xs-4"><span>4</span></div>
-          <div class="col-xs-4"><span>4</span></div>
-          <div class="col-xs-4"><span>4</span></div>
+          <div class="col-xxs-4"><span>4</span></div>
+          <div class="col-xxs-4"><span>4</span></div>
+          <div class="col-xxs-4"><span>4</span></div>
         </div>
         <div class="row">
-          <div class="col-xs-6"><span>6</span></div>
-          <div class="col-xs-6"><span>6</span></div>
+          <div class="col-xxs-6"><span>6</span></div>
+          <div class="col-xxs-6"><span>6</span></div>
         </div>
       </div>
     </div>
@@ -57,13 +57,13 @@ export const Grid = () => `
     <div class="story-grid-wrapper">
       <div class="container">
         <div class="row">
-          <div class="col-xs-12 col-s-6 col-m-5 col-l-4 col-xl-3 col-xxl-2"><span>Column</span></div>
-          <div class="col-xs-12 col-s-6 col-m-7 col-l-8 col-xl-9 col-xxl-10"><span>Column</span></div>
+          <div class="col-xxs-12 col-s-6 col-m-5 col-l-4 col-xl-3 col-xxl-2"><span>Column</span></div>
+          <div class="col-xxs-12 col-s-6 col-m-7 col-l-8 col-xl-9 col-xxl-10"><span>Column</span></div>
         </div>
         <div class="row">
-          <div class="col-xs-12 col-s-4 col-m-3 col-l-2 col-xl-4"><span>Column</span></div>
-          <div class="col-xs-12 col-s-4 col-m-6 col-l-8 col-xl-4"><span>Column</span></div>
-          <div class="col-xs-12 col-s-4 col-m-3 col-l-2 col-xl-4"><span>Column</span></div>
+          <div class="col-xxs-12 col-s-4 col-m-3 col-l-2 col-xl-4"><span>Column</span></div>
+          <div class="col-xxs-12 col-s-4 col-m-6 col-l-8 col-xl-4"><span>Column</span></div>
+          <div class="col-xxs-12 col-s-4 col-m-3 col-l-2 col-xl-4"><span>Column</span></div>
         </div>
       </div>
     </div>
@@ -74,14 +74,14 @@ export const Grid = () => `
     <div class="story-grid-wrapper">
       <div class="container">
         <div class="row">
-          <div class="col-xs-12 col-s-8">
+          <div class="col-xxs-12 col-s-8">
             <div class="row">
-              <div class="col-xs-12 col-s-4"><span>Column in nested grid</span></div>
-              <div class="col-xs-12 col-s-4"><span>Column in nested grid</span></div>
-              <div class="col-xs-12 col-s-4"><span>Column in nested grid</span></div>
+              <div class="col-xxs-12 col-s-4"><span>Column in nested grid</span></div>
+              <div class="col-xxs-12 col-s-4"><span>Column in nested grid</span></div>
+              <div class="col-xxs-12 col-s-4"><span>Column in nested grid</span></div>
             </div>
           </div>
-          <div class="col-xs-12 col-s-4">
+          <div class="col-xxs-12 col-s-4">
             <span>Column in parent grid</span>
           </div>
         </div>

--- a/docroot/themes/contrib/civictheme/civictheme_library/components/00-base/mixins/_grid.scss
+++ b/docroot/themes/contrib/civictheme/civictheme_library/components/00-base/mixins/_grid.scss
@@ -208,7 +208,8 @@
   // Support super-narrow screens as well.
   $width: map.get($civictheme-grid-offsets, xs) * 2;
 
-  max-width: calc(100% - #{$width});
+  // Use vw instead of % so it calculates on viewport and not parent container.
+  max-width: calc(100vw - #{$width});
 
   // Set width for container at each breakpoint accounting for offsets at this
   // breakpoint.

--- a/docroot/themes/contrib/civictheme/civictheme_library/components/02-molecules/attachment/attachment.twig
+++ b/docroot/themes/contrib/civictheme/civictheme_library/components/02-molecules/attachment/attachment.twig
@@ -27,7 +27,7 @@
   <div class="civictheme-attachment {{ modifier_class }}">
     <div class="container">
       <div class="row">
-        <div class="col-xs-12">
+        <div class="col-xxs-12">
           <div class="civictheme-attachment__content">
             {% block content_top %}
               {% if content_top is not empty %}

--- a/docroot/themes/contrib/civictheme/civictheme_library/components/02-molecules/basic-content/basic-content.twig
+++ b/docroot/themes/contrib/civictheme/civictheme_library/components/02-molecules/basic-content/basic-content.twig
@@ -22,7 +22,7 @@
     {% if is_contained %}
       <div class="container">
         <div class="row">
-          <div class="col-xs-12">
+          <div class="col-xxs-12">
             {% endif %}
               {{ content|raw }}
             {% if is_contained %}

--- a/docroot/themes/contrib/civictheme/civictheme_library/components/02-molecules/basic-filter/basic-filter.twig
+++ b/docroot/themes/contrib/civictheme/civictheme_library/components/02-molecules/basic-filter/basic-filter.twig
@@ -19,7 +19,7 @@
 <div class="civictheme-basic-filter {{ modifier_class }}" data-component-name="civictheme-basic-filter">
   <div class="container">
     <div class="row">
-      <div class="col-xs-12">
+      <div class="col-xxs-12">
         <div class="civictheme-basic-filter__list">
           {% block filters %}
             {% for item in items %}

--- a/docroot/themes/contrib/civictheme/civictheme_library/components/02-molecules/map/map.twig
+++ b/docroot/themes/contrib/civictheme/civictheme_library/components/02-molecules/map/map.twig
@@ -22,7 +22,7 @@
   <div class="civictheme-map {{ modifier_class }}">
     <div class="container">
       <div class="row">
-        <div class="col-xs-12">
+        <div class="col-xxs-12">
           {% block map %}
             <div class="civictheme-map__canvas">
               {% set attributes = 'allowfullscreen data-chromatic="ignore"' %}

--- a/docroot/themes/contrib/civictheme/civictheme_library/components/02-molecules/next-steps/next-steps.twig
+++ b/docroot/themes/contrib/civictheme/civictheme_library/components/02-molecules/next-steps/next-steps.twig
@@ -23,7 +23,7 @@
   <a class="civictheme-next-steps {{ modifier_class }}" href={{ url }}>
     <div class="container">
       <div class="row">
-        <div class="col-xs-12">
+        <div class="col-xxs-12">
           <div class="civictheme-next-steps__content">
             {% block content_top %}
               {% if content_top is not empty %}

--- a/docroot/themes/contrib/civictheme/civictheme_library/components/03-organisms/accordion/accordion.twig
+++ b/docroot/themes/contrib/civictheme/civictheme_library/components/03-organisms/accordion/accordion.twig
@@ -25,14 +25,14 @@
     <div class="container">
       <div class="row">
         {% if title is not empty %}
-          <div class="civictheme-accordion__content-top col-xs-12">
+          <div class="civictheme-accordion__content-top col-xxs-12">
             <div class="civictheme-accordion__title-top">
               {{ title }}
             </div>
           </div>
         {% endif %}
 
-        <div class="civictheme-accordion__inner col-xs-12">
+        <div class="civictheme-accordion__inner col-xxs-12">
           <ul class="civictheme-accordion__list">
             {% for fold in panels %}
               {% if fold.title is not empty or fold.content is not empty %}

--- a/docroot/themes/contrib/civictheme/civictheme_library/components/03-organisms/alert/alert.twig
+++ b/docroot/themes/contrib/civictheme/civictheme_library/components/03-organisms/alert/alert.twig
@@ -30,7 +30,7 @@
   <div class="civictheme-alert {{ modifier_class }}" data-alert-id="{{ id }}" data-alert-type="{{ type }}" data-component-name="civictheme-alert" role="alert">
     <div class="container">
       <div class="row">
-        <div class="civictheme-alert__title col-xs-12 col-m-3">
+        <div class="civictheme-alert__title col-xxs-12 col-m-3">
           {% if icons[type] is defined %}
             <span class="civictheme-alert__icon">
               {% include "@base/icon/icon.twig" with {
@@ -41,7 +41,7 @@
           {% endif %}
           {{ title|raw }}
         </div>
-        <div class="civictheme-alert__summary col-xs-12 col-m-9">
+        <div class="civictheme-alert__summary col-xxs-12 col-m-9">
           {{ description|raw }}
           {% include "@atoms/button/button.twig" with {
             kind: 'button',

--- a/docroot/themes/contrib/civictheme/civictheme_library/components/03-organisms/banner/banner.twig
+++ b/docroot/themes/contrib/civictheme/civictheme_library/components/03-organisms/banner/banner.twig
@@ -36,7 +36,7 @@
           {% if content_top1 is not empty %}
             <div class="row">
               {%- block content_top1 %}
-                <div class="col-xs-12">
+                <div class="col-xxs-12">
                   <div class="civictheme-banner__content-top">
                     {{- content_top1 -}}
                   </div>
@@ -49,7 +49,7 @@
             <div class="row">
               {% if breadcrumb is not empty %}
                 {%- block breadcrumb %}
-                  <div class="col-xs-12 col-m-6">
+                  <div class="col-xxs-12 col-m-6">
                     <div class="civictheme-banner__breadcrumb">
                       {{- breadcrumb -}}
                     </div>
@@ -59,7 +59,7 @@
 
               {% if content_top2 is not empty %}
                 {%- block content_top2 %}
-                  <div class="col-xs-12 col-m-6">
+                  <div class="col-xxs-12 col-m-6">
                     <div class="civictheme-banner__content-top2">
                       {{- content_top2 -}}
                     </div>
@@ -72,7 +72,7 @@
           {% if content_top3 is not empty %}
             <div class="row">
               {%- block content_top3 %}
-                <div class="col-xs-12">
+                <div class="col-xxs-12">
                   <div class="civictheme-banner__content-top3">
                     {{- content_top3 -}}
                   </div>
@@ -84,7 +84,7 @@
           {% if section is not empty %}
             <div class="row">
               {%- block section %}
-                <div class="col-xs-12">
+                <div class="col-xxs-12">
                   <div class="civictheme-banner__section">
                     {% include '@atoms/heading/heading.twig' with {
                       content: section,
@@ -99,7 +99,7 @@
           {% if title is not empty %}
             <div class="row">
               {%- block title %}
-                <div class="{{ featured_image is not empty ? 'col-xs-12 col-m-6':'col-xs-12 col-m-8' }}">
+                <div class="{{ featured_image is not empty ? 'col-xxs-12 col-m-6':'col-xxs-12 col-m-8' }}">
                   <div class="civictheme-banner__title">
                     {% include '@atoms/heading/heading.twig' with {
                       content: title,
@@ -114,7 +114,7 @@
           {% if content_middle is not empty %}
             <div class="row">
               {%- block content_middle %}
-                <div class="{{ featured_image is not empty ? 'col-xs-12 col-m-6':'col-xs-12 col-m-8' }}">
+                <div class="{{ featured_image is not empty ? 'col-xxs-12 col-m-6':'col-xxs-12 col-m-8' }}">
                   <div class="civictheme-banner__content-middle">
                     {{- content_middle -}}
                   </div>
@@ -126,7 +126,7 @@
           {% if content is not empty %}
             <div class="row">
               {%- block content %}
-                <div class="{{ featured_image is not empty ? 'col-xs-12 col-m-6':'col-xs-12 col-m-8' }}">
+                <div class="{{ featured_image is not empty ? 'col-xxs-12 col-m-6':'col-xxs-12 col-m-8' }}">
                   <div class="civictheme-banner__content">
                     {{- content -}}
                   </div>
@@ -155,7 +155,7 @@
       <div class="container">
         <div class="row">
           {%- block content_below %}
-            <div class="col-xs-12">
+            <div class="col-xxs-12">
               <div class="civictheme-banner__content-below">
                 {{- content_below -}}
               </div>
@@ -169,7 +169,7 @@
       <div class="container">
         <div class="row">
           {%- block content_bottom %}
-            <div class="col-xs-12">
+            <div class="col-xxs-12">
               <div class="civictheme-banner__content-bottom">
                 {{- content_bottom -}}
               </div>

--- a/docroot/themes/contrib/civictheme/civictheme_library/components/03-organisms/callout/callout.twig
+++ b/docroot/themes/contrib/civictheme/civictheme_library/components/03-organisms/callout/callout.twig
@@ -26,7 +26,7 @@
 <div class="civictheme-callout {{ modifier_class }}">
   <div class="container">
     <div class="row">
-      <div class="col-xs-12">
+      <div class="col-xxs-12">
         <div class="civictheme-callout--wrapper">
           {% block content_top %}
             {% if content_top is not empty %}

--- a/docroot/themes/contrib/civictheme/civictheme_library/components/03-organisms/card-container/card-container.twig
+++ b/docroot/themes/contrib/civictheme/civictheme_library/components/03-organisms/card-container/card-container.twig
@@ -32,7 +32,7 @@
   <div class="civictheme-card-container {{ modifier_class }}" aria-live="polite">
     <div class="container">
       <div class="row">
-        <div class="col-m-12">
+        <div class="col-xxs-12">
           {% block title %}
             {% if title is not empty or (header_link_url is not empty and header_link_text is not empty) %}
               <div class="civictheme-card-container__header">

--- a/docroot/themes/contrib/civictheme/civictheme_library/components/03-organisms/card-container/card-container.twig
+++ b/docroot/themes/contrib/civictheme/civictheme_library/components/03-organisms/card-container/card-container.twig
@@ -23,7 +23,7 @@
 
 {% set vertical_space_class = vertical_space in ['top', 'bottom', 'both'] ? 'civictheme-card-container--vertical-space-%s'|format(vertical_space) : '' %}
 {% set with_background_class = with_background ? 'civictheme-card-container--with-background' : '' %}
-{% set column_class = 'col-xs-12 col-m-%s'|format(12 / column_count|default(1)) %}
+{% set column_class = 'col-xxs-12 col-m-%s'|format(12 / column_count|default(1)) %}
 {% set fill_width_class = fill_width ? 'civictheme-card-container--fill-width' : '' %}
 {% set theme_class = 'civictheme-theme-%s'|format(theme|default('light')) %}
 {% set modifier_class = '%s %s %s %s %s'|format(theme_class, fill_width_class, vertical_space_class, with_background_class, modifier_class|default('')) %}

--- a/docroot/themes/contrib/civictheme/civictheme_library/components/03-organisms/fieldset/fieldset.stories.js
+++ b/docroot/themes/contrib/civictheme/civictheme_library/components/03-organisms/fieldset/fieldset.stories.js
@@ -43,5 +43,5 @@ export const Fieldset = () => {
     children: randomFormElements(numOfElements, theme, true).join(''),
   });
 
-  return `<div class="container"><div class="row"><div class="col-xs-12">${html}</div></div></div>`;
+  return `<div class="container"><div class="row"><div class="col-xxs-12">${html}</div></div></div>`;
 };

--- a/docroot/themes/contrib/civictheme/civictheme_library/components/03-organisms/footer/footer.stories.twig
+++ b/docroot/themes/contrib/civictheme/civictheme_library/components/03-organisms/footer/footer.stories.twig
@@ -89,7 +89,7 @@
   {% endset %}
 
   {%- block content_bottom1 %}
-    <div class="col-xs-12 col-m-7">
+    <div class="col-xxs-12 col-m-7">
       <div class="civictheme-footer__bottom__content-bottom1">
         {{- content_bottom1 -}}
       </div>
@@ -105,7 +105,7 @@
   {% endset %}
 
   {%- block content_bottom2 %}
-    <div class="col-xs-12 col-m-5">
+    <div class="col-xxs-12 col-m-5">
       <div class="civictheme-footer__bottom__content-bottom2">
         {{- content_bottom2 -}}
       </div>

--- a/docroot/themes/contrib/civictheme/civictheme_library/components/03-organisms/footer/footer.twig
+++ b/docroot/themes/contrib/civictheme/civictheme_library/components/03-organisms/footer/footer.twig
@@ -30,7 +30,7 @@
 
           {% if content_top1 is not empty %}
             {%- block content_top1 %}
-              <div class="col-xs-12 col-m-6">
+              <div class="col-xxs-12 col-m-6">
                 <div class="civictheme-footer__top__content-top1">
                   {{- content_top1 -}}
                 </div>
@@ -40,7 +40,7 @@
 
           {% if content_top2 is not empty %}
             {%- block content_top2 %}
-              <div class="col-xs-12 col-m-6">
+              <div class="col-xxs-12 col-m-6">
                 <div class="civictheme-footer__top__content-top2">
                   {{- content_top2 -}}
                 </div>
@@ -58,7 +58,7 @@
 
           {% if content_middle1 is not empty %}
             {%- block content_middle1 %}
-              <div class="col-xs-12 col-m-3">
+              <div class="col-xxs-12 col-m-3">
                 <div class="civictheme-footer__middle__content-middle1">
                   {{- content_middle1 -}}
                 </div>
@@ -68,7 +68,7 @@
 
           {% if content_middle2 is not empty %}
             {%- block content_middle2 %}
-              <div class="col-xs-12 col-m-3">
+              <div class="col-xxs-12 col-m-3">
                 <div class="civictheme-footer__middle__content-middle2">
                   {{- content_middle2 -}}
                 </div>
@@ -78,7 +78,7 @@
 
           {% if content_middle3 is not empty %}
             {%- block content_middle3 %}
-              <div class="col-xs-12 col-m-3">
+              <div class="col-xxs-12 col-m-3">
                 <div class="civictheme-footer__middle__content-middle3">
                   {{- content_middle3 -}}
                 </div>
@@ -88,7 +88,7 @@
 
           {% if content_middle4 is not empty %}
             {%- block content_middle4 %}
-              <div class="col-xs-12 col-m-3">
+              <div class="col-xxs-12 col-m-3">
                 <div class="civictheme-footer__middle__content-middle4">
                   {{- content_middle4 -}}
                 </div>
@@ -106,7 +106,7 @@
 
           {% if content_bottom1 is not empty %}
             {%- block content_bottom1 %}
-              <div class="col-xs-12 col-m-7">
+              <div class="col-xxs-12 col-m-7">
                 <div class="civictheme-footer__bottom__content-bottom1">
                   {{- content_bottom1 -}}
                 </div>
@@ -116,7 +116,7 @@
 
           {% if content_bottom2 is not empty %}
             {%- block content_bottom2 %}
-              <div class="col-xs-12 col-m-5">
+              <div class="col-xxs-12 col-m-5">
                 <div class="civictheme-footer__bottom__content-bottom2">
                   {{- content_bottom2 -}}
                 </div>

--- a/docroot/themes/contrib/civictheme/civictheme_library/components/03-organisms/form-element/form-element.stories.js
+++ b/docroot/themes/contrib/civictheme/civictheme_library/components/03-organisms/form-element/form-element.stories.js
@@ -195,5 +195,5 @@ export const FormElement = () => {
     children,
   });
 
-  return `<div class="container"><div class="row"><div class="col-xs-12">${html}</div></div></div>`;
+  return `<div class="container"><div class="row"><div class="col-xxs-12">${html}</div></div></div>`;
 };

--- a/docroot/themes/contrib/civictheme/civictheme_library/components/03-organisms/listing/listing.twig
+++ b/docroot/themes/contrib/civictheme/civictheme_library/components/03-organisms/listing/listing.twig
@@ -74,7 +74,7 @@
           <header class="civictheme-listing__rows-header" tabindex="0">
             <div class="container">
               <div class="row">
-                <div class="col-xs-12">
+                <div class="col-xxs-12">
                   {{ rows_header }}
                 </div>
               </div>
@@ -96,7 +96,7 @@
           <div class="civictheme-listing__empty-results">
             <div class="container">
               <div class="row">
-                <div class="col-xs-12">
+                <div class="col-xxs-12">
                   {{ empty }}
                 </div>
               </div>

--- a/docroot/themes/contrib/civictheme/civictheme_library/components/03-organisms/promo/promo.twig
+++ b/docroot/themes/contrib/civictheme/civictheme_library/components/03-organisms/promo/promo.twig
@@ -26,7 +26,7 @@
   <div class="civictheme-promo {{ modifier_class }}" {% if attributes is not empty %}{{ attributes|raw }}{% endif%}>
     <div class="container">
       <div class="row">
-        <div class="col-xs-12">
+        <div class="col-xxs-12">
           <div class="civictheme-promo__inner">
             {% block content %}
               {% block column_one %}

--- a/docroot/themes/contrib/civictheme/civictheme_library/components/03-organisms/slider/slider.twig
+++ b/docroot/themes/contrib/civictheme/civictheme_library/components/03-organisms/slider/slider.twig
@@ -23,7 +23,7 @@
   <div class="civictheme-slider {{ modifier_class }}">
     <div class="container">
       <div class="row">
-        <div class="col-xs-12">
+        <div class="col-xxs-12">
           <div class="civictheme-slider__container" data-component-civictheme-slider>
             {% block top_controls %}
               {% if title is not empty or link is not empty %}

--- a/docroot/themes/contrib/civictheme/civictheme_library/components/03-organisms/webform/webform.twig
+++ b/docroot/themes/contrib/civictheme/civictheme_library/components/03-organisms/webform/webform.twig
@@ -21,7 +21,7 @@
   <div class="civictheme-webform {{ modifier_class }}">
     <div class="container">
       <div class="row">
-        <div class="col-m-12">
+        <div class="col-xxs-12">
           {{ reference_webform }}
         </div>
       </div>

--- a/docroot/themes/contrib/civictheme/civictheme_library/components/04-templates/page/page.twig
+++ b/docroot/themes/contrib/civictheme/civictheme_library/components/04-templates/page/page.twig
@@ -41,7 +41,7 @@
     {% block highlighted %}
       <div class="container">
         <div class="row">
-          <div class="col-m-12">
+          <div class="col-xxs-12">
             {{ highlighted }}
           </div>
         </div>


### PR DESCRIPTION
https://salsadigital.atlassian.net/browse/CIVIC-992

## Checklist before requesting a review

- [x] I have formatted the subject to include ticket number as `[CIVIC-123] Verb in past tense with dot at the end.`
- [x] I have added a link to the JIRA ticket
- [x] I have provided information in `Changed` section about WHY something was done if this was not a normal implementation
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run new and existing relevant tests locally with my changes, and they passed
- [x] I have provided screenshots, where applicable

## Changed
1. Replaced instances of col-xs classes with col-xxs classes so that tiny mobile screens are not forgotten and still receive the column padding / formatting.
2. Replaced col-m- classes where that was being used as the smallest class.
3. Set container max-width to use vw instead of % 

## Screenshots

### Before
<img width="612" alt="Screen Shot 2022-09-16 at 10 48 18 am" src="https://user-images.githubusercontent.com/520440/190534371-df0b5019-c876-42f3-8f2b-915cf350144d.png">
<img width="612" alt="Screen Shot 2022-09-16 at 10 48 41 am" src="https://user-images.githubusercontent.com/520440/190534377-e3e2428b-83ba-4822-a410-8ff84bd889e4.png">

### After (without changing % to vw)
<img width="612" alt="Screen Shot 2022-09-16 at 11 26 26 am" src="https://user-images.githubusercontent.com/520440/190536957-d0ec8059-1404-4647-bf12-adab72473e54.png">
<img width="612" alt="Screen Shot 2022-09-16 at 11 26 23 am" src="https://user-images.githubusercontent.com/520440/190536976-1c407839-7389-49ef-bc19-1733939d8271.png">


### After (WITH change from % to vw on container)
<img width="612" alt="Screen Shot 2022-09-16 at 11 28 54 am" src="https://user-images.githubusercontent.com/520440/190537014-915d863b-6f79-4c05-b164-cb0a70042e56.png">
<img width="612" alt="Screen Shot 2022-09-16 at 11 28 50 am" src="https://user-images.githubusercontent.com/520440/190537028-4e254241-c2e4-4255-8029-9a92207ec8c0.png">
