### PR TITLE
[CIVIC-888] Fixed regression issue of Link component.

### DIFF
--- a/docroot/themes/contrib/civictheme/civictheme_library/components/01-atoms/link/link.scss
+++ b/docroot/themes/contrib/civictheme/civictheme_library/components/01-atoms/link/link.scss
@@ -17,7 +17,7 @@
 }
 
 @mixin ct-link-base() {
-  @include ct-link-decoration(false, true, false, false);
+  @include ct-link-decoration(false, false, true, false);
   @include ct-typography('label-regular');
 
   text-decoration-thickness: rem(1px);


### PR DESCRIPTION
https://salsadigital.atlassian.net/browse/CIVIC-888

## Checklist before requesting a review

- [x] I have formatted the subject to include ticket number as `[CIVIC-123] Verb in past tense with dot at the end.`
- [x] I have added a link to the JIRA ticket
- [x] I have provided information in `Changed` section about WHY something was done if this was not a normal implementation
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run new and existing relevant tests locally with my changes, and they passed
- [ ] I have provided screenshots, where applicable

## Changed
1. Fixed regression issue of Link component.
Hover > no underline should be displayed. Only colour should change.
Active > underline should be displayed with colour change.
## Screenshots
