### PR TITLE
[CIVIC-1310] Updated ellipsis component to use single boolean.

### DIFF
--- a/docroot/themes/contrib/civictheme/civictheme_library/components/02-molecules/pagination/pagination.stories.js
+++ b/docroot/themes/contrib/civictheme/civictheme_library/components/02-molecules/pagination/pagination.stories.js
@@ -46,36 +46,14 @@ export const Pagination = (knobTab) => {
     },
     generalKnobTab,
   );
-  const ellipsis = boolean('With ellipsis', true, generalKnobTab)
-    ? pageCount >= 1
-      ? current > 1
-        ? current < pageCount
-          ? {
-            previous: 1,
-            next: 1,
-          }
-          : {
-            previous: 1,
-            next: 0,
-          }
-        : current <= pageCount
-          ? {
-            previous: 0,
-            next: 1,
-          }
-          : {
-            previous: 1,
-            next: 1,
-          }
-      : false
-    : false;
+  const use_ellipsis = boolean('With ellipsis', false, generalKnobTab);
 
   const pages = {};
   const pagerMiddle = Math.ceil(pageCount / 2);
   const pagerFirst = current - pagerMiddle + 1;
   const pagerLast = current + pageCount - pagerMiddle;
   for (let i = 0; i < pageCount; i++) {
-    if (ellipsis) {
+    if (use_ellipsis) {
       if (i === 0 || (i > pagerFirst && i < pagerLast) || i === (pageCount - 1)) {
         pages[i + 1] = {
           href: randomUrl(),
@@ -101,7 +79,7 @@ export const Pagination = (knobTab) => {
       },
     } : null,
     heading_id: text('Heading Id', 'ct-pager-demo', generalKnobTab),
-    ellipsis,
+    use_ellipsis,
     items_per_page_options: boolean('With items per page', true, generalKnobTab) ? [
       {
         type: 'option', label: 10, value: 10, selected: false,

--- a/docroot/themes/contrib/civictheme/civictheme_library/components/02-molecules/pagination/pagination.stories.js
+++ b/docroot/themes/contrib/civictheme/civictheme_library/components/02-molecules/pagination/pagination.stories.js
@@ -46,14 +46,14 @@ export const Pagination = (knobTab) => {
     },
     generalKnobTab,
   );
-  const use_ellipsis = boolean('With ellipsis', false, generalKnobTab);
+  const useEllipsis = boolean('With ellipsis', false, generalKnobTab);
 
   const pages = {};
   const pagerMiddle = Math.ceil(pageCount / 2);
   const pagerFirst = current - pagerMiddle + 1;
   const pagerLast = current + pageCount - pagerMiddle;
   for (let i = 0; i < pageCount; i++) {
-    if (use_ellipsis) {
+    if (useEllipsis) {
       if (i === 0 || (i > pagerFirst && i < pagerLast) || i === (pageCount - 1)) {
         pages[i + 1] = {
           href: randomUrl(),
@@ -79,7 +79,7 @@ export const Pagination = (knobTab) => {
       },
     } : null,
     heading_id: text('Heading Id', 'ct-pager-demo', generalKnobTab),
-    use_ellipsis,
+    use_ellipsis: useEllipsis,
     items_per_page_options: boolean('With items per page', true, generalKnobTab) ? [
       {
         type: 'option', label: 10, value: 10, selected: false,

--- a/docroot/themes/contrib/civictheme/civictheme_library/components/02-molecules/pagination/pagination.twig
+++ b/docroot/themes/contrib/civictheme/civictheme_library/components/02-molecules/pagination/pagination.twig
@@ -18,9 +18,7 @@
  *   - value: [string] Option value.
  *   - selected: [string] Flag whether option is selected.
  * - items_per_page_attributes: attributes for select element.
- * - ellipsis: [object] Object with oolean flags for whether to print ellipsis.
- *   - previous: [boolean] Show ellipsis before item links
- *   - next: [boolean] Show ellipsis after item links
+ * - use_ellipsis: [boolean] Flag whether ellipsis to be shown.
  * - attributes: [string] Additional attributes.
  * - modifier_class: [string] Additional classes.
  */
@@ -93,9 +91,9 @@
       {# Generate pager. #}
       {% for key, item in items.pages %}
         {% if loop.last %}
-          {# Add an ellipsis if there are further next pages. #}
-          {% if ellipsis.next %}
-            <li class="ct-pager__item ct-pager__item--ellipsis ct-pager__item--ellipsis-next" role="presentation">
+          {# Add an ellipsis if there are further previous pages. #}
+          {% if use_ellipsis and current > 1 %}
+            <li class="ct-pager__item ct-pager__item--ellipsis ct-pager__item--ellipsis-previous" role="presentation">
               &hellip;
             </li>
           {% endif %}
@@ -118,9 +116,9 @@
           } only %}
         </li>
         {% if loop.first %}
-          {# Add an ellipsis if there are further previous pages. #}
-          {% if ellipsis.previous %}
-            <li class="ct-pager__item ct-pager__item--ellipsis ct-pager__item--ellipsis-previous" role="presentation">
+          {# Add an ellipsis if there are further next pages. #}
+          {% if use_ellipsis and current < total_pages %}
+            <li class="ct-pager__item ct-pager__item--ellipsis ct-pager__item--ellipsis-next" role="presentation">
               &hellip;
             </li>
           {% endif %}

--- a/docroot/themes/contrib/civictheme/includes/pager.inc
+++ b/docroot/themes/contrib/civictheme/includes/pager.inc
@@ -94,7 +94,7 @@ function civictheme_preprocess_views_mini_pager(&$variables) {
     _civictheme_preprocess_pager__items_per_page($variables, $view, $pager);
   }
 
-  _civictheme_preprocess_mini_pager__ellipsis($variables);
+  $variables['use_ellipsis'] = TRUE;
 }
 
 /**
@@ -122,17 +122,5 @@ function _civictheme_preprocess_pager__items_per_page(&$variables, $view, $pager
     }
     $variables['items_per_page_options'] = $items_per_page;
     $variables['items_per_page_attributes'] = 'name="items_per_page" form="' . $exposed_widgets['#id'] . '"';
-  }
-}
-
-/**
- * Helper to process ellipsis for mini pager.
- */
-function _civictheme_preprocess_mini_pager__ellipsis(&$variables) {
-  if ($variables['items']['current'] > 1) {
-    $variables['ellipsis']['previous'] = TRUE;
-  }
-  if ($variables['items']['current'] < $variables['total_pages']) {
-    $variables['ellipsis']['next'] = TRUE;
   }
 }

--- a/docroot/themes/contrib/civictheme/templates/navigation/pager.html.twig
+++ b/docroot/themes/contrib/civictheme/templates/navigation/pager.html.twig
@@ -21,11 +21,7 @@
  *   - text: The visible text used for the item link, such as "‹ Previous"
  *     or "Next ›".
  * - current: The page number of the current page.
- * - ellipses: If there are more pages than the quantity allows, then an
- *   ellipsis before or after the listed pages may be present.
- *   - previous: Present if the currently visible list of pages does not start
- *     at the first page.
- *   - next: Present if the visible list of pages ends before the last page.
+ * - use_ellipsis: [boolean] Flag whether ellipsis to be shown.
  *
  * @see template_preprocess_pager()
  */

--- a/docroot/themes/contrib/civictheme/templates/navigation/views-mini-pager.html.twig
+++ b/docroot/themes/contrib/civictheme/templates/navigation/views-mini-pager.html.twig
@@ -21,11 +21,7 @@
  *   - text: The visible text used for the item link, such as "‹ Previous"
  *     or "Next ›".
  * - current: The page number of the current page.
- * - ellipses: If there are more pages than the quantity allows, then an
- *   ellipsis before or after the listed pages may be present.
- *   - previous: Present if the currently visible list of pages does not start
- *     at the first page.
- *   - next: Present if the visible list of pages ends before the last page.
+ * - use_ellipsis: [boolean] Flag whether ellipsis to be shown.
  *
  * @see template_preprocess_pager()
  */

--- a/tests/behat/features/pagination.render.feature
+++ b/tests/behat/features/pagination.render.feature
@@ -30,7 +30,7 @@ Feature: Pagination
       | [TEST] Page 24 | 1      |
       | [TEST] Page 25 | 1      |
 
-  @api @skipped
+  @api
   Scenario: Views page with full pager and items per page should render and function correctly
     Given I am an anonymous user
     When I visit "civictheme-no-sidebar/test-table"
@@ -42,7 +42,7 @@ Feature: Pagination
     And I should not see "First" in the ".ct-list__results-below .ct-pager" element
     And I should see "Prev" in the ".ct-list__results-below .ct-pager .ct-pager__link[disabled]" element
     And I should see "Last" in the ".ct-list__results-below .ct-pager" element
-    And I should see a ".ct-pager .ct-pager__item--ellipsis-next" element
+    And I should not see a ".ct-pager .ct-pager__item--ellipsis-next" element
     And I should not see a ".ct-pager .ct-pager__item--ellipsis-previous" element
     And I click "2"
     And I should see "Last" in the ".ct-list__results-below .ct-pager" element
@@ -53,7 +53,7 @@ Feature: Pagination
     And I should see "Next" in the ".ct-list__results-below .ct-pager .ct-pager__link[disabled]" element
     And I should see "Items per page" in the ".ct-list__results-below .ct-pager .ct-pager__items_per_page" element
     And I should not see a ".ct-pager .ct-pager__item--ellipsis-next" element
-    And I should see a ".ct-pager .ct-pager__item--ellipsis-previous" element
+    And I should not see a ".ct-pager .ct-pager__item--ellipsis-previous" element
     And select "items_per_page" should have an option "5"
     And select "items_per_page" should have an option "10"
     And select "items_per_page" should have an option "25"


### PR DESCRIPTION
[https://salsadigital.atlassian.net/browse/CIVIC-1310](https://salsadigital.atlassian.net/browse/CIVIC-1310)

## Checklist before requesting a review

- [x] I have formatted the subject to include ticket number as `[CIVIC-123] Verb in past tense with dot at the end.`
- [x] I have added a link to the JIRA ticket
- [x] I have provided information in `Changed` section about WHY something was done if this was not a normal implementation
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run new and existing relevant tests locally with my changes, and they passed
- [x] I have provided screenshots, where applicable

## Changed
1. Updated ellipsis component to use single boolean.

## Screenshots
<img width="1314" alt="Screenshot 2022-12-28 at 2 49 54 PM" src="https://user-images.githubusercontent.com/83997348/209789058-522ef5b8-f7e2-4efe-953f-4d9c3e40a7d4.png">

![Screenshot 2022-12-28 at 2 50 07 PM](https://user-images.githubusercontent.com/83997348/209789074-83835ad0-4657-4ec6-bf5e-80ff58657bb7.png)
![Screenshot 2022-12-28 at 2 50 23 PM](https://user-images.githubusercontent.com/83997348/209789108-183219ca-e64f-4bae-bc77-6640c20d8cb6.png)
