### PR TITLE
Fixed alert test after CivicTheme renaming.

### DIFF
--- a/docroot/themes/contrib/civictheme/includes/alert.inc
+++ b/docroot/themes/contrib/civictheme/includes/alert.inc
@@ -9,6 +9,6 @@
  * Page pre-process to support showing of alerts.
  */
 function _civictheme_preprocess_page__civictheme_alert(&$variables) {
-  $variables['attributes']['data-component-name'] = 'civictheme-alerts';
+  $variables['attributes']['data-component-name'] = 'ct-alerts';
   $variables['attributes']['data-alert-endpoint'] = '/api/civictheme-alerts?_format=json';
 }

--- a/tests/behat/features/content_type.civictheme_alert.view.feature
+++ b/tests/behat/features/content_type.civictheme_alert.view.feature
@@ -1,4 +1,4 @@
-@civictheme @civictheme_alert @skipped
+@civictheme @civictheme_alert
 Feature: CivicTheme alert rendering
 
   Ensure that alerts are shown correctly.


### PR DESCRIPTION


## Checklist before requesting a review

- [x] I have formatted the subject to include ticket number as `[CIVIC-123] Verb in past tense with dot at the end.`
- [ ] I have added a link to the JIRA ticket
- [ ] I have provided information in `Changed` section about WHY something was done if this was not a normal implementation
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run new and existing relevant tests locally with my changes, and they passed
- [ ] I have provided screenshots, where applicable

## Changed
1. Fixed front-end naming for alerts data attribute.
