### PR TITLE
[CIVIC-1332] Disabled the vertical spacing field value is rendering on Events page.

### DIFF
--- a/docroot/themes/contrib/civictheme/config/install/core.entity_view_display.node.civictheme_event.default.yml
+++ b/docroot/themes/contrib/civictheme/config/install/core.entity_view_display.node.civictheme_event.default.yml
@@ -20,7 +20,6 @@ dependencies:
     - entity_reference_revisions
     - layout_builder
     - layout_builder_restrictions
-    - options
     - text
     - user
 third_party_settings:
@@ -73,13 +72,6 @@ content:
     third_party_settings: {  }
     weight: 3
     region: content
-  field_c_n_vertical_spacing:
-    type: list_default
-    label: above
-    settings: {  }
-    third_party_settings: {  }
-    weight: 4
-    region: content
 hidden:
   field_c_n_attachments: true
   field_c_n_custom_last_updated: true
@@ -88,4 +80,5 @@ hidden:
   field_c_n_summary: true
   field_c_n_thumbnail: true
   field_c_n_topics: true
+  field_c_n_vertical_spacing: true
   links: true


### PR DESCRIPTION
https://salsadigital.atlassian.net/browse/CIVIC-1332

## Checklist before requesting a review

- [x] I have formatted the subject to include ticket number as `[CIVIC-123] Verb in past tense with dot at the end.`
- [x] I have added a link to the JIRA ticket
- [x] I have provided information in `Changed` section about WHY something was done if this was not a normal implementation
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run new and existing relevant tests locally with my changes, and they passed
- [x] I have provided screenshots, where applicable

## Changed
1. Disabled the vertical spacing field value is rendering on Events page.

## Screenshots
![Screenshot 2023-01-31 at 11 13 21 AM](https://user-images.githubusercontent.com/83997348/215675841-2a0325e5-f33b-48fc-a344-32951f921426.png)
