### PR TITLE
[CIVIC-1242] Updated Navigation titles to correct heading H2.

### DIFF
--- a/docroot/themes/contrib/civictheme/civictheme_library/components/03-organisms/navigation/navigation.scss
+++ b/docroot/themes/contrib/civictheme/civictheme_library/components/03-organisms/navigation/navigation.scss
@@ -10,6 +10,8 @@
   $root: &;
 
   #{$root}__title {
+    @include ct-typography('heading-5');
+
     margin-bottom: ct-spacing(2);
     margin-top: ct-spacing(2);
   }

--- a/docroot/themes/contrib/civictheme/civictheme_library/components/03-organisms/navigation/navigation.twig
+++ b/docroot/themes/contrib/civictheme/civictheme_library/components/03-organisms/navigation/navigation.twig
@@ -53,7 +53,7 @@
       {% block title %}
         {% include '@atoms/heading/heading.twig' with {
           theme: theme,
-          level: 5,
+          level: 2,
           content: title,
           modifier_class: 'ct-navigation__title',
         } only %}


### PR DESCRIPTION
https://salsadigital.atlassian.net/browse/CIVIC-1242

## Checklist before requesting a review

- [x] I have formatted the subject to include ticket number as `[CIVIC-123] Verb in past tense with dot at the end.`
- [x] I have added a link to the JIRA ticket
- [x] I have provided information in `Changed` section about WHY something was done if this was not a normal implementation
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run new and existing relevant tests locally with my changes, and they passed
- [x] I have provided screenshots, where applicable

## Changed
1. Updated Navigation titles to correct heading H2.
2. Updated styles to use heading 5

## Screenshots
<img width="1513" alt="Screenshot 2022-12-15 at 8 20 55 AM" src="https://user-images.githubusercontent.com/83997348/207761154-3fdca606-5a49-4629-9221-6c8c110c5dda.png">

