### PR TITLE
Issue #3525185 by anirudhsingh19: Expose banner type as a variable

### DIFF
--- a/web/themes/contrib/civictheme/includes/banner.inc
+++ b/web/themes/contrib/civictheme/includes/banner.inc
@@ -71,8 +71,6 @@ function _civictheme_preprocess_block__civictheme_banner(array &$variables): voi
   $variables['#cache']['contexts'][] = 'url.path';
   $variables['#cache']['contexts'][] = 'url.query_args';
 
-  // 'type' is internal field and should not be passed to the template.
-  unset($variables['type']);
   // 'attributes' field includes an id which conflicts with the template
   // `main-content` id.
   unset($variables['attributes']);


### PR DESCRIPTION
## Checklist before requesting a review

- [ done] I have formatted the subject to include ticket number as `Issue #123456 by drupal_org_username: Issue title`
- [ done] I have added a link to the issue tracker
- [ done] I have provided information in `Changed` section about WHY something was done if this was not a normal implementation
- [ done] I have performed a self-review of my code
- [ N/A] I have commented my code, particularly in hard-to-understand areas
- [N/A ] I have added tests that prove my fix is effective or that my feature works
- [N/A ] I have run new and existing relevant tests locally with my changes, and they passed
- [ N/A] I have provided screenshots, where applicable

Issue link: https://www.drupal.org/project/civictheme/issues/3525185 
## Changed

1. This was done to expose the type variable to the template as it could be useful.

## Screenshots


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected banner behavior by ensuring its “type” is preserved during rendering, restoring expected variants and decorative states.
  * Fixes issues where banners could render with incorrect styling or logic, improving visual consistency.
  * Enhances accessibility by allowing decorative banners to be properly identified and treated by downstream logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->