### PR TITLE
[CIVIC-1123] Fixed color stylesheet generation to correclty handle active theme prefix.

### DIFF
--- a/docroot/themes/contrib/civictheme/civictheme.libraries.yml
+++ b/docroot/themes/contrib/civictheme/civictheme.libraries.yml
@@ -15,7 +15,7 @@ global:
 css-variables:
   css:
     theme:
-      dist/civictheme.variables.css: {}
+      dist/civictheme.variables.css: {preprocess: false}
 
 # Color-related CivicTheme theme settings.
 theme-settings.colors:

--- a/docroot/themes/contrib/civictheme/civictheme.theme
+++ b/docroot/themes/contrib/civictheme/civictheme.theme
@@ -320,8 +320,11 @@ function civictheme_library_info_alter(&$libraries, $extension) {
 
       // Replace existing stylesheet with dynamically generated styles providing
       // extension name for context.
+      $default_theme = \Drupal::config('system.theme')->get('default');
       $libraries['css-variables']['css']['theme'] = [
-        $color_manager->stylesheet($extension) => [],
+        $color_manager->stylesheet($default_theme) => [
+          'preprocess' => FALSE,
+        ],
       ];
     }
   }

--- a/tests/behat/features/theme.settings.color.feature
+++ b/tests/behat/features/theme.settings.color.feature
@@ -1,4 +1,4 @@
-@civictheme @civictheme_theme_settings
+@civictheme @civictheme_theme_settings @civictheme_theme_color_settings
 Feature: Check that Color settings are available in theme settings
 
   @api
@@ -143,6 +143,7 @@ Feature: Check that Color settings are available in theme settings
     And I should see an "input[name='colors[palette][dark][status][success]']" element
 
     And I press "Save configuration"
+    Then save screenshot
     Then I should see the text "The configuration options have been saved."
 
   # Drush driver does not support passing '--include', this test is skipped until patch provided.
@@ -163,3 +164,20 @@ Feature: Check that Color settings are available in theme settings
     Given I run drush 'civictheme:set-brand-colors' '--include=docroot/themes/contrib/civictheme/src/Drush "#00698f" "#e6e9eb" "#121313" "#61daff" "#003a4f" "#00698f"'
     When I go to the homepage
     Then save screenshot
+
+  @api
+  Scenario: To check that generating a color file has different suffix per theme.
+    Given I am logged in as a user with the "Site Administrator" role
+    And I visit "/admin/appearance"
+    And I click on "a[title='Set CivicTheme as default theme']" element
+    Then I go to the homepage
+    And I should see the 'link[href^="/sites/default/files/css-variables.civictheme.css"]' element with the "rel" attribute set to 'stylesheet'
+    And I visit "/admin/appearance"
+    And I click on "a[title='Set CivicTheme Demo as default theme']" element
+    Then I go to the homepage
+    And I should see the 'link[href^="/sites/default/files/css-variables.civictheme_demo.css"]' element with the "rel" attribute set to 'stylesheet'
+
+  @api
+  Scenario: The css-variables library CSS file is always included separately on the page.
+    Given I go to the homepage
+    And I should see the 'link[href^="/sites/default/files/css-variables.civictheme_demo.css"]' element with the "rel" attribute set to 'stylesheet'


### PR DESCRIPTION
Updated civictheme_library_info_alter to use the prefix of current theme.

https://salsadigital.atlassian.net/browse/CIVIC-1123

## Checklist before requesting a review

- [x] I have formatted the subject to include ticket number as `[CIVIC-123] Verb in past tense with dot at the end.`
- [x] I have added a link to the JIRA ticket
- [ ] I have provided information in `Changed` section about WHY something was done if this was not a normal implementation
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run new and existing relevant tests locally with my changes, and they passed
- [ ] I have provided screenshots, where applicable

## Changed
1.

## Screenshots
