### PR TITLE
[CIVIC-1438] Added site slogan settings.

### DIFF
--- a/docroot/themes/contrib/civictheme/config/install/civictheme.settings.yml
+++ b/docroot/themes/contrib/civictheme/config/install/civictheme.settings.yml
@@ -117,3 +117,4 @@ colors:
       success: '#14b0ae'
 migration:
   expose_metadata: false
+optouts: {  }

--- a/docroot/themes/contrib/civictheme/config/install/civictheme.settings.yml
+++ b/docroot/themes/contrib/civictheme/config/install/civictheme.settings.yml
@@ -62,8 +62,6 @@ components:
     summary_length: 160
   publication_card:
     summary_length: 160
-  site_slogan:
-    content: 'A design system by Salsa Digital'
 colors:
   use_color_selector: true
   use_brand_colors: true

--- a/docroot/themes/contrib/civictheme/config/install/civictheme.settings.yml
+++ b/docroot/themes/contrib/civictheme/config/install/civictheme.settings.yml
@@ -62,6 +62,8 @@ components:
     summary_length: 160
   publication_card:
     summary_length: 160
+  site_slogan:
+    content: 'A design system by Salsa Digital'
 colors:
   use_color_selector: true
   use_brand_colors: true

--- a/docroot/themes/contrib/civictheme/config/schema/civictheme.schema.yml
+++ b/docroot/themes/contrib/civictheme/config/schema/civictheme.schema.yml
@@ -173,6 +173,13 @@ civictheme.settings:
               type: sequence
               sequence:
                 type: string
+        site_slogan:
+          type: mapping
+          label: 'Site slogan setting'
+          mapping:
+            content:
+              label: 'Content'
+              type: string
         skip_link:
           type: mapping
           label: 'Skip Link settings'
@@ -375,3 +382,6 @@ civictheme.settings:
         expose_metadata:
           label: 'Expose migration metadata'
           type: boolean
+    optouts:
+      type: mapping
+      label: 'Opt-out flags'

--- a/docroot/themes/contrib/civictheme/config/schema/civictheme.schema.yml
+++ b/docroot/themes/contrib/civictheme/config/schema/civictheme.schema.yml
@@ -173,13 +173,6 @@ civictheme.settings:
               type: sequence
               sequence:
                 type: string
-        site_slogan:
-          type: mapping
-          label: 'Site slogan setting'
-          mapping:
-            content:
-              label: 'Content'
-              type: string
         skip_link:
           type: mapping
           label: 'Skip Link settings'

--- a/docroot/themes/contrib/civictheme/src/CivicthemeConfigManager.php
+++ b/docroot/themes/contrib/civictheme/src/CivicthemeConfigManager.php
@@ -125,14 +125,15 @@ class CivicthemeConfigManager implements ContainerInjectionInterface {
    *   Instance of the current class.
    */
   public function save($key, $value) {
-    $theme_name = $this->theme->getName();
-    $config = $this->configFactory->getEditable("$theme_name.settings");
-    $config->set($key, $value)->save();
-
     // Set site slogan.
     if ($key == 'components.site_slogan.content') {
       $config = $this->configFactory->getEditable('system.site')->set('slogan', $value)->save();
+      return $this;
     }
+
+    $theme_name = $this->theme->getName();
+    $config = $this->configFactory->getEditable("$theme_name.settings");
+    $config->set($key, $value)->save();
 
     return $this;
   }

--- a/docroot/themes/contrib/civictheme/src/CivicthemeConfigManager.php
+++ b/docroot/themes/contrib/civictheme/src/CivicthemeConfigManager.php
@@ -88,6 +88,11 @@ class CivicthemeConfigManager implements ContainerInjectionInterface {
    *   The value of the requested setting, NULL if the setting does not exist.
    */
   public function load($key, $default = NULL) {
+    // Return site slogan from system site settings.
+    if ($key == 'components.site_slogan.content') {
+      return $this->configFactory->getEditable('system.site')->get('slogan');
+    }
+
     return theme_get_setting($key, $this->theme->getName()) ?? $default;
   }
 
@@ -123,6 +128,11 @@ class CivicthemeConfigManager implements ContainerInjectionInterface {
     $theme_name = $this->theme->getName();
     $config = $this->configFactory->getEditable("$theme_name.settings");
     $config->set($key, $value)->save();
+
+    // Set site slogan.
+    if ($key == 'components.site_slogan.content') {
+      $config = $this->configFactory->getEditable('system.site')->set('slogan', $value)->save();
+    }
 
     return $this;
   }

--- a/docroot/themes/contrib/civictheme/src/Settings/CivicthemeSettingsFormSectionComponents.php
+++ b/docroot/themes/contrib/civictheme/src/Settings/CivicthemeSettingsFormSectionComponents.php
@@ -106,6 +106,22 @@ class CivicthemeSettingsFormSectionComponents extends CivicthemeSettingsFormSect
       '#default_value' => $this->themeConfigManager->load('components.logo.image_alt'),
     ];
 
+    $form['components']['site_slogan'] = [
+      '#type' => 'details',
+      '#title' => $this->t('Site slogan'),
+      '#group' => 'components',
+      '#tree' => TRUE,
+    ];
+
+    $form['components']['site_slogan']['content'] = [
+      '#title' => $this->t('Content'),
+      '#description' => $this->t('Set the site slogan.'),
+      '#type' => 'textfield',
+      '#required' => TRUE,
+      '#min' => 0,
+      '#default_value' => $this->themeConfigManager->load('components.site_slogan.content'),
+    ];
+
     $form['components']['header'] = [
       '#type' => 'details',
       '#title' => $this->t('Header'),
@@ -546,6 +562,16 @@ class CivicthemeSettingsFormSectionComponents extends CivicthemeSettingsFormSect
    */
   protected function externalLinkNormalizeDomain($domain) {
     return civictheme_external_link_normalize_domain($domain);
+  }
+
+  /**
+   * Submit callback for site slogan component.
+   *
+   * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+   */
+  public function submitSiteSlogan(array &$form, FormStateInterface $form_state) {
+    $slogan = $form_state->getValue(['components', 'site_slogan', 'content']);
+    $this->themeConfigManager->save('components.site_slogan.content', $slogan);
   }
 
 }

--- a/tests/behat/features/theme.settings.components.feature
+++ b/tests/behat/features/theme.settings.components.feature
@@ -60,6 +60,10 @@ Feature: Components settings are available in the theme settings
     And I should see an "input[name='components[header][theme]']" element
     And I should see an "#edit-components-header-theme--wrapper.required" element
 
+    And I should see the text "Content"
+    And I should see an "input[name='components[site_slogan][content]']" element
+    And I should see an "#edit-components-site-slogan-content.required" element
+
     And I should see the text "Theme"
     And I should see an "input[name='components[footer][theme]']" element
     And I should see an "#edit-components-footer-theme--wrapper.required" element
@@ -250,6 +254,24 @@ Feature: Components settings are available in the theme settings
     Then I should see the text "The configuration options have been saved."
     And I go to the homepage
     And I should see a ".ct-skip-link.ct-theme-dark" element
+
+    # Reset settings.
+    When I visit current theme settings page
+    And I check the box "Confirm settings reset"
+    And I press "reset_to_defaults"
+    Then I should see the text "Theme configuration was reset to defaults."
+
+  @api
+  Scenario: The CivicTheme theme settings to set site slogan.
+    Given I am logged in as a user with the "Site Administrator" role
+
+    When I visit current theme settings page
+    When I fill in "components[site_slogan][content]" with "A design system by Salsa Digital - Updated"
+    And I press "Save configuration"
+    Then I should see the text "The configuration options have been saved."
+
+    And I go to the homepage
+    And I should see the text "A design system by Salsa Digital - Updated"
 
     # Reset settings.
     When I visit current theme settings page


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have formatted the subject to include ticket number as `[CIVIC-123] Verb in past tense with dot at the end.`
- [x] I have added a link to the JIRA ticket
- [ ] I have provided information in `Changed` section about WHY something was done if this was not a normal implementation
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run new and existing relevant tests locally with my changes, and they passed
- [ ] I have provided screenshots, where applicable

https://salsadigital.atlassian.net/browse/CIVIC-1438

## Changed
1. Site slogan settings component in the theme settings page.

## Screenshots
![Screenshot 2023-06-12 at 3 32 26 PM](https://github.com/salsadigitalauorg/civictheme_source/assets/4437018/c54ef358-380b-46fd-b3ab-729f37b3a867)
![Screenshot 2023-06-12 at 3 32 38 PM](https://github.com/salsadigitalauorg/civictheme_source/assets/4437018/39161824-6203-4b59-8f72-eb84ba4562b2)
![Screenshot 2023-06-12 at 3 33 04 PM](https://github.com/salsadigitalauorg/civictheme_source/assets/4437018/f2e1450f-0605-4149-8c3c-a327feb341cf)
![Screenshot 2023-06-12 at 3 33 13 PM](https://github.com/salsadigitalauorg/civictheme_source/assets/4437018/3a27cf30-6ce1-40ae-9f74-b8566942be4f)
![Screenshot 2023-06-12 at 3 33 27 PM](https://github.com/salsadigitalauorg/civictheme_source/assets/4437018/4e70fccd-664d-40de-a6f1-4ba2185f9ea9)
