### PR TITLE
Issue #3381798 by alexskrypnyk, sonnykt, joshua1234511, richardgaunt: Drupal.org: Missing class Civictheme unset($variables['attributes']['class'])

### DIFF
--- a/web/themes/contrib/civictheme/includes/form_element.inc
+++ b/web/themes/contrib/civictheme/includes/form_element.inc
@@ -308,25 +308,11 @@ function _civictheme_preprocess_form_element__generic(array &$variables): void {
 function _civictheme_preprocess_form_element__control(array &$variables): void {
   $element = $variables['element'];
 
-  $allowed_attributes = ['size', 'maxlength', 'rows', 'autocomplete'];
-
   $attributes = [];
-
-  $allowed_attributes_map = array_map(function ($attribute) {
-    return '#' . $attribute;
-  }, $allowed_attributes);
-
-  foreach ($allowed_attributes_map as $key) {
-    if (isset($element[$key])) {
-      $attributes[substr($key, 1)] = $element[$key];
-    }
-  }
 
   if (!empty($element['#attributes']) && is_iterable($element['#attributes'])) {
     foreach ($element['#attributes'] as $key => $value) {
-      if (str_starts_with($key, 'data') || in_array($key, $allowed_attributes)) {
-        $attributes[$key] = is_array($value) ? implode(' ', $value) : $value;
-      }
+      $attributes[$key] = is_array($value) ? implode(' ', $value) : $value;
     }
   }
   $attributes_string = implode(' ', array_map(function ($key, $value) {

--- a/web/themes/contrib/civictheme/includes/utilities.inc
+++ b/web/themes/contrib/civictheme/includes/utilities.inc
@@ -319,9 +319,6 @@ function civictheme_convert_attributes_to_modifier_class(array &$variables): voi
   $attributes = new Attribute($variables['attributes']);
   civictheme_add_modifier_class($variables, $attributes->getClass()->value());
 
-  // Remove class from attributes to avoid duplicated 'class' attribute on
-  // the element.
-  unset($variables['attributes']['class']);
 }
 
 /**


### PR DESCRIPTION
https://www.drupal.org/project/civictheme/issues/3381798

## Checklist before requesting a review

- [ ] I have formatted the subject to include ticket number as `Issue #123456 by drupal_org_username: Issue title`
- [ ] I have added a link to the issue tracker
- [ ] I have provided information in `Changed` section about WHY something was done if this was not a normal implementation
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run new and existing relevant tests locally with my changes, and they passed
- [ ] I have provided screenshots, where applicable

## Changed

1.

## Screenshots
