### PR TITLE
[CIVIC] Fix bug in theme settings for external new window.

### DIFF
--- a/docroot/themes/contrib/civictheme/theme-settings.php
+++ b/docroot/themes/contrib/civictheme/theme-settings.php
@@ -205,7 +205,7 @@ function _civictheme_form_system_theme_settings_components(&$form, FormStateInte
     '#type' => 'checkbox',
     '#title' => t('Open external links in a new window'),
     '#description' => t('Open all external links in a new browser window.'),
-    '#default_value' => theme_get_setting('components.link.new_window'),
+    '#default_value' => theme_get_setting('components.link.external_new_window'),
     '#states' => [
       'visible' => [
         ':input[name="components[link][new_window]"]' => ['checked' => FALSE],


### PR DESCRIPTION
https://salsadigital.atlassian.net/browse/CIVIC-<NUMBER>

## Checklist before requesting a review

- [ ] I have formatted the subject to include ticket number as `[CIVIC-123] Verb in past tense with dot at the end.`
- [ ] I have added a link to the JIRA ticket
- [ ] I have provided information in `Changed` section about WHY something was done if this was not a normal implementation
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run new and existing relevant tests locally with my changes, and they passed
- [ ] I have provided screenshots, where applicable

## Changed
1. Changed default value in theme settings for the link.external_new_window to use link.external_new_window instead of the incorrect link.new_window

## Screenshots
