### PR TITLE
Fixed missing default theme value to default to 'light'.

### DIFF
--- a/web/themes/contrib/civictheme/includes/utilities.inc
+++ b/web/themes/contrib/civictheme/includes/utilities.inc
@@ -462,13 +462,13 @@ function civictheme_get_entity_field_key_values(FieldableEntityInterface $entity
  * @param \Drupal\Core\Entity\FieldableEntityInterface|null $entity
  *   Entity to check field existence.
  * @param string $default
- *   Optional default theme value. Defaults to NULL.
+ *   Optional default theme value. Defaults to CivicthemeConstants::THEME_LIGHT.
  *
  * @return string
  *   The theme field value for the entity.
  *   If field does not have a value - $default is returned.
  */
-function civictheme_get_field_theme_value(FieldableEntityInterface|null $entity, string $default = NULL): string {
+function civictheme_get_field_theme_value(FieldableEntityInterface|null $entity, string $default = CivicthemeConstants::THEME_LIGHT): string {
   $field_name = FALSE;
 
   if (!$entity instanceof FieldableEntityInterface) {


### PR DESCRIPTION
When retrieving a theme value from the component, a default value may be provided to be returned if the component does not have it's theme value set (in case of incorrectly programmatically-created components). 

In case where a default value is not provided, this leads to empty theme value being propagated to descendant components.