### PR TITLE
Issue #3409009 by alex.skrypnyk: Add summary settings for Snippet component.

### DIFF
--- a/web/themes/contrib/civictheme/config/schema/civictheme.schema.yml
+++ b/web/themes/contrib/civictheme/config/schema/civictheme.schema.yml
@@ -208,6 +208,13 @@ civictheme.settings:
             summary_length:
               label: 'Summary length'
               type: integer
+        snippet:
+          type: mapping
+          label: 'Snippet settings'
+          mapping:
+            summary_length:
+              label: 'Summary length'
+              type: integer
     colors:
       type: mapping
       label: Colors

--- a/web/themes/contrib/civictheme/includes/paragraphs.inc
+++ b/web/themes/contrib/civictheme/includes/paragraphs.inc
@@ -212,11 +212,11 @@ function _civictheme_preprocess_paragraph__paragraph_field__links(array &$variab
 function _civictheme_preprocess_paragraph__paragraph_field__summary(array &$variables): void {
   $summary = civictheme_get_field_value($variables['paragraph'], 'field_c_p_summary', TRUE);
   if (!empty($summary)) {
-    $length = CivicthemeConstants::CARD_SUMMARY_DEFAULT_LENGTH;
+    $length = CivicthemeConstants::COMPONENT_SUMMARY_DEFAULT_LENGTH;
 
-    $card_name = _civictheme_get_card_name_from_bundle($variables['paragraph']->bundle());
-    if ($card_name) {
-      $length = civictheme_get_theme_config_manager()->loadForComponent($card_name, 'summary_length', CivicthemeConstants::CARD_SUMMARY_DEFAULT_LENGTH);
+    $component_name = _civictheme_get_configurable_component_name_from_bundle($variables['paragraph']->bundle());
+    if ($component_name) {
+      $length = civictheme_get_theme_config_manager()->loadForComponent($component_name, 'summary_length', CivicthemeConstants::COMPONENT_SUMMARY_DEFAULT_LENGTH);
     }
 
     $variables['summary'] = text_summary($summary, NULL, $length);
@@ -231,11 +231,11 @@ function _civictheme_preprocess_paragraph__node_field__summary(array &$variables
   if ($node) {
     $summary = civictheme_get_field_value($node, 'field_c_n_summary', TRUE);
     if (!empty($summary)) {
-      $length = CivicthemeConstants::CARD_SUMMARY_DEFAULT_LENGTH;
+      $length = CivicthemeConstants::COMPONENT_SUMMARY_DEFAULT_LENGTH;
 
-      $card_name = _civictheme_get_card_name_from_bundle($bundle ?? (!empty($variables['paragraph']) ? $variables['paragraph']->bundle() : 'none'));
-      if ($card_name) {
-        $length = civictheme_get_theme_config_manager()->loadForComponent($card_name, 'summary_length', CivicthemeConstants::CARD_SUMMARY_DEFAULT_LENGTH);
+      $component_name = _civictheme_get_configurable_component_name_from_bundle($bundle ?? (!empty($variables['paragraph']) ? $variables['paragraph']->bundle() : 'none'));
+      if ($component_name) {
+        $length = civictheme_get_theme_config_manager()->loadForComponent($component_name, 'summary_length', CivicthemeConstants::COMPONENT_SUMMARY_DEFAULT_LENGTH);
       }
 
       $variables['summary'] = text_summary($summary, NULL, $length);

--- a/web/themes/contrib/civictheme/includes/snippet.inc
+++ b/web/themes/contrib/civictheme/includes/snippet.inc
@@ -36,7 +36,7 @@ function civictheme_preprocess_paragraph__civictheme_snippet_ref(array &$variabl
  */
 function _civictheme_preprocess_node__civictheme_snippet(array &$variables): void {
   _civictheme_preprocess_paragraph__node_field__title($variables);
-  _civictheme_preprocess_paragraph__node_field__summary($variables);
+  _civictheme_preprocess_paragraph__node_field__summary($variables, $variables['view_mode'] ?? 'civictheme_snippet');
   _civictheme_preprocess_paragraph__node_field__link($variables);
   _civictheme_preprocess_paragraph__node_field__topics($variables);
   // @see civictheme_preprocess_views_view_grid()

--- a/web/themes/contrib/civictheme/includes/utilities.inc
+++ b/web/themes/contrib/civictheme/includes/utilities.inc
@@ -725,10 +725,12 @@ function civictheme_external_link_normalize_domain(string $domain): string {
 }
 
 /**
- * Extract card name from card and reference card paragraph bundles.
+ * Extract a configurable component name from a paragraph bundle.
  */
-function _civictheme_get_card_name_from_bundle(string $bundle): ?string {
-  if (preg_match('/civictheme_(.*_card).*/', $bundle, $matches)) {
+function _civictheme_get_configurable_component_name_from_bundle(string $bundle): ?string {
+  // Accommodate for existing and additional components that could be added in
+  // the sub-themes.
+  if (preg_match('/civictheme_(.*_card|.*_?snippet).*/', $bundle, $matches)) {
     if (!empty($matches[1])) {
       return $matches[1];
     }

--- a/web/themes/contrib/civictheme/src/CivicthemeConstants.php
+++ b/web/themes/contrib/civictheme/src/CivicthemeConstants.php
@@ -147,7 +147,16 @@ final class CivicthemeConstants {
   const NAVIGATION_DROPDOWN_DRAWER = 'drawer';
 
   /**
+   * Defines component summary length.
+   */
+  const COMPONENT_SUMMARY_DEFAULT_LENGTH = 160;
+
+  /**
    * Defines card summary length.
+   *
+   * @deprecated in civictheme:1.6.2 and is removed from civicthtme:1.8.0.
+   * Replaceed by COMPONENT_SUMMARY_DEFAULT_LENGTH.
+   * @see https://www.drupal.org/project/civictheme/issues/3409009
    */
   const CARD_SUMMARY_DEFAULT_LENGTH = 160;
 

--- a/web/themes/contrib/civictheme/src/Settings/CivicthemeSettingsFormSectionComponents.php
+++ b/web/themes/contrib/civictheme/src/Settings/CivicthemeSettingsFormSectionComponents.php
@@ -352,7 +352,7 @@ class CivicthemeSettingsFormSectionComponents extends CivicthemeSettingsFormSect
       '#type' => 'number',
       '#required' => TRUE,
       '#min' => 0,
-      '#default_value' => $this->themeConfigManager->loadForComponent('event_card', 'summary_length', CivicthemeConstants::CARD_SUMMARY_DEFAULT_LENGTH),
+      '#default_value' => $this->themeConfigManager->loadForComponent('event_card', 'summary_length', CivicthemeConstants::COMPONENT_SUMMARY_DEFAULT_LENGTH),
     ];
 
     $form['components']['navigation_card'] = [
@@ -368,23 +368,7 @@ class CivicthemeSettingsFormSectionComponents extends CivicthemeSettingsFormSect
       '#type' => 'number',
       '#required' => TRUE,
       '#min' => 0,
-      '#default_value' => $this->themeConfigManager->loadForComponent('navigation_card', 'summary_length', CivicthemeConstants::CARD_SUMMARY_DEFAULT_LENGTH),
-    ];
-
-    $form['components']['publication_card'] = [
-      '#type' => 'details',
-      '#title' => $this->t('Publication card'),
-      '#group' => 'components',
-      '#tree' => TRUE,
-    ];
-
-    $form['components']['publication_card']['summary_length'] = [
-      '#title' => $this->t('Summary length'),
-      '#description' => $this->t('Set the length of the Summary field: the content will be trimmed to this length and ellipsis will be added. Set to 0 for no limit.'),
-      '#type' => 'number',
-      '#required' => TRUE,
-      '#min' => 0,
-      '#default_value' => $this->themeConfigManager->loadForComponent('publication_card', 'summary_length', CivicthemeConstants::CARD_SUMMARY_DEFAULT_LENGTH),
+      '#default_value' => $this->themeConfigManager->loadForComponent('navigation_card', 'summary_length', CivicthemeConstants::COMPONENT_SUMMARY_DEFAULT_LENGTH),
     ];
 
     $form['components']['promo_card'] = [
@@ -400,7 +384,39 @@ class CivicthemeSettingsFormSectionComponents extends CivicthemeSettingsFormSect
       '#type' => 'number',
       '#required' => TRUE,
       '#min' => 0,
-      '#default_value' => $this->themeConfigManager->loadForComponent('promo_card', 'summary_length', CivicthemeConstants::CARD_SUMMARY_DEFAULT_LENGTH),
+      '#default_value' => $this->themeConfigManager->loadForComponent('promo_card', 'summary_length', CivicthemeConstants::COMPONENT_SUMMARY_DEFAULT_LENGTH),
+    ];
+
+    $form['components']['publication_card'] = [
+      '#type' => 'details',
+      '#title' => $this->t('Publication card'),
+      '#group' => 'components',
+      '#tree' => TRUE,
+    ];
+
+    $form['components']['publication_card']['summary_length'] = [
+      '#title' => $this->t('Summary length'),
+      '#description' => $this->t('Set the length of the Summary field: the content will be trimmed to this length and ellipsis will be added. Set to 0 for no limit.'),
+      '#type' => 'number',
+      '#required' => TRUE,
+      '#min' => 0,
+      '#default_value' => $this->themeConfigManager->loadForComponent('publication_card', 'summary_length', CivicthemeConstants::COMPONENT_SUMMARY_DEFAULT_LENGTH),
+    ];
+
+    $form['components']['snippet'] = [
+      '#type' => 'details',
+      '#title' => $this->t('Snippet'),
+      '#group' => 'components',
+      '#tree' => TRUE,
+    ];
+
+    $form['components']['snippet']['summary_length'] = [
+      '#title' => $this->t('Summary length'),
+      '#description' => $this->t('Set the length of the Summary field: the content will be trimmed to this length and ellipsis will be added. Set to 0 for no limit.'),
+      '#type' => 'number',
+      '#required' => TRUE,
+      '#min' => 0,
+      '#default_value' => $this->themeConfigManager->loadForComponent('snippet', 'summary_length', CivicthemeConstants::COMPONENT_SUMMARY_DEFAULT_LENGTH),
     ];
 
     $form['#process'][] = [$this, 'processForm'];


### PR DESCRIPTION
https://www.drupal.org/project/civictheme/issues/3409009

## Checklist before requesting a review

- [x] I have formatted the subject to include ticket number as `[CS-123] Verb in past tense with dot at the end.`
- [x] I have added a link to the issue tracker
- [x] I have provided information in `Changed` section about WHY something was done if this was not a normal implementation
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have run new and existing relevant tests locally with my changes, and they passed
- [ ] I have provided screenshots, where applicable

## Changed

1. Added summary settings for Snippet component.
2. Added an ability to use settings for other Snippet-base components (`civictheme_my_snippet`, `civictheme_my__other_snippet` etc.) if extended in sub-themes.
3. Fixed summary settings for cards not being correctly passed in views Rows style.

