### PR TITLE
[CIVIC-1314] Updated banner block component to add Type and Featured image fields.

### DIFF
--- a/docroot/themes/contrib/civictheme/civictheme.info.yml
+++ b/docroot/themes/contrib/civictheme/civictheme.info.yml
@@ -236,7 +236,9 @@ config_devel:
     - core.entity_view_mode.node.civictheme_subject_card
     - editor.editor.civictheme_rich_text
     - field.field.block_content.civictheme_banner.field_c_b_background_image
+    - field.field.block_content.civictheme_banner.field_c_b_banner_type
     - field.field.block_content.civictheme_banner.field_c_b_blend_mode
+    - field.field.block_content.civictheme_banner.field_c_b_featured_image
     - field.field.block_content.civictheme_banner.field_c_b_theme
     - field.field.block_content.civictheme_component_block.field_c_b_components
     - field.field.block_content.civictheme_mobile_navigation.field_c_b_bottom
@@ -451,9 +453,11 @@ config_devel:
     - field.field.paragraph.civictheme_webform.field_c_p_vertical_spacing
     - field.field.paragraph.civictheme_webform.field_c_p_webform
     - field.storage.block_content.field_c_b_background_image
+    - field.storage.block_content.field_c_b_banner_type
     - field.storage.block_content.field_c_b_blend_mode
     - field.storage.block_content.field_c_b_bottom
     - field.storage.block_content.field_c_b_components
+    - field.storage.block_content.field_c_b_featured_image
     - field.storage.block_content.field_c_b_link
     - field.storage.block_content.field_c_b_social_icons
     - field.storage.block_content.field_c_b_theme

--- a/docroot/themes/contrib/civictheme/config/install/core.entity_form_display.block_content.civictheme_banner.default.yml
+++ b/docroot/themes/contrib/civictheme/config/install/core.entity_form_display.block_content.civictheme_banner.default.yml
@@ -4,7 +4,9 @@ dependencies:
   config:
     - block_content.type.civictheme_banner
     - field.field.block_content.civictheme_banner.field_c_b_background_image
+    - field.field.block_content.civictheme_banner.field_c_b_banner_type
     - field.field.block_content.civictheme_banner.field_c_b_blend_mode
+    - field.field.block_content.civictheme_banner.field_c_b_featured_image
     - field.field.block_content.civictheme_banner.field_c_b_theme
   module:
     - media_library
@@ -15,26 +17,39 @@ mode: default
 content:
   field_c_b_background_image:
     type: media_library_widget
-    weight: 27
+    weight: 3
     region: content
     settings:
       media_types: {  }
     third_party_settings: {  }
-  field_c_b_blend_mode:
+  field_c_b_banner_type:
     type: options_select
-    weight: 28
+    weight: 1
     region: content
     settings: {  }
     third_party_settings: {  }
+  field_c_b_blend_mode:
+    type: options_select
+    weight: 4
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_c_b_featured_image:
+    type: media_library_widget
+    weight: 5
+    region: content
+    settings:
+      media_types: {  }
+    third_party_settings: {  }
   field_c_b_theme:
     type: options_buttons
-    weight: 26
+    weight: 2
     region: content
     settings: {  }
     third_party_settings: {  }
   info:
     type: string_textfield
-    weight: -5
+    weight: 0
     region: content
     settings:
       size: 60

--- a/docroot/themes/contrib/civictheme/config/install/core.entity_view_display.block_content.civictheme_banner.default.yml
+++ b/docroot/themes/contrib/civictheme/config/install/core.entity_view_display.block_content.civictheme_banner.default.yml
@@ -4,7 +4,9 @@ dependencies:
   config:
     - block_content.type.civictheme_banner
     - field.field.block_content.civictheme_banner.field_c_b_background_image
+    - field.field.block_content.civictheme_banner.field_c_b_banner_type
     - field.field.block_content.civictheme_banner.field_c_b_blend_mode
+    - field.field.block_content.civictheme_banner.field_c_b_featured_image
     - field.field.block_content.civictheme_banner.field_c_b_theme
 id: block_content.civictheme_banner.default
 targetEntityType: block_content
@@ -21,5 +23,7 @@ content:
     weight: 0
     region: content
 hidden:
+  field_c_b_banner_type: true
   field_c_b_blend_mode: true
+  field_c_b_featured_image: true
   field_c_b_theme: true

--- a/docroot/themes/contrib/civictheme/config/install/field.field.block_content.civictheme_banner.field_c_b_banner_type.yml
+++ b/docroot/themes/contrib/civictheme/config/install/field.field.block_content.civictheme_banner.field_c_b_banner_type.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.civictheme_banner
+    - field.storage.block_content.field_c_b_banner_type
+  module:
+    - options
+id: block_content.civictheme_banner.field_c_b_banner_type
+field_name: field_c_b_banner_type
+entity_type: block_content
+bundle: civictheme_banner
+label: Type
+description: ''
+required: true
+translatable: false
+default_value:
+  -
+    value: default
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/docroot/themes/contrib/civictheme/config/install/field.field.block_content.civictheme_banner.field_c_b_featured_image.yml
+++ b/docroot/themes/contrib/civictheme/config/install/field.field.block_content.civictheme_banner.field_c_b_featured_image.yml
@@ -1,0 +1,28 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.civictheme_banner
+    - field.storage.block_content.field_c_b_featured_image
+    - media.type.civictheme_image
+id: block_content.civictheme_banner.field_c_b_featured_image
+field_name: field_c_b_featured_image
+entity_type: block_content
+bundle: civictheme_banner
+label: 'Featured image'
+description: 'Image displayed on a side of the banner.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:media'
+  handler_settings:
+    target_bundles:
+      civictheme_image: civictheme_image
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/docroot/themes/contrib/civictheme/config/install/field.storage.block_content.field_c_b_banner_type.yml
+++ b/docroot/themes/contrib/civictheme/config/install/field.storage.block_content.field_c_b_banner_type.yml
@@ -1,0 +1,26 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - block_content
+    - options
+id: block_content.field_c_b_banner_type
+field_name: field_c_b_banner_type
+entity_type: block_content
+type: list_string
+settings:
+  allowed_values:
+    -
+      value: default
+      label: Default
+    -
+      value: large
+      label: Large
+  allowed_values_function: ''
+module: options
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/themes/contrib/civictheme/config/install/field.storage.block_content.field_c_b_featured_image.yml
+++ b/docroot/themes/contrib/civictheme/config/install/field.storage.block_content.field_c_b_featured_image.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - block_content
+    - media
+id: block_content.field_c_b_featured_image
+field_name: field_c_b_featured_image
+entity_type: block_content
+type: entity_reference
+settings:
+  target_type: media
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/themes/contrib/civictheme/includes/banner.inc
+++ b/docroot/themes/contrib/civictheme/includes/banner.inc
@@ -14,6 +14,7 @@ use Drupal\node\NodeInterface;
  *
  * @SuppressWarnings(PHPMD.StaticAccess)
  * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+ * @SuppressWarnings(PHPMD.NPathComplexity)
  */
 function _civictheme_preprocess_block__civictheme_banner(&$variables) {
   if ($variables['base_plugin_id'] != 'block_content') {

--- a/docroot/themes/contrib/civictheme/includes/banner.inc
+++ b/docroot/themes/contrib/civictheme/includes/banner.inc
@@ -40,11 +40,24 @@ function _civictheme_preprocess_block__civictheme_banner(&$variables) {
 
   $variables['theme'] = civictheme_get_field_theme_value($entity);
 
+  if (civictheme_field_has_value($entity, 'field_c_b_banner_type')) {
+    $variables['type'] = civictheme_get_field_value($entity, 'field_c_b_banner_type', TRUE);
+  }
+
   if (civictheme_field_has_value($entity, 'field_c_b_background_image')) {
     $variables['background_image'] = civictheme_media_get_url_from_field($entity, 'field_c_b_background_image');
 
     if (civictheme_field_has_value($entity, 'field_c_b_blend_mode')) {
       $variables['background_image_blend_mode'] = civictheme_get_field_value($entity, 'field_c_b_blend_mode', TRUE);
+    }
+  }
+
+  if (civictheme_field_has_value($entity, 'field_c_b_featured_image')) {
+    $featured_image = civictheme_get_field_value($entity, 'field_c_b_featured_image', TRUE);
+    if ($featured_image !== NULL) {
+      $image = civictheme_get_field_value($featured_image, 'field_c_m_image', TRUE);
+      $variables['featured_image']['src'] = civictheme_media_get_url($featured_image);
+      $variables['featured_image']['alt'] = $image !== NULL ? $image->getValue()['alt'] : '';
     }
   }
 

--- a/docroot/themes/contrib/civictheme/theme-settings.provision.inc
+++ b/docroot/themes/contrib/civictheme/theme-settings.provision.inc
@@ -682,6 +682,8 @@ function _civictheme_provision__blocks__banner(array $block) {
   $block_content->field_c_b_background_image = civictheme_provision_load_media_by_name("{$theme_name}_background_1.png");
   $block_content->field_c_b_theme = 'dark';
   $block_content->field_c_b_blend_mode = 'soft-light';
+  $block_content->field_c_b_banner_type = 'default';
+  $block_content->field_c_b_featured_image = civictheme_provision_load_media_by_name("demo_image.jpg");
   $block_content->save();
   civictheme_provision_place_block($block['name'], $block['region'], $block_content->uuid());
 }

--- a/tests/behat/features/block_type.civictheme_banner.fields.feature
+++ b/tests/behat/features/block_type.civictheme_banner.fields.feature
@@ -12,3 +12,5 @@ Feature: Banner block fields
     Given I am logged in as a user with the "Administrator" role
     When I go to "admin/structure/block/block-content/manage/civictheme_banner/fields"
     Then I should see the text "Theme" in the "field_c_b_theme" row
+    Then I should see the text "Featured image" in the "field_c_b_featured_image" row
+    Then I should see the text "Type" in the "field_c_b_banner_type" row

--- a/tests/behat/features/block_type.civictheme_banner.render.feature
+++ b/tests/behat/features/block_type.civictheme_banner.render.feature
@@ -1,0 +1,32 @@
+@p0 @civictheme @block_type @block_civictheme_banner
+Feature: Banner render
+
+  Background:
+    Given managed file:
+      | filename       | uri                                       | path           |
+      | test_image.jpg | public://civictheme_test/test_image.jpg   | test_image.jpg |
+      | image.jpg      | public://civictheme_test/image.jpg        | image.jpg      |
+
+    And "civictheme_image" media:
+      | name                            | field_c_m_image |
+      | [TEST] CivicTheme Block Image   | test_image.jpg  |
+      | [TEST] CivicTheme Content Image | image.jpg       |
+
+    And "civictheme_page" content:
+      | title                            | status | field_c_n_banner_type | field_c_n_banner_featured_image |
+      | [TEST] Page banner test          | 1      |                       |                                 |
+      | [TEST] Page banner override test | 1      | large                 | [TEST] CivicTheme Content Image |
+
+  @api @javascript
+  Scenario: CivicTheme Page banner with default values.
+    Given I am an anonymous user
+    When I visit "civictheme_page" "[TEST] Page banner test"
+    And save screenshot
+
+  @api @javascript
+  Scenario: CivicTheme Page banner with override values.
+    Given I am an anonymous user
+    When I visit "civictheme_page" "[TEST] Page banner override test"
+    And I should see an ".ct-banner__featured-image" element
+    And I should see an ".ct-banner.ct-banner--decorative" element
+    And save screenshot


### PR DESCRIPTION
https://salsadigital.atlassian.net/browse/CIVIC-1314

## Checklist before requesting a review

- [x] I have formatted the subject to include ticket number as `[CIVIC-123] Verb in past tense with dot at the end.`
- [x] I have added a link to the JIRA ticket
- [x] I have provided information in `Changed` section about WHY something was done if this was not a normal implementation
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run new and existing relevant tests locally with my changes, and they passed
- [x] I have provided screenshots, where applicable

## Changed
1. Added Type field field_c_b_banner_type with values Default and Large to Banner block.
2. Added Featured image field field_c_b_featured_image 
3. Updated banner preprocessing to use values from these 2 fields and allow to override with values in the page.
4. Updated _civictheme_provision__blocks__banner() to accommodate for the new fields
5. Updated Behat test to check banner overrides.

## Screenshots
![Screenshot 2022-12-15 at 3 20 48 PM](https://user-images.githubusercontent.com/83997348/207827984-8b766b17-8161-4055-a1d1-054e07a837b7.png)
