### PR TITLE
[CIVIC-1189] Updated Navigation Card summary field to non-mandatory.

### DIFF
--- a/docroot/themes/contrib/civictheme/config/install/field.field.paragraph.civictheme_navigation_card.field_c_p_summary.yml
+++ b/docroot/themes/contrib/civictheme/config/install/field.field.paragraph.civictheme_navigation_card.field_c_p_summary.yml
@@ -10,7 +10,7 @@ entity_type: paragraph
 bundle: civictheme_navigation_card
 label: Summary
 description: 'The summary field may contain up to 100 characters. Any characters past the 100 character limit will not show for users.'
-required: true
+required: false
 translatable: true
 default_value: {  }
 default_value_callback: ''


### PR DESCRIPTION
https://salsadigital.atlassian.net/browse/CIVIC-1189

## Checklist before requesting a review

- [x] I have formatted the subject to include ticket number as `[CIVIC-123] Verb in past tense with dot at the end.`
- [x] I have added a link to the JIRA ticket
- [x] I have provided information in `Changed` section about WHY something was done if this was not a normal implementation
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run new and existing relevant tests locally with my changes, and they passed
- [x] I have provided screenshots, where applicable

## Changed
1. Updated Navigation Card summary field to non-mandatory.

## Screenshots
![Screenshot 2022-11-11 at 9 56 53 AM](https://user-images.githubusercontent.com/83997348/201263170-de10631b-0db4-4d3c-a30c-8f797eaf3549.png)
