### PR TITLE
[#3563874] Updated check for when menu item titles are render arrays.

### DIFF
--- a/web/themes/contrib/civictheme/includes/menu.inc
+++ b/web/themes/contrib/civictheme/includes/menu.inc
@@ -15,6 +15,7 @@ use Drupal\Core\Url;
  *
  * @SuppressWarnings(PHPMD.BooleanArgumentFlag)
  * @SuppressWarnings(PHPMD.StaticAccess)
+ * @SuppressWarnings(PHPMD.ElseExpression)
  */
 function _civictheme_preprocess_menu_items(array &$items, bool $expand_all = FALSE): void {
   foreach ($items as &$item) {
@@ -27,7 +28,12 @@ function _civictheme_preprocess_menu_items(array &$items, bool $expand_all = FAL
     $item['is_expanded'] = $expand_all || ($item['is_expanded'] ?? FALSE);
     // Initialize 'below' as an empty array if not set.
     $item['below'] = $item['below'] ?? [];
-    $item['title'] = isset($item['title']) ? strip_tags($item['title']) : '';
+    if (isset($item['title'])) {
+      $item['title'] = is_string($item['title']) ? strip_tags($item['title']) : $item['title'];
+    }
+    else {
+      $item['title'] = '';
+    }
 
     if (!empty($item['below'])) {
       _civictheme_preprocess_menu_items($item['below'], $expand_all);


### PR DESCRIPTION
## JIRA ticket: [#3563874](https://www.drupal.org/project/civictheme/issues/3563874)

## Checklist before requesting a review

- [x] I have formatted the subject to include ticket number as 
- [x] I have added a link to the issue tracker
- [x] I have provided information in  section about WHY something was done if this was not a normal implementation
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run new and existing relevant tests locally with my changes, and they passed
- [ ] I have provided screenshots, where applicable

## Changed
1. Check for menu item to be an array.

## Background

Comes from this conversation thread: https://drupal.slack.com/archives/C039UV0CQBZ/p1765788174230759?thread_ts=1765470743.227649&cid=C039UV0CQBZ

## Screenshots


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Normalized menu item title handling: strips HTML from string titles, preserves non-string values, and sets a default empty title when missing to prevent warnings and ensure consistent behavior across menu items. Improves menu rendering stability. No public interface changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->