### PR TITLE
[CIVIC-1313] Updated Next steps content component.

### DIFF
--- a/docroot/modules/custom/cs_generated_content/generated_content/node/civictheme_page_variations/component.next_step.inc
+++ b/docroot/modules/custom/cs_generated_content/generated_content/node/civictheme_page_variations/component.next_step.inc
@@ -30,6 +30,29 @@ function _cs_generated_content_create_node_civictheme_page__variations__componen
       ],
     ],
     [
+      'title' => 'Next Step component, No Summary',
+      'components' => [
+        [
+          'type' => 'next_step',
+          'title' => $helper::staticSentence(3),
+          'link' => [
+            'uri' => $helper::staticUrl(),
+            'title' => $helper::staticSentence(2),
+          ],
+        ],
+      ],
+    ],
+    [
+      'title' => 'Next Step component, No link',
+      'components' => [
+        [
+          'type' => 'next_step',
+          'title' => $helper::staticSentence(3),
+          'summary' => $helper::staticSentence(8),
+        ],
+      ],
+    ],
+    [
       'title' => 'Next Step component, No link text',
       'components' => [
         [

--- a/docroot/themes/contrib/civictheme/config/install/field.field.paragraph.civictheme_next_step.field_c_p_link.yml
+++ b/docroot/themes/contrib/civictheme/config/install/field.field.paragraph.civictheme_next_step.field_c_p_link.yml
@@ -12,11 +12,11 @@ entity_type: paragraph
 bundle: civictheme_next_step
 label: Link
 description: ''
-required: true
+required: false
 translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:
-  link_type: 17
   title: 1
+  link_type: 17
 field_type: link

--- a/docroot/themes/contrib/civictheme/config/install/field.field.paragraph.civictheme_next_step.field_c_p_summary.yml
+++ b/docroot/themes/contrib/civictheme/config/install/field.field.paragraph.civictheme_next_step.field_c_p_summary.yml
@@ -10,7 +10,7 @@ entity_type: paragraph
 bundle: civictheme_next_step
 label: Summary
 description: 'The summary field may contain up to 100 characters. Any characters past the 100 character limit will not show for users.'
-required: true
+required: false
 translatable: true
 default_value: {  }
 default_value_callback: ''

--- a/tests/behat/features/paragraph.civictheme_next_step.fields.feature
+++ b/tests/behat/features/paragraph.civictheme_next_step.fields.feature
@@ -49,4 +49,6 @@ Feature: Next step fields
     And I see field "field_c_n_components[0][subform][field_c_p_vertical_spacing]"
     And I see field "Title"
     And I see field "Summary"
+    And should not see an "textarea[name='field_c_n_components[0][subform][field_c_p_summary][0][value]'].required" element
     And I should see an "input[name='field_c_n_components[0][subform][field_c_p_link][0][uri]']" element
+    And should not see an "input[name='field_c_n_components[0][subform][field_c_p_link][0][uri]'].required" element


### PR DESCRIPTION
https://salsadigital.atlassian.net/browse/CIVIC-1313

## Checklist before requesting a review

- [x] I have formatted the subject to include ticket number as `[CIVIC-123] Verb in past tense with dot at the end.`
- [x] I have added a link to the JIRA ticket
- [x] I have provided information in `Changed` section about WHY something was done if this was not a normal implementation
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run new and existing relevant tests locally with my changes, and they passed
- [x] I have provided screenshots, where applicable

## Changed
1. Updated field configuration to make Summary and Link to be not required.
2. Updated Behat tests.
3. Verified preprocessors to make sure that empty Summary and Link are handled correctly.
4. Added 2 cases to the generated content: with empty summary, with empty link.

## Screenshots
![Screenshot 2022-12-15 at 9 39 41 AM](https://user-images.githubusercontent.com/83997348/207770554-0c3c2ecc-a232-4cfd-8660-66951424db62.png)
