### PR TITLE
Updated dependencies.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,10 +20,10 @@
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
         "drevops/behat-format-progress-fail": "^1",
         "drevops/behat-screenshot": "^1",
-        "drevops/behat-steps": "^1",
+        "drevops/behat-steps": "^1.5",
         "drupal/coder": "8.3.16",
         "drupal/core-dev": "^9",
-        "drupal/drupal-extension": "^4",
+        "drupal/drupal-extension": "dev-feature/drupal-10 as 4.2.1-dev",
         "phpcompatibility/php-compatibility": "^9.0",
         "phpmd/phpmd": "^2.12",
         "phpspec/prophecy-phpunit": "^2",
@@ -64,6 +64,14 @@
         "drupal/drupal": "*"
     },
     "repositories": {
+        "drupal/drupal-driver": {
+            "type": "vcs",
+            "url": "https://github.com/drevops/DrupalDriver"
+        },
+        "drupal/drupal-extension": {
+            "type": "vcs",
+            "url": "https://github.com/drevops/drupalextension"
+        },
         "drupal": {
             "type": "composer",
             "url": "https://packages.drupal.org/8"
@@ -101,7 +109,7 @@
             "Utilities\\composer\\DrupalSettings::create"
         ]
     },
-    "minimum-stability": "alpha",
+    "minimum-stability": "dev",
     "prefer-stable": true,
     "extra": {
         "composer-exit-on-patch-failure": true,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fd2cedb56f04b3aac5483918901ea078",
+    "content-hash": "ab6c03e6c3f3e59af64da96178d3d4f4",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -3344,17 +3344,17 @@
         },
         {
             "name": "drupal/consumers",
-            "version": "1.16.0",
+            "version": "1.17.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/consumers.git",
-                "reference": "8.x-1.16"
+                "reference": "8.x-1.17"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/consumers-8.x-1.16.zip",
-                "reference": "8.x-1.16",
-                "shasum": "9f207f1ac05ae2a21c93a2405c5ea9bf23e779ba"
+                "url": "https://ftp.drupal.org/files/projects/consumers-8.x-1.17.zip",
+                "reference": "8.x-1.17",
+                "shasum": "8e7efc2c8386ead8ca459a1a5e0558fb66cde142"
             },
             "require": {
                 "drupal/core": "^8 || ^9 || ^10"
@@ -3362,8 +3362,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "8.x-1.16",
-                    "datestamp": "1671105682",
+                    "version": "8.x-1.17",
+                    "datestamp": "1679920063",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -3572,16 +3572,16 @@
         },
         {
             "name": "drupal/core",
-            "version": "9.4.11",
+            "version": "9.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/drupal/core.git",
-                "reference": "9051bd85c4daacb3c38947e5b1acdc816bc54bc4"
+                "reference": "8ad87c86ce88504a0f8b3f8a5f8cc350da48dc4d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/drupal/core/zipball/9051bd85c4daacb3c38947e5b1acdc816bc54bc4",
-                "reference": "9051bd85c4daacb3c38947e5b1acdc816bc54bc4",
+                "url": "https://api.github.com/repos/drupal/core/zipball/8ad87c86ce88504a0f8b3f8a5f8cc350da48dc4d",
+                "reference": "8ad87c86ce88504a0f8b3f8a5f8cc350da48dc4d",
                 "shasum": ""
             },
             "require": {
@@ -3733,9 +3733,9 @@
             ],
             "description": "Drupal is an open source content management platform powering millions of websites and applications.",
             "support": {
-                "source": "https://github.com/drupal/core/tree/9.4.11"
+                "source": "https://github.com/drupal/core/tree/9.4.13"
             },
-            "time": "2023-02-01T20:00:36+00:00"
+            "time": "2023-03-24T13:11:03+00:00"
         },
         {
             "name": "drupal/core-composer-scaffold",
@@ -3830,16 +3830,16 @@
         },
         {
             "name": "drupal/core-recommended",
-            "version": "9.4.11",
+            "version": "9.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/drupal/core-recommended.git",
-                "reference": "9f89326da4fc93a9262dac6aa6072c7d2bd13aba"
+                "reference": "b598c6eab4af86049360db98794e6ee25ba01c61"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/drupal/core-recommended/zipball/9f89326da4fc93a9262dac6aa6072c7d2bd13aba",
-                "reference": "9f89326da4fc93a9262dac6aa6072c7d2bd13aba",
+                "url": "https://api.github.com/repos/drupal/core-recommended/zipball/b598c6eab4af86049360db98794e6ee25ba01c61",
+                "reference": "b598c6eab4af86049360db98794e6ee25ba01c61",
                 "shasum": ""
             },
             "require": {
@@ -3848,7 +3848,7 @@
                 "doctrine/annotations": "~1.13.2",
                 "doctrine/lexer": "~1.2.3",
                 "doctrine/reflection": "~1.2.3",
-                "drupal/core": "9.4.11",
+                "drupal/core": "9.4.13",
                 "egulias/email-validator": "~3.2",
                 "guzzlehttp/guzzle": "~6.5.8",
                 "guzzlehttp/promises": "~1.5.1",
@@ -3910,9 +3910,9 @@
             ],
             "description": "Core and its dependencies with known-compatible minor versions. Require this project INSTEAD OF drupal/core.",
             "support": {
-                "source": "https://github.com/drupal/core-recommended/tree/9.4.11"
+                "source": "https://github.com/drupal/core-recommended/tree/9.4.13"
             },
-            "time": "2023-02-01T20:00:36+00:00"
+            "time": "2023-03-24T13:11:03+00:00"
         },
         {
             "name": "drupal/crop",
@@ -5839,17 +5839,17 @@
         },
         {
             "name": "drupal/inline_entity_form",
-            "version": "1.0.0-rc14",
+            "version": "1.0.0-rc15",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/inline_entity_form.git",
-                "reference": "8.x-1.0-rc14"
+                "reference": "8.x-1.0-rc15"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/inline_entity_form-8.x-1.0-rc14.zip",
-                "reference": "8.x-1.0-rc14",
-                "shasum": "2c9efd73332acfba43fe9b29e78e508ddc9d3664"
+                "url": "https://ftp.drupal.org/files/projects/inline_entity_form-8.x-1.0-rc15.zip",
+                "reference": "8.x-1.0-rc15",
+                "shasum": "7702801f7e599956fc3d10cff8257809f53ac3ec"
             },
             "require": {
                 "drupal/core": "^8.8 || ^9 || ^10",
@@ -5861,8 +5861,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "8.x-1.0-rc14",
-                    "datestamp": "1663701306",
+                    "version": "8.x-1.0-rc15",
+                    "datestamp": "1678126675",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "RC releases are not covered by Drupal security advisories."
@@ -9712,16 +9712,16 @@
         },
         {
             "name": "govcms/govcms",
-            "version": "2.28.0",
+            "version": "2.29.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/govCMS/GovCMS.git",
-                "reference": "46e32bfc8a015f14dfd68e3c0c598c77cdf4050a"
+                "reference": "1ed772345e1757fa36a5a8fa58813f07c40d7940"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/govCMS/GovCMS/zipball/46e32bfc8a015f14dfd68e3c0c598c77cdf4050a",
-                "reference": "46e32bfc8a015f14dfd68e3c0c598c77cdf4050a",
+                "url": "https://api.github.com/repos/govCMS/GovCMS/zipball/1ed772345e1757fa36a5a8fa58813f07c40d7940",
+                "reference": "1ed772345e1757fa36a5a8fa58813f07c40d7940",
                 "shasum": ""
             },
             "require": {
@@ -9742,11 +9742,11 @@
                 "drupal/config_perms": "2.0",
                 "drupal/config_split": "1.5.0",
                 "drupal/config_update": "1.7",
-                "drupal/consumers": "1.16.0",
+                "drupal/consumers": "1.17.0",
                 "drupal/contact_storage": "1.2.0",
                 "drupal/context": "4.1.0",
                 "drupal/core-composer-scaffold": "^9",
-                "drupal/core-recommended": "9.4.11",
+                "drupal/core-recommended": "9.4.13",
                 "drupal/crop": "2.3.0",
                 "drupal/ctools": "3.13.0",
                 "drupal/devel": "5.1.1",
@@ -9771,7 +9771,7 @@
                 "drupal/google_analytics": "4.0.2",
                 "drupal/govcms_dlm": "2.0.0",
                 "drupal/honeypot": "2.1.2",
-                "drupal/inline_entity_form": "1.0.0-rc14",
+                "drupal/inline_entity_form": "1.0.0-rc15",
                 "drupal/key": "1.17.0",
                 "drupal/layout_builder_modal": "1.2.0",
                 "drupal/layout_builder_restrictions": "2.17.0",
@@ -9892,7 +9892,7 @@
                 "source": "https://github.com/GovCMS/GovCMS/releases",
                 "wik": "https://github.com/GovCMS/GovCMS/wiki"
             },
-            "time": "2023-03-16T22:55:07+00:00"
+            "time": "2023-04-05T02:22:16+00:00"
         },
         {
             "name": "graham-campbell/result-type",
@@ -10708,21 +10708,21 @@
         },
         {
             "name": "lcobucci/clock",
-            "version": "2.3.0",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/lcobucci/clock.git",
-                "reference": "c7aadcd6fd97ed9e199114269c0be3f335e38876"
+                "reference": "039ef98c6b57b101d10bd11d8fdfda12cbd996dc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/lcobucci/clock/zipball/c7aadcd6fd97ed9e199114269c0be3f335e38876",
-                "reference": "c7aadcd6fd97ed9e199114269c0be3f335e38876",
+                "url": "https://api.github.com/repos/lcobucci/clock/zipball/039ef98c6b57b101d10bd11d8fdfda12cbd996dc",
+                "reference": "039ef98c6b57b101d10bd11d8fdfda12cbd996dc",
                 "shasum": ""
             },
             "require": {
                 "php": "~8.1.0 || ~8.2.0",
-                "stella-maris/clock": "^0.1.7"
+                "psr/clock": "^1.0"
             },
             "provide": {
                 "psr/clock-implementation": "1.0"
@@ -10756,7 +10756,7 @@
             "description": "Yet another clock abstraction",
             "support": {
                 "issues": "https://github.com/lcobucci/clock/issues",
-                "source": "https://github.com/lcobucci/clock/tree/2.3.0"
+                "source": "https://github.com/lcobucci/clock/tree/3.0.0"
             },
             "funding": [
                 {
@@ -10768,7 +10768,7 @@
                     "type": "patreon"
                 }
             ],
-            "time": "2022-12-19T14:38:11+00:00"
+            "time": "2022-12-19T15:00:24+00:00"
         },
         {
             "name": "lcobucci/jwt",
@@ -11069,27 +11069,27 @@
         },
         {
             "name": "league/oauth2-server",
-            "version": "8.5.0",
+            "version": "8.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/oauth2-server.git",
-                "reference": "8170913a2aeadebbba17b46df4dc18d17c891516"
+                "reference": "43cd4d406906c6be5c8de2cee9bd3ad3753544ef"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/oauth2-server/zipball/8170913a2aeadebbba17b46df4dc18d17c891516",
-                "reference": "8170913a2aeadebbba17b46df4dc18d17c891516",
+                "url": "https://api.github.com/repos/thephpleague/oauth2-server/zipball/43cd4d406906c6be5c8de2cee9bd3ad3753544ef",
+                "reference": "43cd4d406906c6be5c8de2cee9bd3ad3753544ef",
                 "shasum": ""
             },
             "require": {
-                "defuse/php-encryption": "^2.3.0",
+                "defuse/php-encryption": "^2.3",
                 "ext-json": "*",
                 "ext-openssl": "*",
-                "lcobucci/clock": "^2.2.0 || ^3.1.0",
-                "lcobucci/jwt": "^4.3.0 || ^5.0.0",
+                "lcobucci/clock": "^2.2 || ^3.0",
+                "lcobucci/jwt": "^4.3 || ^5.0",
                 "league/event": "^2.2",
                 "league/uri": "^6.7",
-                "php": "~8.0.0 || ~8.1.0 || ~8.2.0",
+                "php": "^8.0",
                 "psr/http-message": "^1.0.1"
             },
             "replace": {
@@ -11146,7 +11146,7 @@
             ],
             "support": {
                 "issues": "https://github.com/thephpleague/oauth2-server/issues",
-                "source": "https://github.com/thephpleague/oauth2-server/tree/8.5.0"
+                "source": "https://github.com/thephpleague/oauth2-server/tree/8.5.1"
             },
             "funding": [
                 {
@@ -11154,7 +11154,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-04-03T14:54:34+00:00"
+            "time": "2023-04-04T10:20:16+00:00"
         },
         {
             "name": "league/uri",
@@ -13000,53 +13000,6 @@
                 "source": "https://github.com/stackphp/builder/tree/v1.0.6"
             },
             "time": "2020-01-30T12:17:27+00:00"
-        },
-        {
-            "name": "stella-maris/clock",
-            "version": "0.1.7",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/stella-maris-solutions/clock.git",
-                "reference": "fa23ce16019289a18bb3446fdecd45befcdd94f8"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/stella-maris-solutions/clock/zipball/fa23ce16019289a18bb3446fdecd45befcdd94f8",
-                "reference": "fa23ce16019289a18bb3446fdecd45befcdd94f8",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.0|^8.0",
-                "psr/clock": "^1.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "StellaMaris\\Clock\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Andreas Heigl",
-                    "role": "Maintainer"
-                }
-            ],
-            "description": "A pre-release of the proposed PSR-20 Clock-Interface",
-            "homepage": "https://gitlab.com/stella-maris/clock",
-            "keywords": [
-                "clock",
-                "datetime",
-                "point in time",
-                "psr20"
-            ],
-            "support": {
-                "source": "https://github.com/stella-maris-solutions/clock/tree/0.1.7"
-            },
-            "time": "2022-11-25T16:15:06+00:00"
         },
         {
             "name": "steverhoades/oauth2-openid-connect-server",
@@ -17629,34 +17582,40 @@
         },
         {
             "name": "drevops/behat-steps",
-            "version": "1.4.3",
+            "version": "1.5.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/drevops/behat-steps.git",
-                "reference": "91e2bd432c43ac00856b7af9badc942b92bd3a4f"
+                "reference": "1f09d7369e3833a55fc10837f9bf45ca502ec9e7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/drevops/behat-steps/zipball/91e2bd432c43ac00856b7af9badc942b92bd3a4f",
-                "reference": "91e2bd432c43ac00856b7af9badc942b92bd3a4f",
+                "url": "https://api.github.com/repos/drevops/behat-steps/zipball/1f09d7369e3833a55fc10837f9bf45ca502ec9e7",
+                "reference": "1f09d7369e3833a55fc10837f9bf45ca502ec9e7",
                 "shasum": ""
             },
             "require": {
                 "behat/behat": "^3",
-                "drupal/drupal-extension": "^4"
+                "cweagans/composer-patches": "^1.7",
+                "drupal/drupal-extension": "dev-feature/drupal-10 as 4.2.1-dev"
             },
             "require-dev": {
                 "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
                 "drevops/behat-screenshot": "^1",
                 "drupal/coder": "^8.3",
+                "mglaman/drupal-check": "^1",
+                "palantirnet/drupal-rector": "^0.15",
                 "php-parallel-lint/php-parallel-lint": "^1.3",
                 "phpcompatibility/php-compatibility": "^9.3",
-                "phpunit/phpunit": "^8.5 || ^9.0"
+                "phpunit/phpunit": "^8.5 || ^9.0",
+                "rector/rector": "0.15.13"
             },
             "type": "library",
             "extra": {
+                "enable-patching": true,
                 "branch-alias": {
-                    "dev-master": "1.x-dev"
+                    "dev-master": "1.x-dev",
+                    "dev-main": "1.x-dev"
                 }
             },
             "autoload": {
@@ -17669,12 +17628,24 @@
             "license": [
                 "GPL-2.0-or-later"
             ],
+            "authors": [
+                {
+                    "name": "Alex Skrypnyk",
+                    "email": "alex@drevops.com"
+                }
+            ],
             "description": "Collection of Behat traits",
             "support": {
                 "issues": "https://github.com/drevops/behat-steps/issues",
-                "source": "https://github.com/drevops/behat-steps/tree/1.4.3"
+                "source": "https://github.com/drevops/behat-steps/tree/1.5.2"
             },
-            "time": "2022-09-29T02:03:03+00:00"
+            "funding": [
+                {
+                    "url": "https://www.patreon.com/alexskrypnyk",
+                    "type": "patreon"
+                }
+            ],
+            "time": "2023-04-03T11:54:08+00:00"
         },
         {
             "name": "drupal/coder",
@@ -17779,16 +17750,16 @@
         },
         {
             "name": "drupal/drupal-driver",
-            "version": "v2.2.2",
+            "version": "dev-feature/drupal-10",
             "source": {
                 "type": "git",
-                "url": "https://github.com/jhedstrom/DrupalDriver.git",
-                "reference": "632712db66681b76651518bf5ab1e60fddc70a39"
+                "url": "https://github.com/drevops/DrupalDriver.git",
+                "reference": "03ae7c9ea5a0071ea6d49a8868f5ad5ae0163bb6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/jhedstrom/DrupalDriver/zipball/632712db66681b76651518bf5ab1e60fddc70a39",
-                "reference": "632712db66681b76651518bf5ab1e60fddc70a39",
+                "url": "https://api.github.com/repos/drevops/DrupalDriver/zipball/03ae7c9ea5a0071ea6d49a8868f5ad5ae0163bb6",
+                "reference": "03ae7c9ea5a0071ea6d49a8868f5ad5ae0163bb6",
                 "shasum": ""
             },
             "require": {
@@ -17818,6 +17789,9 @@
             },
             "type": "library",
             "extra": {
+                "branch-alias": {
+                    "dev-master": "2.3.x-dev"
+                },
                 "installer-paths": {
                     "drupal/core": [
                         "type:drupal-core"
@@ -17838,7 +17812,19 @@
                     "Drupal\\Tests\\Driver": "tests/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "scripts": {
+                "test": [
+                    "composer validate --no-interaction",
+                    "parallel-lint src spec tests",
+                    "phpunit",
+                    "phpspec run -f pretty --no-interaction",
+                    "phpcs --standard=./phpcs-ruleset.xml .",
+                    "./vendor/bin/drupal-check --drupal-root=drupal ./src/Drupal/Driver/Cores/Drupal8.php ./src/Drupal/Driver/Fields/Drupal8",
+                    "cp ./vendor/palantirnet/drupal-rector/rector.php drupal/.",
+                    "cd drupal && ../vendor/bin/rector process ../src/Drupal/Driver/Cores/Drupal8.php --dry-run",
+                    "cd drupal && ../vendor/bin/rector process ../src/Drupal/Driver/Fields/Drupal8 --dry-run"
+                ]
+            },
             "license": [
                 "GPL-2.0-or-later"
             ],
@@ -17856,53 +17842,56 @@
                 "web"
             ],
             "support": {
-                "issues": "https://github.com/jhedstrom/DrupalDriver/issues",
-                "source": "https://github.com/jhedstrom/DrupalDriver/tree/v2.2.2"
+                "source": "https://github.com/drevops/DrupalDriver/tree/feature/drupal-10"
             },
             "funding": [
                 {
-                    "url": "https://github.com/jhedstrom",
-                    "type": "github"
+                    "type": "github",
+                    "url": "https://github.com/jhedstrom"
                 }
             ],
-            "time": "2023-01-06T17:22:24+00:00"
+            "time": "2022-11-23T06:48:32+00:00"
         },
         {
             "name": "drupal/drupal-extension",
-            "version": "v4.2.1",
+            "version": "dev-feature/drupal-10",
             "source": {
                 "type": "git",
-                "url": "https://github.com/jhedstrom/drupalextension.git",
-                "reference": "03c06860db91a2e456e3e7ca170414c2a4a40107"
+                "url": "https://github.com/drevops/drupalextension.git",
+                "reference": "02d13f78d379c45359d31788d62de3da24aa1a95"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/jhedstrom/drupalextension/zipball/03c06860db91a2e456e3e7ca170414c2a4a40107",
-                "reference": "03c06860db91a2e456e3e7ca170414c2a4a40107",
+                "url": "https://api.github.com/repos/drevops/drupalextension/zipball/02d13f78d379c45359d31788d62de3da24aa1a95",
+                "reference": "02d13f78d379c45359d31788d62de3da24aa1a95",
                 "shasum": ""
             },
             "require": {
                 "behat/behat": "~3.2",
                 "behat/mink": "~1.5",
-                "behat/mink-goutte-driver": "~1.0",
+                "behat/mink-goutte-driver": "~1|^2",
                 "behat/mink-selenium2-driver": "~1.1",
-                "drupal/drupal-driver": "^2.1.0",
-                "friends-of-behat/mink-extension": "^2",
-                "symfony/browser-kit": "^3.4|~4.4",
-                "symfony/dependency-injection": "~3.0|~4.4",
-                "symfony/translation": "^3.4|~4.4"
+                "cweagans/composer-patches": "^1.7",
+                "drupal/drupal-driver": "dev-feature/drupal-10 as 2.1.0-dev",
+                "friends-of-behat/mink-extension": "^2.7.2",
+                "symfony/browser-kit": "^3.4|~4.4|^6",
+                "symfony/dependency-injection": "~3.0|~4.4|^6",
+                "symfony/translation": "^3.4|~4.4|^6"
             },
             "require-dev": {
-                "composer/installers": "^1.2",
+                "composer/installers": "^1.2|^2",
                 "drupal/coder": "^8.3",
-                "drupal/core-composer-scaffold": "^9.1",
-                "drupal/core-recommended": "^9.1",
-                "drush/drush": "^10.5",
+                "drupal/core-composer-scaffold": "^9.1|^10@beta",
+                "drupal/core-recommended": "^9.1|^10@beta",
+                "drush/drush": "^10.5|^11 ",
                 "php-parallel-lint/php-parallel-lint": "^1.3",
                 "phpspec/phpspec": "^4.0 || ^6.0 || ^7.0"
             },
             "type": "behat-extension",
             "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0.x-dev"
+                },
                 "installer-paths": {
                     "drupal/core": [
                         "type:drupal-core"
@@ -17918,11 +17907,20 @@
                 "psr-0": {
                     "Drupal\\Drupal": "src/",
                     "Drupal\\Exception": "src/",
-                    "Drupal\\MinkExtension": "src/",
-                    "Drupal\\DrupalExtension": "src/"
+                    "Drupal\\DrupalExtension": "src/",
+                    "Drupal\\MinkExtension": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "scripts": {
+                "test": [
+                    "composer validate --no-interaction",
+                    "parallel-lint src spec features fixtures",
+                    "phpcs --standard=./phpcs-ruleset.xml -p",
+                    "phpcs --standard=./phpcs-drupal-ruleset.xml -p",
+                    "npm test",
+                    "phpspec run -f pretty --no-interaction"
+                ]
+            },
             "license": [
                 "GPL-2.0-or-later"
             ],
@@ -17948,16 +17946,15 @@
                 "web"
             ],
             "support": {
-                "issues": "https://github.com/jhedstrom/drupalextension/issues",
-                "source": "https://github.com/jhedstrom/drupalextension/tree/v4.2.1"
+                "source": "https://github.com/drevops/drupalextension/tree/feature/drupal-10"
             },
             "funding": [
                 {
-                    "url": "https://github.com/jhedstrom",
-                    "type": "github"
+                    "type": "github",
+                    "url": "https://github.com/jhedstrom"
                 }
             ],
-            "time": "2022-04-26T19:55:44+00:00"
+            "time": "2022-10-26T03:33:38+00:00"
         },
         {
             "name": "easyrdf/easyrdf",
@@ -21427,9 +21424,17 @@
             "time": "2021-07-28T10:34:58+00:00"
         }
     ],
-    "aliases": [],
-    "minimum-stability": "alpha",
+    "aliases": [
+        {
+            "package": "drupal/drupal-extension",
+            "version": "dev-feature/drupal-10",
+            "alias": "4.2.1-dev",
+            "alias_normalized": "4.2.1.0-dev"
+        }
+    ],
+    "minimum-stability": "dev",
     "stability-flags": {
+        "drupal/drupal-extension": 20,
         "drupal/linkit": 10,
         "drupal/default_content": 15
     },


### PR DESCRIPTION
Changelogs summary:

 - stella-maris/clock removed (installed version was 0.1.7)

 - drupal/core updated from 9.4.11 to 9.4.13 patch
   See changes: https://github.com/drupal/core/compare/9.4.11...9.4.13
   Release notes: https://github.com/drupal/core/releases/tag/9.4.13

 - drupal/drupal-driver downgraded from v2.2.2 to dev-feature/drupal-10@03ae7c9 major
   See changes: https://github.com/drevops/DrupalDriver/compare/jhedstrom:v2.2.2...drevops:03ae7c9

 - drupal/drupal-extension downgraded from v4.2.1 to dev-feature/drupal-10@02d13f7 major
   See changes: https://github.com/drevops/drupalextension/compare/jhedstrom:v4.2.1...drevops:02d13f7

 - drevops/behat-steps updated from 1.4.3 to 1.5.2 minor
   See changes: https://github.com/drevops/behat-steps/compare/1.4.3...1.5.2
   Release notes: https://github.com/drevops/behat-steps/releases/tag/1.5.2

 - lcobucci/clock updated from 2.3.0 to 3.0.0 major
   See changes: https://github.com/lcobucci/clock/compare/2.3.0...3.0.0
   Release notes: https://github.com/lcobucci/clock/releases/tag/3.0.0

 - league/oauth2-server updated from 8.5.0 to 8.5.1 patch
   See changes: https://github.com/thephpleague/oauth2-server/compare/8.5.0...8.5.1
   Release notes: https://github.com/thephpleague/oauth2-server/releases/tag/8.5.1

 - drupal/consumers updated from 1.16.0 to 1.17.0 minor

 - drupal/inline_entity_form updated from 1.0.0-rc14 to 1.0.0-rc15 patch

 - drupal/core-recommended updated from 9.4.11 to 9.4.13 patch
   See changes: https://github.com/drupal/core-recommended/compare/9.4.11...9.4.13
   Release notes: https://github.com/drupal/core-recommended/releases/tag/9.4.13

 - govcms/govcms updated from 2.28.0 to 2.29.0 minor
   See changes: https://github.com/govCMS/GovCMS/compare/2.28.0...2.29.0
   Release notes: https://github.com/govCMS/GovCMS/releases/tag/2.29.0

