### PR TITLE
Issue #3527810 by richardgaunt, fionamorrison23, joshua1234511: Site is broken when trying to view a node that references an archived webform

### DIFF
--- a/web/themes/contrib/civictheme/templates/misc/status-messages.html.twig
+++ b/web/themes/contrib/civictheme/templates/misc/status-messages.html.twig
@@ -8,7 +8,7 @@
   {% for message in messages %}
     {% include 'civictheme:message' with {
       title: status_headings[type] ? status_headings[type] : type|capitalize,
-      description: message|render,
+      content: message|render,
       type: (type == 'status' or type == 'info') ? 'information' : type,
       vertical_spacing: 'both',
     } only %}


### PR DESCRIPTION
https://www.drupal.org/project/civictheme/issues/3527810

## Checklist before requesting a review

- [x] I have formatted the subject to include ticket number as `Issue #123456 by drupal_org_username: Issue title`
- [x] I have added a link to the issue tracker
- [x] I have provided information in `Changed` section about WHY something was done if this was not a normal implementation
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run new and existing relevant tests locally with my changes, and they passed
- [x] I have provided screenshots, where applicable

## Changed

1. Updated to pass correct variable to the template.

## Screenshots
Admin 
<img width="1259" height="659" alt="Screenshot 2025-08-05 at 1 35 33 PM" src="https://github.com/user-attachments/assets/d1a0274a-77d1-471b-b4ad-7de211f28912" />

Non Admin 
<img width="1129" height="732" alt="Screenshot 2025-08-05 at 1 35 29 PM" src="https://github.com/user-attachments/assets/ce8ebcfb-e9b0-446a-9933-e4994c64d6a3" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the status messages template to use a different key name when displaying messages. No visible changes to the appearance or behavior for end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->