### PR TITLE
Issue #3571153 by richardgaunt, joshua1234511, fionamorrison23: Add an alt text field for both Primary and Secondary logos

### DIFF
--- a/tests/behat/features/theme.settings.components.feature
+++ b/tests/behat/features/theme.settings.components.feature
@@ -52,11 +52,11 @@ Feature: Components settings are available in the theme settings
     And I should see an "input#edit-components-logo-secondary-dark-mobile-path" element
     And I should not see an "input#edit-components-logo-secondary-dark-mobile-path.required" element
 
-    And I see field "Primary logo image \"alt\" text"
+    And I see field 'Primary logo image "alt" text'
     And I should see an "input[name='components[logo][primary][image_alt]']" element
     And I should not see an "input#edit-components-logo-primary-image-alt.required" element
 
-    And I see field "Secondary logo image \"alt\" text"
+    And I see field 'Secondary logo image "alt" text'
     And I should see an "input[name='components[logo][secondary][image_alt]']" element
     And I should not see an "input#edit-components-logo-secondary-image-alt.required" element
 

--- a/tests/behat/features/theme.settings.components.feature
+++ b/tests/behat/features/theme.settings.components.feature
@@ -52,9 +52,13 @@ Feature: Components settings are available in the theme settings
     And I should see an "input#edit-components-logo-secondary-dark-mobile-path" element
     And I should not see an "input#edit-components-logo-secondary-dark-mobile-path.required" element
 
-    And I see field 'Logo image "alt" text'
-    And I should see an "input[name='components[logo][image_alt]']" element
-    And I should not see an "edit-components-logo-alt.required" element
+    And I see field "Primary logo image \"alt\" text"
+    And I should see an "input[name='components[logo][primary][image_alt]']" element
+    And I should not see an "input#edit-components-logo-primary-image-alt.required" element
+
+    And I see field "Secondary logo image \"alt\" text"
+    And I should see an "input[name='components[logo][secondary][image_alt]']" element
+    And I should not see an "input#edit-components-logo-secondary-image-alt.required" element
 
     And I should see the text "Theme"
     And I should see an "input[name='components[header][theme]']" element

--- a/web/themes/contrib/civictheme/civictheme.post_update.php
+++ b/web/themes/contrib/civictheme/civictheme.post_update.php
@@ -1205,3 +1205,66 @@ function civictheme_post_update_add_field_c_n_hide_sidebar(): string {
 
   return (string) new TranslatableMarkup('Added field_c_n_hide_sidebar to civictheme_event content type and placed it under Appearance.');
 }
+
+/**
+ * Migrate legacy logo image_alt to primary and secondary logo image_alt.
+ *
+ * Copies the old single components.logo.image_alt value into
+ * components.logo.primary.image_alt and components.logo.secondary.image_alt
+ * when the old value is not empty and the new fields are empty.
+ * Runs for CivicTheme and all its subthemes (themes that have civictheme
+ * in their base theme chain).
+ *
+ * @SuppressWarnings(PHPMD.StaticAccess)
+ */
+function civictheme_post_update_migrate_logo_image_alt_to_per_type(): TranslatableMarkup {
+  $config_factory = \Drupal::configFactory();
+  $theme_list = \Drupal::service('extension.list.theme');
+  $themes = $theme_list->getList();
+  $helper = \Drupal::classResolver(CivicthemeUpdateHelper::class);
+  $theme_names_to_migrate = $helper->logoAltThemesWithCivicthemeBase($themes);
+
+  $migrated = [];
+  foreach ($theme_names_to_migrate as $theme_name) {
+    $config_name = $theme_name . '.settings';
+    $config = $config_factory->getEditable($config_name);
+    if ($config->isNew()) {
+      continue;
+    }
+
+    $old_alt = $config->get('components.logo.image_alt');
+    if ($old_alt === NULL || (is_string($old_alt) && trim($old_alt) === '')) {
+      continue;
+    }
+
+    $updated = FALSE;
+    $primary_alt = $config->get('components.logo.primary.image_alt');
+    if ($primary_alt === NULL || (is_string($primary_alt) && trim($primary_alt) === '')) {
+      $config->set('components.logo.primary.image_alt', $old_alt);
+      $updated = TRUE;
+    }
+
+    $secondary_alt = $config->get('components.logo.secondary.image_alt');
+    if ($secondary_alt === NULL || (is_string($secondary_alt) && trim($secondary_alt) === '')) {
+      $config->set('components.logo.secondary.image_alt', $old_alt);
+      $updated = TRUE;
+    }
+
+    $config->clear('components.logo.image_alt');
+    if ($updated) {
+      $config->save();
+      $migrated[] = $theme_name;
+    }
+    else {
+      $config->save();
+    }
+  }
+
+  if (!empty($migrated)) {
+    return new TranslatableMarkup('Migrated legacy logo image alt text to Primary and Secondary logo alt fields for: @themes.', [
+      '@themes' => implode(', ', $migrated),
+    ]);
+  }
+
+  return new TranslatableMarkup('No legacy logo image alt value to migrate, or Primary and Secondary logo alt fields already set.');
+}

--- a/web/themes/contrib/civictheme/civictheme.post_update.php
+++ b/web/themes/contrib/civictheme/civictheme.post_update.php
@@ -1216,6 +1216,9 @@ function civictheme_post_update_add_field_c_n_hide_sidebar(): string {
  * in their base theme chain).
  *
  * @SuppressWarnings(PHPMD.StaticAccess)
+ * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+ * @SuppressWarnings(PHPMD.NPathComplexity)
+ * @SuppressWarnings(PHPMD.ElseExpression)
  */
 function civictheme_post_update_migrate_logo_image_alt_to_per_type(): TranslatableMarkup {
   $config_factory = \Drupal::configFactory();
@@ -1251,12 +1254,9 @@ function civictheme_post_update_migrate_logo_image_alt_to_per_type(): Translatab
     }
 
     $config->clear('components.logo.image_alt');
+    $config->save();
     if ($updated) {
-      $config->save();
       $migrated[] = $theme_name;
-    }
-    else {
-      $config->save();
     }
   }
 

--- a/web/themes/contrib/civictheme/config/install/civictheme.settings.yml
+++ b/web/themes/contrib/civictheme/config/install/civictheme.settings.yml
@@ -17,6 +17,7 @@ components:
           path: themes/contrib/civictheme/dist/assets/logos/logo_primary_dark_desktop.svg
         mobile:
           path: themes/contrib/civictheme/dist/assets/logos/logo_primary_dark_mobile.svg
+      image_alt: 'Logo image'
     secondary:
       light:
         desktop:
@@ -28,7 +29,7 @@ components:
           path: themes/contrib/civictheme/dist/assets/logos/logo_secondary_dark_desktop.png
         mobile:
           path: themes/contrib/civictheme/dist/assets/logos/logo_secondary_dark_mobile.png
-    image_alt: 'Logo image'
+      image_alt: 'Logo image'
   header:
     theme: light
     logo_type: inline

--- a/web/themes/contrib/civictheme/config/schema/civictheme.schema.yml
+++ b/web/themes/contrib/civictheme/config/schema/civictheme.schema.yml
@@ -52,9 +52,12 @@ civictheme.settings:
                         path:
                           label: Path
                           type: string
+                image_alt:
+                  label: 'Primary logo image "alt" text'
+                  type: string
             secondary:
               type: mapping
-              label: Primary
+              label: Secondary
               mapping:
                 light:
                   type: mapping
@@ -92,9 +95,9 @@ civictheme.settings:
                         path:
                           label: Path
                           type: string
-            image_alt:
-              label: 'Logo image "alt" text'
-              type: string
+                image_alt:
+                  label: 'Secondary logo image "alt" text'
+                  type: string
         header:
           type: mapping
           label: 'Header settings'

--- a/web/themes/contrib/civictheme/includes/system_branding.inc
+++ b/web/themes/contrib/civictheme/includes/system_branding.inc
@@ -39,9 +39,9 @@ function civictheme_preprocess_block__system_branding_block(array &$variables): 
     $logo_type = $is_footer_region ? civictheme_get_theme_config_manager()->load('components.footer.logo_type') : civictheme_get_theme_config_manager()->load('components.header.logo_type');
     $variables['type'] = str_replace('_', '-', $logo_type ?? CivicthemeConstants::LOGO_TYPE_DEFAULT);
     civictheme_add_modifier_class($variables, $is_footer_region ? 'ct-footer__logo' : 'ct-header__logo');
-    $logo_alt = civictheme_get_theme_config_manager()->load('components.logo.image_alt') ?? '';
 
     foreach (['primary', 'secondary'] as $type) {
+      $logo_alt = civictheme_get_theme_config_manager()->load(sprintf('components.logo.%s.image_alt', $type)) ?? '';
       foreach (['desktop', 'mobile'] as $breakpoint) {
         $logo_image = civictheme_get_theme_config_manager()->load(sprintf('components.logo.%s.%s.%s.path', $type, $theme, $breakpoint), '');
         if (!empty($logo_image)) {

--- a/web/themes/contrib/civictheme/src/CivicthemeUpdateHelper.php
+++ b/web/themes/contrib/civictheme/src/CivicthemeUpdateHelper.php
@@ -299,4 +299,45 @@ final class CivicthemeUpdateHelper implements ContainerInjectionInterface {
     return NULL;
   }
 
+  /**
+   * Returns theme names that are CivicTheme or have CivicTheme as a base theme.
+   *
+   * @param \Drupal\Core\Extension\Extension[] $themes
+   *   Theme extension list keyed by theme name.
+   *
+   * @return string[]
+   *   Theme machine names.
+   */
+  public function logoAltThemesWithCivicthemeBase(array $themes): array {
+    $result = [];
+    foreach (array_keys($themes) as $theme_name) {
+      if ($this->logoAltThemeExtendsCivictheme($themes, $theme_name)) {
+        $result[] = $theme_name;
+      }
+    }
+    return $result;
+  }
+
+  /**
+   * Checks if a theme is CivicTheme or has CivicTheme in its base theme chain.
+   *
+   * @param \Drupal\Core\Extension\Extension[] $themes
+   *   Theme extension list keyed by theme name.
+   * @param string $theme_name
+   *   Theme machine name.
+   *
+   * @return bool
+   *   TRUE if the theme is CivicTheme or has it in its base theme chain.
+   */
+  public function logoAltThemeExtendsCivictheme(array $themes, string $theme_name): bool {
+    if ($theme_name === 'civictheme') {
+      return TRUE;
+    }
+    if (!isset($themes[$theme_name]) || !isset($themes[$theme_name]->info['base theme'])) {
+      return FALSE;
+    }
+    $base_theme = $themes[$theme_name]->info['base theme'];
+    return $this->logoAltThemeExtendsCivictheme($themes, $base_theme);
+  }
+
 }

--- a/web/themes/contrib/civictheme/src/CivicthemeUpdateHelper.php
+++ b/web/themes/contrib/civictheme/src/CivicthemeUpdateHelper.php
@@ -16,6 +16,8 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * CivicTheme utilities.
+ *
+ * @SuppressWarnings(PHPMD.TooManyPublicMethods)
  */
 final class CivicthemeUpdateHelper implements ContainerInjectionInterface {
 

--- a/web/themes/contrib/civictheme/src/Settings/CivicthemeSettingsFormSectionComponents.php
+++ b/web/themes/contrib/civictheme/src/Settings/CivicthemeSettingsFormSectionComponents.php
@@ -54,6 +54,7 @@ class CivicthemeSettingsFormSectionComponents extends CivicthemeSettingsFormSect
     $allowed_extensions = implode(' ', $allowed_extensions);
 
     foreach ($logo_types as $logo_type) {
+      /** @phpstan-ignore-next-line */
       $form['components']['logo'][$logo_type] = [
         '#type' => 'details',
         '#title' => $this->t('@logo_type logo', [
@@ -72,7 +73,6 @@ class CivicthemeSettingsFormSectionComponents extends CivicthemeSettingsFormSect
       ];
       foreach (civictheme_theme_options() as $theme => $theme_label) {
         foreach ($breakpoints as $breakpoint) {
-          // @phpstan-ignore-next-line
           $form['components']['logo'][$logo_type][$theme][$breakpoint] = [
             '#type' => 'fieldset',
             '#title' => $this->t('@logo_type logo @theme @breakpoint', [

--- a/web/themes/contrib/civictheme/src/Settings/CivicthemeSettingsFormSectionComponents.php
+++ b/web/themes/contrib/civictheme/src/Settings/CivicthemeSettingsFormSectionComponents.php
@@ -60,6 +60,16 @@ class CivicthemeSettingsFormSectionComponents extends CivicthemeSettingsFormSect
           '@logo_type' => ucfirst($logo_type),
         ]),
       ];
+      $form['components']['logo'][$logo_type]['image_alt'] = [
+        '#type' => 'textfield',
+        '#title' => $this->t('@logo_type logo image "alt" text', [
+          '@logo_type' => ucfirst($logo_type),
+        ]),
+        '#description' => $this->t('Text for the <code>alt</code> attribute of the @logo_type logo image.', [
+          '@logo_type' => ucfirst($logo_type),
+        ]),
+        '#default_value' => $this->themeConfigManager->load(sprintf('components.logo.%s.image_alt', $logo_type)),
+      ];
       foreach (civictheme_theme_options() as $theme => $theme_label) {
         foreach ($breakpoints as $breakpoint) {
           // @phpstan-ignore-next-line
@@ -104,13 +114,6 @@ class CivicthemeSettingsFormSectionComponents extends CivicthemeSettingsFormSect
         }
       }
     }
-
-    $form['components']['logo']['image_alt'] = [
-      '#type' => 'textfield',
-      '#title' => $this->t('Logo image "alt" text'),
-      '#description' => $this->t('Text for the <code>alt</code> attribute of the site logo image.'),
-      '#default_value' => $this->themeConfigManager->load('components.logo.image_alt'),
-    ];
 
     $form['components']['site_slogan'] = [
       '#type' => 'details',


### PR DESCRIPTION
https://www.drupal.org/project/civictheme/issues/3571153

## Checklist before requesting a review

- [x] I have formatted the subject to include ticket number as `Issue #123456 by drupal_org_username: Issue title`
- [x] I have added a link to the issue tracker
- [x] I have provided information in `Changed` section about WHY something was done if this was not a normal implementation
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run new and existing relevant tests locally with my changes, and they passed
- [x] I have provided screenshots, where applicable

## Changed

1. Behat: Primary and Secondary logo alt steps and selectors added/updated.
2. Schema: image_alt moved under primary/secondary; secondary label fixed.
3. System branding: Alt text loaded per logo type from config.
4. Post-update: Migrates old logo alt to primary/secondary for base + subthemes, then removes old key.
5. Update helper: Theme/subtheme helpers added.

## Screenshots
<img width="1233" height="582" alt="Screenshot 2026-02-21 at 9 41 09 PM" src="https://github.com/user-attachments/assets/3f09d111-8367-454c-86cd-bf9a25646718" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Logo alt text can be configured separately for Primary and Secondary logos and is applied per logo type.

* **Tests**
  * Scenarios updated to validate distinct Primary and Secondary logo alt text fields.

* **Chores**
  * Automatic migration copies any existing single logo alt text into the new per-type fields during update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->