### PR TITLE
[CIVIC] Fix list typo in Drupal template.

### DIFF
--- a/docroot/themes/contrib/civictheme/civictheme_library/components/03-organisms/list/list.twig
+++ b/docroot/themes/contrib/civictheme/civictheme_library/components/03-organisms/list/list.twig
@@ -85,7 +85,7 @@
       {% endif %}
     {% endblock %}
 
-    {% block List %}
+    {% block list %}
 
       {% block filters %}
         {% if filters -%}

--- a/docroot/themes/contrib/civictheme/templates/paragraphs/paragraph--civictheme-manual-list.html.twig
+++ b/docroot/themes/contrib/civictheme/templates/paragraphs/paragraph--civictheme-manual-list.html.twig
@@ -8,7 +8,7 @@
 
 {% block rows %}
   {% if rows -%}
-    <div class="ct--list__body">
+    <div class="ct-list__body">
       {% include '@base/item-grid/item-grid.twig' with {
         title: title,
         column_count: column_count,


### PR DESCRIPTION
https://salsadigital.atlassian.net/browse/CIVIC-<NUMBER>

## Checklist before requesting a review

- [ ] I have formatted the subject to include ticket number as `[CIVIC-123] Verb in past tense with dot at the end.`
- [ ] I have added a link to the JIRA ticket
- [ ] I have provided information in `Changed` section about WHY something was done if this was not a normal implementation
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run new and existing relevant tests locally with my changes, and they passed
- [ ] I have provided screenshots, where applicable

## Changed
1. Fixed a typo in manual list template in Drupal theme twig.

## Screenshots
