### PR TITLE
[CIVIC-1327] Updated Event card Image field to not be compulsory.

### DIFF
--- a/docroot/themes/contrib/civictheme/config/install/field.field.paragraph.civictheme_event_card.field_c_p_image.yml
+++ b/docroot/themes/contrib/civictheme/config/install/field.field.paragraph.civictheme_event_card.field_c_p_image.yml
@@ -11,7 +11,7 @@ entity_type: paragraph
 bundle: civictheme_event_card
 label: Image
 description: ''
-required: true
+required: false
 translatable: true
 default_value: {  }
 default_value_callback: ''

--- a/tests/behat/features/paragraph.civictheme_event_card.fields.feature
+++ b/tests/behat/features/paragraph.civictheme_event_card.fields.feature
@@ -14,6 +14,7 @@ Feature: Event Card fields
     And I should not see an "[name='field_c_n_components[0][subform][field_c_p_list_items][0][subform][field_c_p_title][0][value]'][disabled]" element
 
     And I should see an "[name='field_c_n_components[0][subform][field_c_p_list_items][0][subform][field_c_p_image][media_library_selection]']" element
+    And I should not see an "[name='field_c_n_components[0][subform][field_c_p_list_items][0][subform][field_c_p_image][media_library_selection]'].required" element
 
     And I should see an "[name='field_c_n_components[0][subform][field_c_p_list_items][0][subform][field_c_p_summary][0][value]']" element
     And I should not see an "[name='field_c_n_components[0][subform][field_c_p_list_items][0][subform][field_c_p_summary][0][value]'].required" element


### PR DESCRIPTION
https://salsadigital.atlassian.net/browse/CIVIC-1327

## Checklist before requesting a review

- [x] I have formatted the subject to include ticket number as `[CIVIC-123] Verb in past tense with dot at the end.`
- [x] I have added a link to the JIRA ticket
- [x] I have provided information in `Changed` section about WHY something was done if this was not a normal implementation
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have run new and existing relevant tests locally with my changes, and they passed
- [x] I have provided screenshots, where applicable

## Changed
1. Updated Event card Image field to not be compulsory.

## Screenshots
![Screenshot 2023-01-31 at 11 35 03 AM](https://user-images.githubusercontent.com/83997348/215679507-4d8600a0-603c-4668-b37d-8680e2b3854d.png)
![Screenshot 2023-01-31 at 11 35 16 AM](https://user-images.githubusercontent.com/83997348/215679537-1832f120-9d91-4184-bfa5-5f490212f13d.png)

![Screenshot 2023-01-31 at 11 35 29 AM](https://user-images.githubusercontent.com/83997348/215679580-74e266dc-fa20-4a61-9723-eb3482fcb057.png)
