### PR TITLE
[CIVIC-1449] Fixed Automated list filters not being hidden.

### DIFF
--- a/tests/behat/features/paragraph.civictheme_automated_list.render.feature
+++ b/tests/behat/features/paragraph.civictheme_automated_list.render.feature
@@ -284,3 +284,57 @@ Feature: Automated list render
     And I see field "Title"
     And should see an "input[name='title']" element
     And should not see an "input[name='title'].required" element
+
+  @api @testmode
+  Scenario: Automated list, All filters selected
+    Given "civictheme_page" content:
+      | title          | created            | status |
+      | [TEST] Page 18 | [relative:-5 days] | 1      |
+      | [TEST] Page 19 | [relative:-5 days] | 1      |
+
+    And "field_c_n_components" in "civictheme_page" "node" with "title" of "Test page with Automated list content" has "civictheme_automated_list" paragraph:
+      | field_c_p_title            | [TEST] Automated list title |
+      | field_c_p_list_limit_type  | unlimited                   |
+      | field_c_p_list_filters_exp | title, topic, type          |
+
+    When I visit "civictheme_page" "Test page with Automated list content"
+    Then I should see an ".ct-list__filters" element
+    And I should see an ".ct-group-filter__filters .ct-form-element--topic" element
+    And I should see an ".ct-group-filter__filters .ct-form-element--type" element
+    And I should see an ".ct-group-filter__filters .ct-form-element--title" element
+
+  @api @testmode
+  Scenario: Automated list, No filters selected
+    Given "civictheme_page" content:
+      | title          | created            | status |
+      | [TEST] Page 20 | [relative:-5 days] | 1      |
+      | [TEST] Page 21 | [relative:-5 days] | 1      |
+
+    And "field_c_n_components" in "civictheme_page" "node" with "title" of "Test page with Automated list content" has "civictheme_automated_list" paragraph:
+      | field_c_p_title            | [TEST] Automated list title |
+      | field_c_p_list_limit_type  | unlimited                   |
+      | field_c_p_list_filters_exp |                             |
+
+    When I visit "civictheme_page" "Test page with Automated list content"
+    Then I should not see an ".ct-list__filters" element
+    And I should not see an ".ct-group-filter__filters .ct-form-element--topic" element
+    And I should not see an ".ct-group-filter__filters .ct-form-element--type" element
+    And I should not see an ".ct-group-filter__filters .ct-form-element--title" element
+
+  @api @testmode
+  Scenario: Automated list, Some filters selected
+    Given "civictheme_page" content:
+      | title          | created            | status |
+      | [TEST] Page 22 | [relative:-5 days] | 1      |
+      | [TEST] Page 23 | [relative:-5 days] | 1      |
+
+    And "field_c_n_components" in "civictheme_page" "node" with "title" of "Test page with Automated list content" has "civictheme_automated_list" paragraph:
+      | field_c_p_title            | [TEST] Automated list title |
+      | field_c_p_list_limit_type  | unlimited                   |
+      | field_c_p_list_filters_exp | title, topic                |
+
+    When I visit "civictheme_page" "Test page with Automated list content"
+    Then I should see an ".ct-list__filters" element
+    And I should see an ".ct-group-filter__filters .ct-form-element--topic" element
+    And I should not see an ".ct-group-filter__filters .ct-form-element--type" element
+    And I should see an ".ct-group-filter__filters .ct-form-element--title" element

--- a/tests/behat/features/paragraph.civictheme_automated_list.render.feature
+++ b/tests/behat/features/paragraph.civictheme_automated_list.render.feature
@@ -285,14 +285,9 @@ Feature: Automated list render
     And should see an "input[name='title']" element
     And should not see an "input[name='title'].required" element
 
-  @api @testmode
-  Scenario: Automated list, All filters selected
-    Given "civictheme_page" content:
-      | title          | created            | status |
-      | [TEST] Page 18 | [relative:-5 days] | 1      |
-      | [TEST] Page 19 | [relative:-5 days] | 1      |
-
-    And "field_c_n_components" in "civictheme_page" "node" with "title" of "Test page with Automated list content" has "civictheme_automated_list" paragraph:
+  @api
+  Scenario: Automated list, all filters shown
+    Given "field_c_n_components" in "civictheme_page" "node" with "title" of "Test page with Automated list content" has "civictheme_automated_list" paragraph:
       | field_c_p_title            | [TEST] Automated list title |
       | field_c_p_list_limit_type  | unlimited                   |
       | field_c_p_list_filters_exp | title, topic, type          |
@@ -303,14 +298,9 @@ Feature: Automated list render
     And I should see an ".ct-group-filter__filters .ct-form-element--type" element
     And I should see an ".ct-group-filter__filters .ct-form-element--title" element
 
-  @api @testmode
-  Scenario: Automated list, No filters selected
-    Given "civictheme_page" content:
-      | title          | created            | status |
-      | [TEST] Page 20 | [relative:-5 days] | 1      |
-      | [TEST] Page 21 | [relative:-5 days] | 1      |
-
-    And "field_c_n_components" in "civictheme_page" "node" with "title" of "Test page with Automated list content" has "civictheme_automated_list" paragraph:
+  @api
+  Scenario: Automated list, no filters shown
+    Given "field_c_n_components" in "civictheme_page" "node" with "title" of "Test page with Automated list content" has "civictheme_automated_list" paragraph:
       | field_c_p_title            | [TEST] Automated list title |
       | field_c_p_list_limit_type  | unlimited                   |
       | field_c_p_list_filters_exp |                             |
@@ -321,14 +311,9 @@ Feature: Automated list render
     And I should not see an ".ct-group-filter__filters .ct-form-element--type" element
     And I should not see an ".ct-group-filter__filters .ct-form-element--title" element
 
-  @api @testmode
-  Scenario: Automated list, Some filters selected
-    Given "civictheme_page" content:
-      | title          | created            | status |
-      | [TEST] Page 22 | [relative:-5 days] | 1      |
-      | [TEST] Page 23 | [relative:-5 days] | 1      |
-
-    And "field_c_n_components" in "civictheme_page" "node" with "title" of "Test page with Automated list content" has "civictheme_automated_list" paragraph:
+  @api
+  Scenario: Automated list, some filters shown
+    Given "field_c_n_components" in "civictheme_page" "node" with "title" of "Test page with Automated list content" has "civictheme_automated_list" paragraph:
       | field_c_p_title            | [TEST] Automated list title |
       | field_c_p_list_limit_type  | unlimited                   |
       | field_c_p_list_filters_exp | title, topic                |

--- a/web/themes/contrib/civictheme/includes/automated_list.inc
+++ b/web/themes/contrib/civictheme/includes/automated_list.inc
@@ -194,17 +194,15 @@ function _civictheme_automated_list__update_view(ViewExecutable $view): void {
   }
 
   // Exposed filters.
-  $exposed_filter = explode(', ', $settings['filters_exp']);
-  $show_filters = !empty(array_filter($exposed_filter));
+  $exposed_filters = explode(', ', $settings['filters_exp']);
+  $show_filters = count($exposed_filters) > 0;
 
   if ($show_filters) {
     // Disable filters based on the component settings.
     $view_filters = $view->display_handler->getOption('filters');
-    foreach ($view_filters as $key => $filter) {
-      if (isset($filter['exposed']) &&
-        $filter['exposed'] &&
-        !in_array($filter['expose']['identifier'], $exposed_filter)) {
-        unset($view_filters[$key]);
+    foreach ($view_filters as $filter_identifier => $filter) {
+      if (!empty($filter['exposed']) && !in_array($filter['expose']['identifier'], $exposed_filters)) {
+        unset($view_filters[$filter_identifier]);
       }
     }
     $view->display_handler->setOption('filters', $view_filters);

--- a/web/themes/contrib/civictheme/includes/automated_list.inc
+++ b/web/themes/contrib/civictheme/includes/automated_list.inc
@@ -193,9 +193,23 @@ function _civictheme_automated_list__update_view(ViewExecutable $view): void {
     $view->display_handler->setOption('row', $view_mode_options);
   }
 
-  // @todo Implement hiding of the filters that were not selected.
-  $show_filters = !empty(array_filter(explode(', ', $settings['filters_exp'])));
-  if (!$show_filters) {
+  // Exposed filters.
+  $exposed_filter = explode(', ', $settings['filters_exp']);
+  $show_filters = !empty(array_filter($exposed_filter));
+
+  if ($show_filters) {
+    // Disable filters based on the component settings.
+    $view_filters = $view->display_handler->getOption('filters');
+    foreach ($view_filters as $key => $filter) {
+      if (isset($filter['exposed']) &&
+        $filter['exposed'] &&
+        !in_array($filter['expose']['identifier'], $exposed_filter)) {
+        unset($view_filters[$key]);
+      }
+    }
+    $view->display_handler->setOption('filters', $view_filters);
+  }
+  else {
     $view->display_handler->has_exposed = FALSE;
   }
 

--- a/web/themes/contrib/civictheme/includes/automated_list.inc
+++ b/web/themes/contrib/civictheme/includes/automated_list.inc
@@ -194,15 +194,14 @@ function _civictheme_automated_list__update_view(ViewExecutable $view): void {
   }
 
   // Exposed filters.
-  $exposed_filters = explode(', ', $settings['filters_exp']);
-  $show_filters = count($exposed_filters) > 0;
-
+  $exposed_filters = array_filter(explode(', ', $settings['filters_exp'] ?? ''));
+  $show_filters = !empty($exposed_filters);
   if ($show_filters) {
     // Disable filters based on the component settings.
     $view_filters = $view->display_handler->getOption('filters');
-    foreach ($view_filters as $filter_identifier => $filter) {
-      if (!empty($filter['exposed']) && !in_array($filter['expose']['identifier'], $exposed_filters)) {
-        unset($view_filters[$filter_identifier]);
+    foreach ($view_filters as $view_filter_id => $view_filter) {
+      if (!empty($view_filter['exposed']) && !in_array($view_filter['expose']['identifier'], $exposed_filters)) {
+        unset($view_filters[$view_filter_id]);
       }
     }
     $view->display_handler->setOption('filters', $view_filters);


### PR DESCRIPTION
https://salsadigital.atlassian.net/browse/CIVIC-1449

## Checklist before requesting a review

- [x] I have formatted the subject to include ticket number as `[CS-123] Verb in past tense with dot at the end.`
- [x] I have added a link to the issue tracker
- [x] I have provided information in `Changed` section about WHY something was done if this was not a normal implementation
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run new and existing relevant tests locally with my 
changes, and they passed
- [x] I have provided screenshots, where applicable

## Changed

1. Based on the component setting unset the view filter for automated list

## Screenshots
<img width="826" alt="Screenshot 2023-11-28 at 10 05 49 AM" src="https://github.com/salsadigitalauorg/civictheme_source/assets/3881627/a5048200-ab9b-4c3f-9849-9dce673f6995">

<img width="625" alt="Screenshot 2023-11-28 at 10 06 06 AM" src="https://github.com/salsadigitalauorg/civictheme_source/assets/3881627/ac584ada-913b-475f-be96-cd2b18cba933">
