### PR TITLE
[CIVIC] Fixed mobile menu theme inheritance.

### DIFF
--- a/docroot/themes/contrib/civictheme/civictheme_library/components/03-organisms/mobile-navigation/mobile-navigation-menu.twig
+++ b/docroot/themes/contrib/civictheme/civictheme_library/components/03-organisms/mobile-navigation/mobile-navigation-menu.twig
@@ -122,7 +122,7 @@ Overrides for generation of child links.
         } only %}
       </div>
 
-      {{ menus.menu_links(items, menu_level, modifier_class) }}
+      {{ menus.menu_links(items, menu_level, modifier_class, theme) }}
     </div>
   </div>
 

--- a/docroot/themes/contrib/civictheme/civictheme_library/components/03-organisms/mobile-navigation/mobile-navigation-menu.twig
+++ b/docroot/themes/contrib/civictheme/civictheme_library/components/03-organisms/mobile-navigation/mobile-navigation-menu.twig
@@ -77,7 +77,7 @@ Copied as-is from '@base/menu/menu.twig'.
         {% endif %}
 
         {% if item.below %}
-          {{ menus.menu_links_below(item.below, menu_level + 1, classes, item) }}
+          {{ menus.menu_links_below(item.below, menu_level + 1, classes, theme, item) }}
         {% endif %}
 
       </li>
@@ -95,7 +95,7 @@ Copied as-is from '@base/menu/menu.twig'.
 {#
 Overrides for generation of child links.
 #}
-{% macro menu_links_below(items, menu_level, modifier_class, parent_item) %}
+{% macro menu_links_below(items, menu_level, modifier_class, theme, parent_item) %}
 
   {% include '@atoms/button/button.twig' with {
     theme: theme,
@@ -128,4 +128,4 @@ Overrides for generation of child links.
 
 {% endmacro %}
 
-{{ menus.menu_links(items, 0, modifier_class) }}
+{{ menus.menu_links(items, 0, modifier_class, theme) }}


### PR DESCRIPTION
https://salsadigital.atlassian.net/browse/CIVIC-<NUMBER>

## Checklist before requesting a review

- [x] I have formatted the subject to include ticket number as `[CIVIC-123] Verb in past tense with dot at the end.`
- [ ] I have added a link to the JIRA ticket
- [x] I have provided information in `Changed` section about WHY something was done if this was not a normal implementation
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run new and existing relevant tests locally with my changes, and they passed
- [x] I have provided screenshots, where applicable

## Changed
1. Inherit the theme for the close button and menu links.

## Screenshots
Before and after, demonstrating that close button inherits the theme.

<img width="612" alt="Screen Shot 2022-11-24 at 12 42 24 pm" src="https://user-images.githubusercontent.com/520440/203686324-5b65224a-bbc3-42e4-90b5-428155eb1cf8.png">
 
<img width="612" alt="Screen Shot 2022-11-24 at 1 15 10 pm" src="https://user-images.githubusercontent.com/520440/203686303-8f40b732-80d4-49ee-a119-a3a9a7fb9b1e.png">
