### PR TITLE
[CIVIC-1216] Implemented summary field config for events card component.

### DIFF
--- a/docroot/modules/custom/civictheme_content/modules/civictheme_content_corporate/config/optional/civictheme.settings.yml
+++ b/docroot/modules/custom/civictheme_content/modules/civictheme_content_corporate/config/optional/civictheme.settings.yml
@@ -54,6 +54,8 @@ components:
     external_override_domains: {  }
   skip_link:
     theme: light
+  event_card:
+    summary_length: 160
   navigation_card:
     summary_length: 160
   promo_card:

--- a/docroot/modules/custom/civictheme_content/modules/civictheme_content_default/config/optional/civictheme.settings.yml
+++ b/docroot/modules/custom/civictheme_content/modules/civictheme_content_default/config/optional/civictheme.settings.yml
@@ -54,6 +54,8 @@ components:
     external_override_domains: {  }
   skip_link:
     theme: light
+  event_card:
+    summary_length: 160
   navigation_card:
     summary_length: 160
   promo_card:

--- a/docroot/modules/custom/civictheme_content/modules/civictheme_content_government/config/optional/civictheme.settings.yml
+++ b/docroot/modules/custom/civictheme_content/modules/civictheme_content_government/config/optional/civictheme.settings.yml
@@ -54,6 +54,8 @@ components:
     external_override_domains: {}
   skip_link:
     theme: light
+  event_card:
+    summary_length: 160
   navigation_card:
     summary_length: 160
   promo_card:

--- a/docroot/modules/custom/civictheme_content/modules/civictheme_content_highereducation/config/optional/civictheme.settings.yml
+++ b/docroot/modules/custom/civictheme_content/modules/civictheme_content_highereducation/config/optional/civictheme.settings.yml
@@ -54,6 +54,8 @@ components:
     external_override_domains: {  }
   skip_link:
     theme: light
+  event_card:
+    summary_length: 160
   navigation_card:
     summary_length: 160
   promo_card:

--- a/docroot/themes/contrib/civictheme/config/install/civictheme.settings.yml
+++ b/docroot/themes/contrib/civictheme/config/install/civictheme.settings.yml
@@ -54,6 +54,8 @@ components:
     external_override_domains: {  }
   skip_link:
     theme: light
+  event_card:
+    summary_length: 160
   navigation_card:
     summary_length: 160
   promo_card:

--- a/docroot/themes/contrib/civictheme/config/schema/civictheme.schema.yml
+++ b/docroot/themes/contrib/civictheme/config/schema/civictheme.schema.yml
@@ -177,6 +177,13 @@ civictheme.settings:
             theme:
               label: Theme
               type: string
+        event_card:
+          type: mapping
+          label: 'Event card settings'
+          mapping:
+            summary_length:
+              label: 'Summary length'
+              type: integer
         navigation_card:
           type: mapping
           label: 'Navigation card settings'

--- a/docroot/themes/contrib/civictheme/src/Settings/CivicthemeSettingsFormSectionComponents.php
+++ b/docroot/themes/contrib/civictheme/src/Settings/CivicthemeSettingsFormSectionComponents.php
@@ -320,6 +320,22 @@ class CivicthemeSettingsFormSectionComponents extends CivicthemeSettingsFormSect
       '#default_value' => $this->themeConfigManager->load('components.skip_link.theme', CivicthemeConstants::HEADER_THEME_DEFAULT),
     ];
 
+    $form['components']['event_card'] = [
+      '#type' => 'details',
+      '#title' => $this->t('Event card'),
+      '#group' => 'components',
+      '#tree' => TRUE,
+    ];
+
+    $form['components']['event_card']['summary_length'] = [
+      '#title' => $this->t('Summary length'),
+      '#description' => $this->t('Set the length of the Summary field: the content will be trimmed to this length and ellipsis will be added. Set to 0 for no limit.'),
+      '#type' => 'number',
+      '#required' => TRUE,
+      '#min' => 0,
+      '#default_value' => $this->themeConfigManager->loadForComponent('event_card', 'summary_length', CivicthemeConstants::CARD_SUMMARY_DEFAULT_LENGTH),
+    ];
+
     $form['components']['navigation_card'] = [
       '#type' => 'details',
       '#title' => $this->t('Navigation card'),


### PR DESCRIPTION
https://salsadigital.atlassian.net/browse/CIVIC-1216

## Checklist before requesting a review

- [x] I have formatted the subject to include ticket number as `[CIVIC-123] Verb in past tense with dot at the end.`
- [x] I have added a link to the JIRA ticket
- [x] I have provided information in `Changed` section about WHY something was done if this was not a normal implementation
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run new and existing relevant tests locally with my changes, and they passed
- [x] I have provided screenshots, where applicable

## Changed
1. Added summary length logic in settings
2. Updated default settings to include events card length in default profiles.

## Screenshots
![Screenshot 2022-11-18 at 8 29 11 AM](https://user-images.githubusercontent.com/83997348/202606823-e3813470-764e-4571-b2f3-8516df58a2db.png)
![Screenshot 2022-11-18 at 8 29 28 AM](https://user-images.githubusercontent.com/83997348/202606863-9727f5eb-5091-4fe4-9577-ee5bb8169298.png)
![Screenshot 2022-11-18 at 8 29 44 AM](https://user-images.githubusercontent.com/83997348/202606895-53627adc-d92e-403d-a460-f8649cd66984.png)

