### PR TITLE
[3574459] Provide field override for _civictheme_preprocess_paragraph__node_field__summary.

### DIFF
--- a/web/themes/contrib/civictheme/includes/paragraphs.inc
+++ b/web/themes/contrib/civictheme/includes/paragraphs.inc
@@ -245,10 +245,10 @@ function _civictheme_preprocess_paragraph__paragraph_field__summary(array &$vari
  *
  * @SuppressWarnings(PHPMD.StaticAccess)
  */
-function _civictheme_preprocess_paragraph__node_field__summary(array &$variables, ?string $bundle = NULL): void {
+function _civictheme_preprocess_paragraph__node_field__summary(array &$variables, ?string $bundle = NULL, string $field_name = 'field_c_n_summary'): void {
   $node = $variables['node'] ?? civictheme_get_field_value($variables['paragraph'], 'field_c_p_reference', TRUE, build: $variables);
   if ($node) {
-    $summary = civictheme_get_field_value($node, 'field_c_n_summary', TRUE);
+    $summary = civictheme_get_field_value($node, $field_name, TRUE);
     if (!empty($summary)) {
       $length = CivicthemeConstants::COMPONENT_SUMMARY_DEFAULT_LENGTH;
 


### PR DESCRIPTION
## JIRA ticket: 3574459

## Checklist before requesting a review

- [x] I have formatted the subject to include ticket number as 
- [x] I have added a link to the issue tracker
- [x] I have provided information in  section about WHY something was done if this was not a normal implementation
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run new and existing relevant tests locally with my changes, and they passed
- [ ] I have provided screenshots, where applicable

## Changed
1. [#3574459] Updated  to allow override of summary field.

## Screenshots


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced paragraph processing to support configurable field mappings for improved flexibility.
  * Updated component resolution logic to better utilize bundle parameters for configuration management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->