### PR TITLE
[CIVIC-1154] Added 'Use Color Selector' setting and additional information about colors.

### DIFF
--- a/docroot/themes/contrib/civictheme/README.md
+++ b/docroot/themes/contrib/civictheme/README.md
@@ -34,26 +34,50 @@ Run the following command from within `civictheme` theme directory:
 This will generate a sub-theme in 'path/to/theme_machine_name' theme directory
 with everything ready to be installed and compiled.
 
-## Setting Brand colors via Drush command
-
-Brand colors can be set using a Drush command
-
-    ./vendor/bin/drush --include=path/to/civictheme/src/Drush civictheme:set-brand-colors light_brand1 light_brand2 light_brand3 dark_brand1 dark_brand2 dark_brand3
-
-Example
-
-    ./vendor/bin/drush --include=docroot/themes/contrib/civictheme/src/Drush civictheme:set-brand-colors "#00698f" "#e6e9eb" "#121313" "#61daff" "#003a4f" "#00698f"
-
-Dynamic assets can be purged:
-
-    ./vendor/bin/drush --include=docroot/themes/contrib/civictheme/src/Drush civictheme:clear-cache
-
-
 ## Compiling sub-theme assets
 
 Run the following command from within your sub-theme directory:
 
     npm run build
+
+## Managing colors
+
+Website colors can be specified via:
+- CSS code
+- Color Selector
+- CSS code with Color Selector overrides
+
+See `admin/appearance/settings/civictheme` for more details about colors and to
+set colors via Color Selector.
+
+### Disabling Color Selector
+
+If colors managed in CSS code only, make sure that Color Selector is disabled
+
+    ./vendor/bin/drush config-set civictheme.settings colors.use_color_selector 0
+
+### Setting colors via Drush command
+
+Palette colors can be set in bulk via Drush command by providing Brand colors.
+
+    # Enable Color Selector.
+    ./vendor/bin/drush config-set civictheme.settings colors.use_color_selector 1
+
+    # Enable Brand Colors.
+    ./vendor/bin/drush config-set civictheme.settings colors.use_brand_colors 1
+
+    # Set Brand Colors.
+    ./vendor/bin/drush --include=path/to/civictheme/src/Drush civictheme:set-brand-colors light_brand1 light_brand2 light_brand3 dark_brand1 dark_brand2 dark_brand3
+
+    # Purge dynamic assets cache. Will be rebuilt during next pageload.
+    ./vendor/bin/drush --include=docroot/themes/contrib/civictheme/src/Drush civictheme:clear-cache
+
+Example
+
+    ./vendor/bin/drush -y config-set civictheme.settings colors.use_color_selector 1
+    ./vendor/bin/drush -y config-set civictheme.settings colors.use_brand_colors 1
+    ./vendor/bin/drush --include=docroot/themes/contrib/civictheme/src/Drush civictheme:set-brand-colors "#00698f" "#e6e9eb" "#121313" "#61daff" "#003a4f" "#00698f"
+    ./vendor/bin/drush --include=docroot/themes/contrib/civictheme/src/Drush civictheme:clear-cache
 
 ## Updating CivicTheme
 

--- a/docroot/themes/contrib/civictheme/civictheme.theme
+++ b/docroot/themes/contrib/civictheme/civictheme.theme
@@ -6,6 +6,7 @@
  */
 
 use Drupal\civictheme\CivicthemeColorManager;
+use Drupal\civictheme\CivicthemeConfigManager;
 use Drupal\civictheme\CivicthemeConstants;
 use Drupal\Core\Render\Element;
 
@@ -296,36 +297,63 @@ function civictheme_field_is_wysiwyg(string $field_name) {
  * Implements hook_library_info_alter().
  */
 function civictheme_library_info_alter(&$libraries, $extension) {
-  // Inject a stylesheet with dynamically generated styles.
+  // Override current CSS-variables file with a dynamically generated styles.
   //
-  // Filter for the current theme.
+  // This hook runs in a context of the extension that provides a library.
+  // For themes, this means that a parent theme may provide a library used by
+  // a sub-theme.
+  //
+  // We are using this hook to implement certain library adjustments on behalf
+  // of sub-themes so that they do not have to implement this logic.
+  //
+  // Filter for the current theme or a parent theme (in case if current theme is
+  // a sub-theme of a theme that declares libraries).
   $themes = \Drupal::service('theme_handler')->listInfo();
   if (array_key_exists($extension, $themes)) {
-    // A theme should opt-in to have the dynamic stylesheet injected by
-    // defining 'css-variables' library.
-    // @todo Consider a different opt-in mechanism based on usage in consumer
-    // themes.
-    if (!empty($libraries['css-variables'])) {
-      /** @var \Drupal\civictheme\CivicthemeColorManager $color_manager */
-      $color_manager = \Drupal::classResolver(CivicthemeColorManager::class);
+    if (empty($libraries['css-variables'])) {
+      return;
+    }
 
-      // Read current CSS variables stylesheet to use the variables as initial
-      // values within color manager (only if there are no stored values in
-      // the config).
-      // If not provided - a fallback default value
-      // CivicthemeColorManager::COLOR_DEFAULT will be used.
+    $active_theme = \Drupal::theme()->getActiveTheme();
+    /** @var \Drupal\civictheme\CivicthemeConfigManager $theme_config_manager */
+    $theme_config_manager = \Drupal::classResolver(CivicthemeConfigManager::class);
+    /** @var \Drupal\civictheme\CivicthemeColorManager $color_manager */
+    $color_manager = \Drupal::classResolver(CivicthemeColorManager::class);
+
+    $use_color_selector = $theme_config_manager->load('colors.use_color_selector', FALSE);
+    $use_color_selector = TRUE;
+
+    // Only apply if Color Selector was explicitly enabled in configuration.
+    if ($use_color_selector) {
+      // Set CSS variables stylesheet path to use CSS variables as initial
+      // values within a Color Manager instance.
       if (!empty($libraries['css-variables']['css']['theme'])) {
-        $color_manager->setCssColorsFilePath($themes[$extension]->getPath() . DIRECTORY_SEPARATOR . key($libraries['css-variables']['css']['theme']));
+        $css_filepath = key($libraries['css-variables']['css']['theme']);
+        // Sub-themes may override paths to CSS variables file via library
+        // overrides.
+        // Resolve sub-theme overrides as core overrides resolution
+        // is executed after this hook.
+        $overrides = $active_theme->getLibrariesOverride();
+        if (!empty($overrides[$active_theme->getPath()]['civictheme/css-variables']['css']['theme'])) {
+          $css_filepath = reset($overrides[$active_theme->getPath()]['civictheme/css-variables']['css']['theme']);
+        }
+        $color_manager->setCssColorsFilePath($active_theme->getPath() . DIRECTORY_SEPARATOR . $css_filepath);
       }
 
-      // Replace existing stylesheet with dynamically generated styles providing
-      // extension name for context.
-      $default_theme = \Drupal::config('system.theme')->get('default');
-      $libraries['css-variables']['css']['theme'] = [
-        $color_manager->stylesheet($default_theme) => [
-          'preprocess' => FALSE,
-        ],
-      ];
+      // Generate stylesheet suffixed with the current theme name.
+      $stylesheet_path = $color_manager->stylesheet($active_theme->getName());
+
+      // Stylesheet generation may fail if, for example, no CSS styles or
+      // config provided - only proceed if we have a valid stylesheet path.
+      if ($stylesheet_path) {
+        // Replace existing stylesheet with dynamically generated styles and
+        // exclude from pre-processing.
+        $libraries['css-variables']['css']['theme'] = [
+          $stylesheet_path => [
+            'preprocess' => FALSE,
+          ],
+        ];
+      }
     }
   }
 }

--- a/docroot/themes/contrib/civictheme/civictheme_starter_kit/README.md
+++ b/docroot/themes/contrib/civictheme/civictheme_starter_kit/README.md
@@ -19,6 +19,45 @@ Learn more about developing with CivicTheme in [CivicTheme documentation](../../
 
     npm run storybook
 
+## Managing colors
+
+Website colors can be specified via:
+- CSS code
+- Color Selector
+- CSS code with Color Selector overrides
+
+See `admin/appearance/settings/civictheme_starter_kit` for more details about colors and to
+set colors via Color Selector.
+
+### Disabling Color Selector
+
+If colors managed in CSS code only, make sure that Color Selector is disabled
+
+    ./vendor/bin/drush config-set civictheme_starter_kit.settings colors.use_color_selector 0
+
+### Setting colors via Drush command
+
+Palette colors can be set in bulk via Drush command by providing Brand colors.
+
+    # Enable Color Selector.
+    ./vendor/bin/drush config-set civictheme_starter_kit.settings colors.use_color_selector 1
+
+    # Enable Brand Colors.
+    ./vendor/bin/drush config-set civictheme_starter_kit.settings colors.use_brand_colors 1
+
+    # Set Brand Colors.
+    ./vendor/bin/drush --include=path/to/civictheme/src/Drush civictheme:set-brand-colors light_brand1 light_brand2 light_brand3 dark_brand1 dark_brand2 dark_brand3
+
+    # Purge dynamic assets cache. Will be rebuilt during next pageload.
+    ./vendor/bin/drush --include=docroot/themes/contrib/civictheme/src/Drush civictheme:clear-cache
+
+Example
+
+    ./vendor/bin/drush -y config-set civictheme_starter_kit.settings colors.use_color_selector 1
+    ./vendor/bin/drush -y config-set civictheme_starter_kit.settings colors.use_brand_colors 1
+    ./vendor/bin/drush --include=docroot/themes/contrib/civictheme/src/Drush civictheme:set-brand-colors "#00698f" "#e6e9eb" "#121313" "#61daff" "#003a4f" "#00698f"
+    ./vendor/bin/drush --include=docroot/themes/contrib/civictheme/src/Drush civictheme:clear-cache
+
 ## Updating site configuration after CivicTheme update
 
 1. Check that your custom theme has 2 files:

--- a/docroot/themes/contrib/civictheme/civictheme_starter_kit/civictheme_starter_kit.info.yml
+++ b/docroot/themes/contrib/civictheme/civictheme_starter_kit/civictheme_starter_kit.info.yml
@@ -39,6 +39,11 @@ libraries-override:
     js:
       dist/civictheme.js: dist/scripts.js
 
+  civictheme/css-variables:
+    css:
+      theme:
+        dist/civictheme.variables.css: dist/styles.variables.css
+
 ckeditor_stylesheets:
   - dist/styles.editor.css
 

--- a/docroot/themes/contrib/civictheme/config/install/civictheme.settings.yml
+++ b/docroot/themes/contrib/civictheme/config/install/civictheme.settings.yml
@@ -34,6 +34,7 @@ components:
     external_new_window: true
     external_override_domains: {  }
 colors:
+  use_color_selector: true
   use_brand_colors: true
   brand:
     light:

--- a/docroot/themes/contrib/civictheme/config/schema/civictheme.schema.yml
+++ b/docroot/themes/contrib/civictheme/config/schema/civictheme.schema.yml
@@ -117,6 +117,9 @@ civictheme.settings:
       type: mapping
       label: 'Colors'
       mapping:
+        use_color_selector:
+          label: 'Use Color Selector'
+          type: boolean
         use_brand_colors:
           label: 'Use Brand colors'
           type: boolean

--- a/docroot/themes/contrib/civictheme/src/CivicthemeColorManager.php
+++ b/docroot/themes/contrib/civictheme/src/CivicthemeColorManager.php
@@ -387,6 +387,11 @@ class CivicthemeColorManager implements ContainerInjectionInterface {
   /**
    * Initialise color matrix.
    *
+   * Values are set in the order (top one wins, if set):
+   * - From configuration
+   * - From CSS file
+   * - Default value (self::COLOR_DEFAULT)
+   *
    * @return $this
    *   Instance of the current class.
    */
@@ -468,7 +473,10 @@ class CivicthemeColorManager implements ContainerInjectionInterface {
    */
   protected function loadMatrixFromConfig() {
     $colors = $this->configManager->load('colors') ?? self::defaultMatrix();
-    unset($colors['use_brand_colors']);
+    $colors = array_intersect_key($colors, array_flip([
+      self::COLOR_TYPE_BRAND,
+      self::COLOR_TYPE_PALETTE,
+    ]));
     self::validateMatrixStructure($colors);
 
     return $colors;

--- a/docroot/themes/contrib/civictheme/src/CivicthemeConfigManager.php
+++ b/docroot/themes/contrib/civictheme/src/CivicthemeConfigManager.php
@@ -56,14 +56,14 @@ class CivicthemeConfigManager implements ContainerInjectionInterface {
    *
    * @param string $key
    *   The configuration key.
+   * @param mixed $default
+   *   Default value to return if the $key is not set. Defaults to NULL.
    *
-   * @return mixed
+   * @return mixed|null
    *   The value of the requested setting, NULL if the setting does not exist.
    */
-  public function load($key) {
-    $theme_name = $this->themeManager->getActiveTheme()->getName();
-
-    return theme_get_setting($key, $theme_name);
+  public function load($key, $default = NULL) {
+    return theme_get_setting($key, $this->themeManager->getActiveTheme()->getName()) ?? $default;
   }
 
   /**

--- a/docroot/themes/contrib/civictheme/src/Color/CivicthemeColor.php
+++ b/docroot/themes/contrib/civictheme/src/Color/CivicthemeColor.php
@@ -83,6 +83,7 @@ class CivicthemeColor {
    * @SuppressWarnings(MissingImport)
    */
   public function setValue($value) {
+    $value = CivicthemeColorUtility::keywordToHex($value);
     $value = CivicthemeColorUtility::normalizeHex($value);
     $this->value = $this->applyFilters($value);
 

--- a/docroot/themes/contrib/civictheme/src/Color/CivicthemeColorUtility.php
+++ b/docroot/themes/contrib/civictheme/src/Color/CivicthemeColorUtility.php
@@ -10,6 +10,43 @@ namespace Drupal\civictheme\Color;
 class CivicthemeColorUtility {
 
   /**
+   * Defines CSS color keywords.
+   *
+   * @see https://www.w3.org/TR/css-color-3/
+   */
+  const KEYWORDS = [
+    'black' => '#000000',
+    'silver' => '#C0C0C0',
+    'gray' => '#808080',
+    'white' => '#FFFFFF',
+    'maroon' => '#800000',
+    'red' => '#FF0000',
+    'purple' => '#800080',
+    'fuchsia' => '#FF00FF',
+    'green' => '#008000',
+    'lime' => '#00FF00',
+    'olive' => '#808000',
+    'yellow' => '#FFFF00',
+    'navy' => '#000080',
+    'blue' => '#0000FF',
+    'teal' => '#008080',
+    'aqua' => '#00FFFF',
+  ];
+
+  /**
+   * Convert color keyword to hex value.
+   *
+   * @param string $value
+   *   The value (keyword) to convert.
+   *
+   * @return string
+   *   Converted value if such keyword exists or original value otherwise.
+   */
+  public static function keywordToHex($value) {
+    return self::KEYWORDS[$value] ?? $value;
+  }
+
+  /**
    * Mix color with another color within a specified percentage range.
    *
    * @param string $color

--- a/docroot/themes/contrib/civictheme/src/Settings/CivicthemeSettingsFormSectionColors.php
+++ b/docroot/themes/contrib/civictheme/src/Settings/CivicthemeSettingsFormSectionColors.php
@@ -63,13 +63,31 @@ class CivicthemeSettingsFormSectionColors extends CivicthemeSettingsFormSectionB
       '#weight' => 40,
       '#open' => TRUE,
       '#tree' => TRUE,
-      '#description' => $this->t('Colors in <em>Palette colors</em> allow to define the colors for components in <em>Light</em> and <em>Dark</em> themes.<br/><br/><em>Palette colors</em> can be set manually or using shorthand <em>Brand colors</em> with pre-defined color formulas.'),
+      '#description' => $this->t('<p>Website colors can be specified via:</p><ul><li><strong>CSS code</strong><br>Uncheck <code>Use Color Selector</code> below.</li><li><strong>Color Selector</strong><br>Check <code>Use Color Selector</code> below.</li><li><strong>CSS code with Color Selector overrides</strong><br>Check <code>Use Color Selector</code> below. Note that this will require to keep CSS synchronised with Color Selector values. This approach is not recommended and should be used as a last resort.</li></ul>'),
+    ];
+
+    $form['colors']['information'] = [
+      '#type' => 'details',
+      '#title' => $this->t('More information'),
+      '#open' => FALSE,
+      '#description' => $this->t('<h3>Color values inheritance</h3><p><code>Palette CSS variable (CSS ot Color Selector) -&gt; Component CSS variable -&gt; Component CSS property</code></p><p>For example, consider the Title of the Promo component.</p><p>The CSS property <code>color</code> has a value of the <code>--ct-promo-light-title-color</code>, which is set to Palette Color CSS variable <code>--ct-color-light-heading</code> by default, which in own turn is set to a value of a colour specified in CSS.</p><p>When Palette Color CSS variable <code>--ct-color-light-heading</code> updated - all values that are based of this value are updated as well. This means that the <code>color</code> CSS property of the Title of the Promo component will be updated to a new value of the <code>--ct-color-light-heading</code> CSS variable.</p><p>If the Title of the Promo component need to have a completely custom color, the variable <code>--ct-promo-light-title-color</code> can be set to a required value in CSS, which will "unlink" it from the value of <code>--ct-color-light-heading</code>.</p><p><h3>Color Selector</h3></p><p>Color Selector produces <em>Palette colors</em> values as CSS variables in dynamically generated stylesheet (<code>public://css-variables.your_theme_name.css</code>), which re-writes CSS variables stylesheet included as a <code>css-variables</code> library. This means that the generated stylesheet is included in DOM after CSS stylesheet.</p><p>Colors in <em>Palette colors</em> allow to define the colors for components in <em>Light</em> and <em>Dark</em> themes.</p><p><em>Palette colors</em> can be set manually or using shorthand <em>Brand colors</em> with pre-defined color formulas (check <em>Show dependants</em> to see which <em>Brand color</em> drives which <em>Palette color</em>).</p>'),
+    ];
+
+    $form['colors']['use_color_selector'] = [
+      '#title' => $this->t('Use Color Selector'),
+      '#type' => 'checkbox',
+      '#default_value' => theme_get_setting('colors.use_color_selector') ?? FALSE,
     ];
 
     $form['colors']['use_brand_colors'] = [
       '#title' => $this->t('Use Brand colors'),
       '#type' => 'checkbox',
       '#default_value' => theme_get_setting('colors.use_brand_colors') ?? TRUE,
+      '#states' => [
+        'visible' => [
+          'input[name="colors[use_color_selector]"' => ['checked' => TRUE],
+        ],
+      ],
     ];
 
     $form['colors']['brand'] = [
@@ -84,6 +102,7 @@ class CivicthemeSettingsFormSectionColors extends CivicthemeSettingsFormSectionB
       ],
       '#states' => [
         'visible' => [
+          'input[name="colors[use_color_selector]"' => ['checked' => TRUE],
           'input[name="colors[use_brand_colors]"' => ['checked' => TRUE],
         ],
       ],
@@ -97,6 +116,11 @@ class CivicthemeSettingsFormSectionColors extends CivicthemeSettingsFormSectionB
         'class' => [
           'civictheme-layout-2col',
           'civictheme-reset-fieldset',
+        ],
+      ],
+      '#states' => [
+        'visible' => [
+          'input[name="colors[use_color_selector]"' => ['checked' => TRUE],
         ],
       ],
     ];


### PR DESCRIPTION
https://salsadigital.atlassian.net/browse/CIVIC-1154

## Checklist before requesting a review

- [x] I have formatted the subject to include ticket number as `[CIVIC-123] Verb in past tense with dot at the end.`
- [x] I have added a link to the JIRA ticket
- [x] I have provided information in `Changed` section about WHY something was done if this was not a normal implementation
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run new and existing relevant tests locally with my changes, and they passed
- [x] I have provided screenshots, where applicable

## Changed
1. Added opt-in to use Color Selector in Theme UI.
2. Fixed color values being mixed: CSS was coming from CivicTheme base theme and overrides were coming from Theme config.
3. Added information section.

## Screenshots
<img width="1113" alt="Cursor_and_CivicTheme___CivicTheme_Source" src="https://user-images.githubusercontent.com/378794/200526024-b63921f5-7916-4dc7-9d40-f0aacdf3ff4d.png">


