### PR TITLE
Updated site slogan in theme settings to be not required.

### DIFF
--- a/docroot/themes/contrib/civictheme/src/Settings/CivicthemeSettingsFormSectionComponents.php
+++ b/docroot/themes/contrib/civictheme/src/Settings/CivicthemeSettingsFormSectionComponents.php
@@ -119,7 +119,7 @@ class CivicthemeSettingsFormSectionComponents extends CivicthemeSettingsFormSect
       '#title' => $this->t('Content'),
       '#description' => $this->t('Set the site slogan.'),
       '#type' => 'textfield',
-      '#required' => TRUE,
+      '#required' => FALSE,
       '#min' => 0,
       '#default_value' => $this->themeConfigManager->load('components.site_slogan.content'),
     ];

--- a/tests/behat/features/theme.settings.components.feature
+++ b/tests/behat/features/theme.settings.components.feature
@@ -62,7 +62,7 @@ Feature: Components settings are available in the theme settings
 
     And I should see the text "Content"
     And I should see an "input[name='components[site_slogan][content]']" element
-    And I should see an "#edit-components-site-slogan-content.required" element
+    And I should not see an "#edit-components-site-slogan-content.required" element
 
     And I should see the text "Theme"
     And I should see an "input[name='components[footer][theme]']" element


### PR DESCRIPTION
The Slogan field in the theme settings should not be required as not every site may have a slogan.