### PR TITLE
Issue #3525932 by iulianrotaru,  fionamorrison23, cb: Summary length help text incorrect on card settings

### DIFF
--- a/web/themes/contrib/civictheme/src/Settings/CivicthemeSettingsFormSectionComponents.php
+++ b/web/themes/contrib/civictheme/src/Settings/CivicthemeSettingsFormSectionComponents.php
@@ -353,7 +353,7 @@ class CivicthemeSettingsFormSectionComponents extends CivicthemeSettingsFormSect
 
     $form['components']['event_card']['summary_length'] = [
       '#title' => $this->t('Summary length'),
-      '#description' => $this->t('Set the length of the Summary field: the content will be trimmed to this length and ellipsis will be added. Set to 0 for no limit.'),
+      '#description' => $this->t('Set the length of the Summary field: the content will be trimmed to this length and ellipsis will be added. Set to 0 to never show a summary on event cards.'),
       '#type' => 'number',
       '#required' => TRUE,
       '#min' => 0,
@@ -369,7 +369,7 @@ class CivicthemeSettingsFormSectionComponents extends CivicthemeSettingsFormSect
 
     $form['components']['navigation_card']['summary_length'] = [
       '#title' => $this->t('Summary length'),
-      '#description' => $this->t('Set the length of the Summary field: the content will be trimmed to this length and ellipsis will be added. Set to 0 for no limit.'),
+      '#description' => $this->t('Set the length of the Summary field: the content will be trimmed to this length and ellipsis will be added. Set to 0 to never show a summary on navigation cards.'),
       '#type' => 'number',
       '#required' => TRUE,
       '#min' => 0,
@@ -385,7 +385,7 @@ class CivicthemeSettingsFormSectionComponents extends CivicthemeSettingsFormSect
 
     $form['components']['promo_card']['summary_length'] = [
       '#title' => $this->t('Summary length'),
-      '#description' => $this->t('Set the length of the Summary field: the content will be trimmed to this length and ellipsis will be added. Set to 0 for no limit.'),
+      '#description' => $this->t('Set the length of the Summary field: the content will be trimmed to this length and ellipsis will be added. Set to 0 to never show a summary on promo cards.'),
       '#type' => 'number',
       '#required' => TRUE,
       '#min' => 0,
@@ -401,7 +401,7 @@ class CivicthemeSettingsFormSectionComponents extends CivicthemeSettingsFormSect
 
     $form['components']['publication_card']['summary_length'] = [
       '#title' => $this->t('Summary length'),
-      '#description' => $this->t('Set the length of the Summary field: the content will be trimmed to this length and ellipsis will be added. Set to 0 for no limit.'),
+      '#description' => $this->t('Set the length of the Summary field: the content will be trimmed to this length and ellipsis will be added. Set to 0 to never show a summary on publication cards.'),
       '#type' => 'number',
       '#required' => TRUE,
       '#min' => 0,
@@ -424,7 +424,7 @@ class CivicthemeSettingsFormSectionComponents extends CivicthemeSettingsFormSect
 
     $form['components']['snippet']['summary_length'] = [
       '#title' => $this->t('Summary length'),
-      '#description' => $this->t('Set the length of the Summary field: the content will be trimmed to this length and ellipsis will be added. Set to 0 for no limit.'),
+      '#description' => $this->t('Set the length of the Summary field: the content will be trimmed to this length and ellipsis will be added. Set to 0 to never show a summary on snippets.'),
       '#type' => 'number',
       '#required' => TRUE,
       '#min' => 0,


### PR DESCRIPTION
https://www.drupal.org/project/civictheme/issues/3525932

## Checklist before requesting a review

- [x] I have formatted the subject to include ticket number as `Issue #123456 by drupal_org_username: Issue title`
- [ ] I have added a link to the issue tracker
- [ ] I have provided information in `Changed` section about WHY something was done if this was not a normal implementation
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run new and existing relevant tests locally with my changes, and they passed
- [ ] I have provided screenshots, where applicable

## Changed

1.

## Screenshots


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated summary length configuration descriptions across multiple components (event cards, navigation cards, promo cards, publication cards, and snippets) for improved clarity on the behavior when setting values to 0.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->