### PR TITLE
[CIVIC-766] Page title styleguide integration.

### DIFF
--- a/docroot/modules/custom/civictheme_styleguide/components/page_title.inc
+++ b/docroot/modules/custom/civictheme_styleguide/components/page_title.inc
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * @file
+ * Page title styleguide integration.
+ */
+
+use Drupal\cs_generated_content\CsGeneratedContentHelper;
+
+/**
+ * Implements _civictheme_styleguide_component_NAME().
+ */
+function _civictheme_styleguide_component_page_title() {
+  $items = [];
+
+  /** @var \Drupal\cs_generated_content\CsGeneratedContentHelper $helper */
+  $helper = CsGeneratedContentHelper::getInstance();
+
+  $variations = [
+    [
+      'title' => 'Page Title component',
+      'components' => [
+        [
+          'type' => 'page_title_block',
+          'title' => $helper::staticSentence(8),
+        ],
+      ],
+    ],
+  ];
+
+  foreach ($variations as $variation) {
+    $block_manager = \Drupal::service('plugin.manager.block');
+    $plugin_block = $block_manager->createInstance($variation['components'][0]['type'], []);
+    $plugin_block->setTitle($variation['components'][0]['title']);
+    $render = $plugin_block->build();
+    \Drupal::service('renderer')->addCacheableDependency($render, $plugin_block);
+
+    $items[] = [
+      'title' => $variation['title'],
+      'content' => $render,
+      'options' => [
+        'edge-to-edge' => FALSE,
+      ],
+    ];
+  }
+
+  return $items;
+}

--- a/docroot/themes/contrib/civictheme/civictheme_library/components/02-molecules/breadcrumb/breadcrumb.scss
+++ b/docroot/themes/contrib/civictheme/civictheme_library/components/02-molecules/breadcrumb/breadcrumb.scss
@@ -33,6 +33,14 @@
         }
       }
     }
+
+    &.mobile-only {
+      display: none;
+
+      @include civictheme-breakpoint-upto('m') {
+        display: flex;
+      }
+    }
   }
 
   .civictheme-link {


### PR DESCRIPTION
https://salsadigital.atlassian.net/browse/CIVIC-766

## Checklist before requesting a review

- [x] I have formatted the subject to include ticket number as `[CIVIC-123] Verb in past tense with dot at the end.`
- [x] I have added a link to the JIRA ticket
- [ ] I have provided information in `Changed` section about WHY something was done if this was not a normal implementation
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run new and existing relevant tests locally with my changes, and they passed
- [ ] I have provided screenshots, where applicable

## Changed
1. Page title styleguide integration
2. Breadcrumb CSS fix

## Screenshots

Before:
<img width="545" alt="Screenshot 2022-09-17 at 11 07 41 PM" src="https://user-images.githubusercontent.com/4437018/190869539-4cc10fbf-7164-40c0-8de3-b958441b992f.png">

Page title
<img width="1323" alt="Screenshot 2022-09-17 at 11 08 02 PM" src="https://user-images.githubusercontent.com/4437018/190869551-fbc1f7f2-ba8c-4420-96f4-768a45e579a4.png">
