### PR TITLE
[CIVIC-1213] Removed summary field displayed from event content page.

### DIFF
--- a/docroot/themes/contrib/civictheme/config/install/core.entity_view_display.node.civictheme_event.default.yml
+++ b/docroot/themes/contrib/civictheme/config/install/core.entity_view_display.node.civictheme_event.default.yml
@@ -69,21 +69,6 @@ third_party_settings:
                 third_party_settings: {  }
             weight: 2
             additional: {  }
-          5c9134f5-9e32-4607-a2f5-ca388ebd50e8:
-            uuid: 5c9134f5-9e32-4607-a2f5-ca388ebd50e8
-            region: content
-            configuration:
-              id: 'field_block:node:civictheme_event:field_c_n_summary'
-              label_display: '0'
-              context_mapping:
-                entity: layout_builder.entity
-              formatter:
-                type: basic_string
-                label: above
-                settings: {  }
-                third_party_settings: {  }
-            weight: 3
-            additional: {  }
           79ee9199-c580-42db-9ff6-f76d86f6b88b:
             uuid: 79ee9199-c580-42db-9ff6-f76d86f6b88b
             region: content
@@ -154,6 +139,7 @@ hidden:
   field_c_n_date: true
   field_c_n_location: true
   field_c_n_show_toc: true
+  field_c_n_summary: true
   field_c_n_thumbnail: true
   field_c_n_topics: true
   links: true


### PR DESCRIPTION
https://salsadigital.atlassian.net/browse/CIVIC-1213

## Checklist before requesting a review

- [x] I have formatted the subject to include ticket number as `[CIVIC-123] Verb in past tense with dot at the end.`
- [x] I have added a link to the JIRA ticket
- [x] I have provided information in `Changed` section about WHY something was done if this was not a normal implementation
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run new and existing relevant tests locally with my changes, and they passed
- [x] I have provided screenshots, where applicable

## Changed
1. Removed summary field displayed from event content page.

## Screenshots
![Screenshot 2022-11-17 at 9 45 29 AM](https://user-images.githubusercontent.com/83997348/202353827-1ff91a38-d668-4bad-94f4-a9935052be20.png)
