### PR TITLE
Added D10 compatibility for civictheme_govcms module.

### DIFF
--- a/docroot/modules/custom/civictheme_govcms/civictheme_govcms.info.yml
+++ b/docroot/modules/custom/civictheme_govcms/civictheme_govcms.info.yml
@@ -1,7 +1,7 @@
 name: 'CivicTheme GovCMS'
 type: module
 description: 'GovCMS adjustments for CivicTheme theme.'
-core_version_requirement: ^9
+core_version_requirement: ^9 | ^10
 package: CivicTheme
 dependencies:
   - govcms:govcms

--- a/docroot/modules/custom/civictheme_govcms/composer.json
+++ b/docroot/modules/custom/civictheme_govcms/composer.json
@@ -9,7 +9,7 @@
     },
     "require": {
         "php": ">=8",
-        "govcms/govcms": "^2.28"
+        "govcms/govcms": ">=2.28"
     },
     "extra": {
         "drush": {


### PR DESCRIPTION
GovCMS released D10 version now: https://github.com/govCMS/GovCMS/releases/tag/3.2.0
However, `civictheme_govcms` version constraint conflicts with that release.

## Checklist before requesting a review

- [ ] I have formatted the subject to include ticket number as `[CIVIC-123] Verb in past tense with dot at the end.`
- [ ] I have added a link to the JIRA ticket
- [x] I have provided information in `Changed` section about WHY something was done if this was not a normal implementation
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have run new and existing relevant tests locally with my changes, and they passed
- [ ] I have provided screenshots, where applicable

## Changed
1. Added D10 compatibility to civictheme_govcms module

## Screenshots
