### PR TITLE
[3575108] Added configuration to change mobile viewport layout order.

### DIFF
--- a/web/themes/contrib/civictheme/civictheme.post_update.php
+++ b/web/themes/contrib/civictheme/civictheme.post_update.php
@@ -1205,3 +1205,42 @@ function civictheme_post_update_add_field_c_n_hide_sidebar(): string {
 
   return (string) new TranslatableMarkup('Added field_c_n_hide_sidebar to civictheme_event content type and placed it under Appearance.');
 }
+
+/**
+ * Add mobile stack order settings to theme configuration.
+ *
+ * Existing sites get the feature disabled so behaviour is unchanged.
+ * New installs receive it enabled via config/install.
+ *
+ * @SuppressWarnings(PHPMD.StaticAccess)
+ */
+function civictheme_post_update_add_mobile_stack_order_settings(): string {
+  /** @var \Drupal\Core\Theme\ActiveTheme $theme */
+  $theme = \Drupal::service('theme.manager')->getActiveTheme();
+  $config_name = $theme->getName() . '.settings';
+
+  $config = \Drupal::configFactory()->getEditable($config_name);
+
+  if ($config->isNew()) {
+    return (string) new TranslatableMarkup('Theme settings config @config does not exist. Skipping update.', [
+      '@config' => $config_name,
+    ]);
+  }
+
+  $defaults = [
+    'stl' => 1,
+    'str' => 2,
+    'm' => 3,
+    'sbl' => 4,
+    'sbr' => 5,
+  ];
+
+  // Disabled by default for existing sites.
+  $config->set('components.layout.mobile_stack_order_enabled', FALSE);
+  $config->set('components.layout.mobile_stack_order', $defaults);
+  $config->save();
+
+  return (string) new TranslatableMarkup('Added mobile stack order settings to @config with feature disabled.', [
+    '@config' => $config_name,
+  ]);
+}

--- a/web/themes/contrib/civictheme/civictheme.post_update.php
+++ b/web/themes/contrib/civictheme/civictheme.post_update.php
@@ -1240,7 +1240,52 @@ function civictheme_post_update_add_mobile_stack_order_settings(): string {
   $config->set('components.layout.mobile_stack_order', $defaults);
   $config->save();
 
-  return (string) new TranslatableMarkup('Added mobile stack order settings to @config with feature disabled.', [
+  // Also update any existing Layout Builder sections to disable the feature.
+  // Prior to this update, sections may have mobile_stack_order configured
+  // without an enabled flag, so we ensure the override is explicitly disabled.
+  $entity_displays = LayoutBuilderEntityViewDisplay::loadMultiple();
+  $updated_displays = [];
+
+  foreach ($entity_displays as $entity_display) {
+    if (!$entity_display->isLayoutBuilderEnabled()) {
+      continue;
+    }
+
+    $sections = $entity_display->getThirdPartySetting('layout_builder', 'sections');
+    if (empty($sections)) {
+      continue;
+    }
+
+    $display_updated = FALSE;
+    foreach ($sections as $section) {
+      if ($section->getLayoutId() !== 'civictheme_three_columns') {
+        continue;
+      }
+
+      $settings = $section->getLayoutSettings();
+      if (!isset($settings['mobile_stack_order_enabled'])) {
+        $settings['mobile_stack_order_enabled'] = FALSE;
+        $section->setLayoutSettings($settings);
+        $display_updated = TRUE;
+      }
+    }
+
+    if ($display_updated) {
+      $entity_display->setThirdPartySetting('layout_builder', 'sections', $sections);
+      $entity_display->save();
+      $updated_displays[] = $entity_display->id();
+    }
+  }
+
+  $message = (string) new TranslatableMarkup('Added mobile stack order settings to @config with feature disabled.', [
     '@config' => $config_name,
   ]);
+
+  if (!empty($updated_displays)) {
+    $message .= ' ' . (string) new TranslatableMarkup('Updated Layout Builder displays: @displays.', [
+      '@displays' => implode(', ', $updated_displays),
+    ]);
+  }
+
+  return $message;
 }

--- a/web/themes/contrib/civictheme/config/install/civictheme.settings.yml
+++ b/web/themes/contrib/civictheme/config/install/civictheme.settings.yml
@@ -67,6 +67,14 @@ components:
     summary_length: 160
   attachment:
     use_media_name: true
+  layout:
+    mobile_stack_order_enabled: true
+    mobile_stack_order:
+      stl: 1
+      str: 2
+      m: 3
+      sbl: 4
+      sbr: 5
   search:
     keyword_fields:
       - keywords

--- a/web/themes/contrib/civictheme/config/install/core.entity_view_display.node.civictheme_page.default.yml
+++ b/web/themes/contrib/civictheme/config/install/core.entity_view_display.node.civictheme_page.default.yml
@@ -23,11 +23,13 @@ dependencies:
     - field.field.node.civictheme_page.field_c_n_topics
     - field.field.node.civictheme_page.field_c_n_vertical_spacing
     - node.type.civictheme_page
+    - system.menu.civictheme-primary-navigation
   module:
     - datetime
     - entity_reference_revisions
     - layout_builder
     - layout_builder_restrictions
+    - menu_block
     - options
     - user
   theme:
@@ -41,8 +43,16 @@ third_party_settings:
         layout_id: civictheme_three_columns
         layout_settings:
           label: 'CivicTheme Three Columns'
-          is_contained: false
           context_mapping: {  }
+          is_contained: false
+          mobile_stack_order_enabled: true
+          mobile_stack_order:
+            stl: 1
+            str: 2
+            m: 3
+            sbl: 4
+            sbr: 5
+          vertical_spacing: none
         components:
           5cf72ad7-c313-4cf3-9d4e-0573bbfa84a0:
             uuid: 5cf72ad7-c313-4cf3-9d4e-0573bbfa84a0
@@ -94,6 +104,29 @@ third_party_settings:
                   format_type: medium
                 third_party_settings: {  }
             weight: 3
+            additional: {  }
+          685a0991-bd51-436b-b922-984c15ceb42b:
+            uuid: 685a0991-bd51-436b-b922-984c15ceb42b
+            region: sidebar_top_left
+            configuration:
+              id: 'menu_block:civictheme-primary-navigation'
+              label: 'Primary Navigation'
+              label_display: '0'
+              provider: menu_block
+              context_mapping: {  }
+              follow: false
+              follow_parent: child
+              display_empty: false
+              label_link: false
+              label_type: block
+              level: 1
+              depth: 3
+              expand_all_items: false
+              parent: 'civictheme-primary-navigation:'
+              render_parent: false
+              suggestion: civictheme_sidebar_navigation
+              hide_on_nonactive: false
+            weight: 0
             additional: {  }
         third_party_settings: {  }
   layout_builder_restrictions:

--- a/web/themes/contrib/civictheme/config/optional/block.block.civictheme_side_navigation.yml
+++ b/web/themes/contrib/civictheme/config/optional/block.block.civictheme_side_navigation.yml
@@ -33,3 +33,11 @@ visibility:
     id: request_path
     negate: true
     pages: /search
+  'entity_bundle:node':
+    id: 'entity_bundle:node'
+    negate: false
+    context_mapping:
+      node: '@node.node_route_context:node'
+    bundles:
+      civictheme_alert: civictheme_alert
+      civictheme_event: civictheme_event

--- a/web/themes/contrib/civictheme/config/schema/civictheme.schema.yml
+++ b/web/themes/contrib/civictheme/config/schema/civictheme.schema.yml
@@ -225,6 +225,32 @@ civictheme.settings:
             use_media_name:
               label: 'Use name of media'
               type: boolean
+        layout:
+          type: mapping
+          label: 'Layout settings'
+          mapping:
+            mobile_stack_order_enabled:
+              label: 'Enable custom mobile stack order'
+              type: boolean
+            mobile_stack_order:
+              type: mapping
+              label: 'Mobile stack order'
+              mapping:
+                stl:
+                  label: 'Sidebar top left'
+                  type: integer
+                str:
+                  label: 'Sidebar top right'
+                  type: integer
+                m:
+                  label: 'Main'
+                  type: integer
+                sbl:
+                  label: 'Sidebar bottom left'
+                  type: integer
+                sbr:
+                  label: 'Sidebar bottom right'
+                  type: integer
         search:
           type: mapping
           label: 'Search settings'
@@ -405,3 +431,22 @@ layout_plugin.settings.civictheme_three_columns:
     is_contained:
       type: boolean
       label: 'Is Contained'
+    mobile_stack_order:
+      type: mapping
+      label: 'Mobile stack order'
+      mapping:
+        stl:
+          label: 'Sidebar top left'
+          type: integer
+        str:
+          label: 'Sidebar top right'
+          type: integer
+        m:
+          label: 'Main'
+          type: integer
+        sbl:
+          label: 'Sidebar bottom left'
+          type: integer
+        sbr:
+          label: 'Sidebar bottom right'
+          type: integer

--- a/web/themes/contrib/civictheme/config/schema/civictheme.schema.yml
+++ b/web/themes/contrib/civictheme/config/schema/civictheme.schema.yml
@@ -431,6 +431,9 @@ layout_plugin.settings.civictheme_three_columns:
     is_contained:
       type: boolean
       label: 'Is Contained'
+    mobile_stack_order_enabled:
+      type: boolean
+      label: 'Enable custom mobile stack order'
     mobile_stack_order:
       type: mapping
       label: 'Mobile stack order'

--- a/web/themes/contrib/civictheme/includes/layout.inc
+++ b/web/themes/contrib/civictheme/includes/layout.inc
@@ -17,14 +17,22 @@ function civictheme_preprocess_layout__three_columns(array &$variables): void {
   $variables['vertical_spacing'] = $variables['settings']['vertical_spacing'] ?? 'auto';
 
   $defaults = ThreeColumnsLayout::MOBILE_STACK_ORDER_DEFAULTS;
-  $mobile_stack_order = $variables['settings']['mobile_stack_order'] ?? $defaults;
+  $mobile_stack_order_enabled = !empty($variables['settings']['mobile_stack_order_enabled']);
 
-  // Only pass custom order to the template when it differs from defaults.
+  // Only pass custom order to the template when the feature is enabled and
+  // the order differs from defaults.
   // When using defaults, no inline styles are needed and the SCSS handles
   // ordering for empty regions via --no-* class combinations. When custom
   // order is set, inline styles override all 5 CSS custom properties;
   // empty regions still get a value but it has no effect since the template
   // does not render their HTML element.
+  if (!$mobile_stack_order_enabled) {
+    $variables['mobile_stack_order'] = [];
+    return;
+  }
+
+  $mobile_stack_order = $variables['settings']['mobile_stack_order'] ?? $defaults;
+
   if ($mobile_stack_order == $defaults) {
     $variables['mobile_stack_order'] = [];
     return;

--- a/web/themes/contrib/civictheme/includes/layout.inc
+++ b/web/themes/contrib/civictheme/includes/layout.inc
@@ -7,12 +7,30 @@
 
 declare(strict_types=1);
 
+use Drupal\civictheme\Plugin\Layout\ThreeColumnsLayout;
+
 /**
  * Implements hook_preprocess_HOOK().
  */
 function civictheme_preprocess_layout__three_columns(array &$variables): void {
   $variables['is_contained'] = $variables['settings']['is_contained'] ?? FALSE;
   $variables['vertical_spacing'] = $variables['settings']['vertical_spacing'] ?? 'auto';
+
+  $defaults = ThreeColumnsLayout::MOBILE_STACK_ORDER_DEFAULTS;
+  $mobile_stack_order = $variables['settings']['mobile_stack_order'] ?? $defaults;
+
+  // Only pass custom order to the template when it differs from defaults.
+  // When using defaults, no inline styles are needed and the SCSS handles
+  // ordering for empty regions via --no-* class combinations. When custom
+  // order is set, inline styles override all 5 CSS custom properties;
+  // empty regions still get a value but it has no effect since the template
+  // does not render their HTML element.
+  if ($mobile_stack_order == $defaults) {
+    $variables['mobile_stack_order'] = [];
+    return;
+  }
+
+  $variables['mobile_stack_order'] = array_map('intval', $mobile_stack_order);
 }
 
 /**

--- a/web/themes/contrib/civictheme/includes/page.inc
+++ b/web/themes/contrib/civictheme/includes/page.inc
@@ -8,6 +8,7 @@
 declare(strict_types=1);
 
 use Drupal\civictheme\CivicthemeConstants;
+use Drupal\civictheme\Plugin\Layout\ThreeColumnsLayout;
 use Drupal\Core\Cache\Cache;
 
 /**
@@ -23,6 +24,20 @@ function _civictheme_preprocess_page(array &$variables): void {
   // For nodes this is set to false via _civictheme_preprocess_page_node as
   // layout is controlled via layout templates.
   $variables['page']['content_contained'] = $variables['page']['content_contained'] ?? TRUE;
+
+  // Set mobile stack order from theme settings.
+  $mobile_stack_order_enabled = civictheme_get_theme_config_manager()->load('components.layout.mobile_stack_order_enabled', FALSE);
+  if ($mobile_stack_order_enabled) {
+    $defaults = ThreeColumnsLayout::MOBILE_STACK_ORDER_DEFAULTS;
+    $mobile_stack_order = [];
+    foreach ($defaults as $key => $default) {
+      $mobile_stack_order[$key] = (int) civictheme_get_theme_config_manager()->load('components.layout.mobile_stack_order.' . $key, $default);
+    }
+    // Only pass custom order if it differs from defaults.
+    if ($mobile_stack_order !== $defaults) {
+      $variables['page']['mobile_stack_order'] = $mobile_stack_order;
+    }
+  }
 }
 
 /**

--- a/web/themes/contrib/civictheme/src/Plugin/Layout/ThreeColumnsLayout.php
+++ b/web/themes/contrib/civictheme/src/Plugin/Layout/ThreeColumnsLayout.php
@@ -32,6 +32,7 @@ class ThreeColumnsLayout extends LayoutDefault implements PluginFormInterface {
 
     return $configuration + [
       'is_contained' => FALSE,
+      'mobile_stack_order_enabled' => FALSE,
       'mobile_stack_order' => self::MOBILE_STACK_ORDER_DEFAULTS,
     ];
   }
@@ -60,6 +61,13 @@ class ThreeColumnsLayout extends LayoutDefault implements PluginFormInterface {
       ],
     ];
 
+    $form['mobile_stack_order_enabled'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Enable custom mobile stack order'),
+      '#default_value' => $this->configuration['mobile_stack_order_enabled'],
+      '#description' => $this->t('Override the default mobile stacking order of layout regions for this section.'),
+    ];
+
     $weight_options = array_combine(range(1, 5), range(1, 5));
     $mobile_stack_order = $this->configuration['mobile_stack_order'] ?? self::MOBILE_STACK_ORDER_DEFAULTS;
 
@@ -76,6 +84,11 @@ class ThreeColumnsLayout extends LayoutDefault implements PluginFormInterface {
       '#title' => $this->t('Mobile stack order'),
       '#description' => $this->t('Configure the order in which regions stack on mobile. Lower numbers appear first. Each weight must be unique.'),
       '#tree' => TRUE,
+      '#states' => [
+        'visible' => [
+          ':input[name="layout_settings[mobile_stack_order_enabled]"]' => ['checked' => TRUE],
+        ],
+      ],
     ];
 
     foreach ($region_labels as $key => $label) {
@@ -94,6 +107,9 @@ class ThreeColumnsLayout extends LayoutDefault implements PluginFormInterface {
    * {@inheritdoc}
    */
   public function validateConfigurationForm(array &$form, FormStateInterface $form_state) {
+    if (!$form_state->getValue('mobile_stack_order_enabled')) {
+      return;
+    }
     $mobile_stack_order = $form_state->getValue('mobile_stack_order');
     if (is_array($mobile_stack_order)) {
       $values = array_map('intval', $mobile_stack_order);
@@ -110,6 +126,7 @@ class ThreeColumnsLayout extends LayoutDefault implements PluginFormInterface {
     parent::submitConfigurationForm($form, $form_state);
     $this->configuration['is_contained'] = $form_state->getValue('is_contained');
     $this->configuration['vertical_spacing'] = $form_state->getValue('vertical_spacing');
+    $this->configuration['mobile_stack_order_enabled'] = (bool) $form_state->getValue('mobile_stack_order_enabled');
     $mobile_stack_order = $form_state->getValue('mobile_stack_order');
     if (is_array($mobile_stack_order)) {
       $this->configuration['mobile_stack_order'] = array_map('intval', $mobile_stack_order);

--- a/web/themes/contrib/civictheme/src/Plugin/Layout/ThreeColumnsLayout.php
+++ b/web/themes/contrib/civictheme/src/Plugin/Layout/ThreeColumnsLayout.php
@@ -12,12 +12,28 @@ use Drupal\Core\Plugin\PluginFormInterface;
 class ThreeColumnsLayout extends LayoutDefault implements PluginFormInterface {
 
   /**
+   * Default mobile stack order for the five layout regions.
+   *
+   * Keys are CSS custom property names used by the layout SCSS.
+   */
+  const MOBILE_STACK_ORDER_DEFAULTS = [
+    'stl' => 1,
+    'str' => 2,
+    'm' => 3,
+    'sbl' => 4,
+    'sbr' => 5,
+  ];
+
+  /**
    * {@inheritdoc}
    */
   public function defaultConfiguration() {
     $configuration = parent::defaultConfiguration();
 
-    return $configuration + ['is_contained' => FALSE];
+    return $configuration + [
+      'is_contained' => FALSE,
+      'mobile_stack_order' => self::MOBILE_STACK_ORDER_DEFAULTS,
+    ];
   }
 
   /**
@@ -44,7 +60,47 @@ class ThreeColumnsLayout extends LayoutDefault implements PluginFormInterface {
       ],
     ];
 
+    $weight_options = array_combine(range(1, 5), range(1, 5));
+    $mobile_stack_order = $this->configuration['mobile_stack_order'] ?? self::MOBILE_STACK_ORDER_DEFAULTS;
+
+    $region_labels = [
+      'stl' => $this->t('Sidebar top left'),
+      'str' => $this->t('Sidebar top right'),
+      'm' => $this->t('Main'),
+      'sbl' => $this->t('Sidebar bottom left'),
+      'sbr' => $this->t('Sidebar bottom right'),
+    ];
+
+    $form['mobile_stack_order'] = [
+      '#type' => 'fieldset',
+      '#title' => $this->t('Mobile stack order'),
+      '#description' => $this->t('Configure the order in which regions stack on mobile. Lower numbers appear first. Each weight must be unique.'),
+      '#tree' => TRUE,
+    ];
+
+    foreach ($region_labels as $key => $label) {
+      $form['mobile_stack_order'][$key] = [
+        '#type' => 'select',
+        '#title' => $label,
+        '#default_value' => $mobile_stack_order[$key] ?? self::MOBILE_STACK_ORDER_DEFAULTS[$key],
+        '#options' => $weight_options,
+      ];
+    }
+
     return parent::buildConfigurationForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validateConfigurationForm(array &$form, FormStateInterface $form_state) {
+    $mobile_stack_order = $form_state->getValue('mobile_stack_order');
+    if (is_array($mobile_stack_order)) {
+      $values = array_map('intval', $mobile_stack_order);
+      if (count($values) !== count(array_unique($values))) {
+        $form_state->setErrorByName('mobile_stack_order', $this->t('Each mobile stack order weight must be unique.'));
+      }
+    }
   }
 
   /**
@@ -54,6 +110,10 @@ class ThreeColumnsLayout extends LayoutDefault implements PluginFormInterface {
     parent::submitConfigurationForm($form, $form_state);
     $this->configuration['is_contained'] = $form_state->getValue('is_contained');
     $this->configuration['vertical_spacing'] = $form_state->getValue('vertical_spacing');
+    $mobile_stack_order = $form_state->getValue('mobile_stack_order');
+    if (is_array($mobile_stack_order)) {
+      $this->configuration['mobile_stack_order'] = array_map('intval', $mobile_stack_order);
+    }
   }
 
 }

--- a/web/themes/contrib/civictheme/src/Settings/CivicthemeSettingsFormSectionLayout.php
+++ b/web/themes/contrib/civictheme/src/Settings/CivicthemeSettingsFormSectionLayout.php
@@ -74,6 +74,8 @@ class CivicthemeSettingsFormSectionLayout extends CivicthemeSettingsFormSectionB
 
   /**
    * Validate callback for layout settings.
+   *
+   * @SuppressWarnings(PHPMD.UnusedFormalParameter)
    */
   public function validateLayout(array &$form, FormStateInterface $form_state): void {
     $enabled = $form_state->getValue(['components', 'layout', 'mobile_stack_order_enabled']);

--- a/web/themes/contrib/civictheme/src/Settings/CivicthemeSettingsFormSectionLayout.php
+++ b/web/themes/contrib/civictheme/src/Settings/CivicthemeSettingsFormSectionLayout.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\civictheme\Settings;
+
+use Drupal\civictheme\Plugin\Layout\ThreeColumnsLayout;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * CivicTheme settings section to display layout configuration.
+ */
+class CivicthemeSettingsFormSectionLayout extends CivicthemeSettingsFormSectionBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function weight(): int {
+    return 31;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function form(array &$form, FormStateInterface $form_state): void {
+    $form['components']['layout'] = [
+      '#type' => 'details',
+      '#title' => $this->t('Layout'),
+      '#group' => 'components',
+      '#tree' => TRUE,
+    ];
+
+    $form['components']['layout']['mobile_stack_order_enabled'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Enable custom mobile stack order'),
+      '#description' => $this->t('Override the default mobile stacking order of layout regions. When enabled, the configured order is applied via inline CSS custom properties on the page layout.'),
+      '#default_value' => $this->themeConfigManager->load('components.layout.mobile_stack_order_enabled', FALSE),
+    ];
+
+    $weight_options = array_combine(range(1, 5), range(1, 5));
+    $defaults = ThreeColumnsLayout::MOBILE_STACK_ORDER_DEFAULTS;
+
+    $region_labels = [
+      'stl' => $this->t('Sidebar top left'),
+      'str' => $this->t('Sidebar top right'),
+      'm' => $this->t('Main'),
+      'sbl' => $this->t('Sidebar bottom left'),
+      'sbr' => $this->t('Sidebar bottom right'),
+    ];
+
+    $form['components']['layout']['mobile_stack_order'] = [
+      '#type' => 'fieldset',
+      '#title' => $this->t('Mobile stack order'),
+      '#description' => $this->t('Configure the order in which regions stack on mobile. Lower numbers appear first. Each weight must be unique.'),
+      '#tree' => TRUE,
+      '#states' => [
+        'visible' => [
+          ':input[name="components[layout][mobile_stack_order_enabled]"]' => ['checked' => TRUE],
+        ],
+      ],
+    ];
+
+    foreach ($region_labels as $key => $label) {
+      $form['components']['layout']['mobile_stack_order'][$key] = [
+        '#type' => 'select',
+        '#title' => $label,
+        '#default_value' => $this->themeConfigManager->load('components.layout.mobile_stack_order.' . $key, $defaults[$key]),
+        '#options' => $weight_options,
+      ];
+    }
+
+    $form['#validate'][] = [$this, 'validateLayout'];
+  }
+
+  /**
+   * Validate callback for layout settings.
+   */
+  public function validateLayout(array &$form, FormStateInterface $form_state): void {
+    $enabled = $form_state->getValue(['components', 'layout', 'mobile_stack_order_enabled']);
+    if (!$enabled) {
+      return;
+    }
+
+    $mobile_stack_order = $form_state->getValue(['components', 'layout', 'mobile_stack_order']);
+    if (is_array($mobile_stack_order)) {
+      $values = array_map('intval', $mobile_stack_order);
+      if (count($values) !== count(array_unique($values))) {
+        $form_state->setErrorByName('components][layout][mobile_stack_order', (string) $this->t('Each mobile stack order weight must be unique.'));
+      }
+    }
+  }
+
+}

--- a/web/themes/contrib/civictheme/templates/layout/layout--three-columns.html.twig
+++ b/web/themes/contrib/civictheme/templates/layout/layout--three-columns.html.twig
@@ -52,7 +52,15 @@
       {% endif %}
     {% endblock %}
 
-    <div class="ct-layout__inner {{ is_contained_class }}">
+    {% set stack_style_parts = [] %}
+    {% if mobile_stack_order is defined and mobile_stack_order is not empty %}
+      {% for var, weight in mobile_stack_order %}
+        {% set stack_style_parts = stack_style_parts|merge(['--' ~ var ~ ':' ~ weight]) %}
+      {% endfor %}
+    {% endif %}
+    {% set stack_style = stack_style_parts|join(';') %}
+
+    <div class="ct-layout__inner {{ is_contained_class }}"{% if stack_style %} style="{{ stack_style }}"{% endif %}>
       {% if content.main is not empty %}
         {% block content_block %}
           <section data-region="main" class="layout-builder__region js-layout-builder-region ct-layout__main" {% if content_attributes is not empty %}{{- content_attributes -}}{% endif %}>


### PR DESCRIPTION
## JIRA ticket: 3575108

## Checklist before requesting a review

- [x] I have formatted the subject to include ticket number as 
- [x] I have added a link to the issue tracker
- [x] I have provided information in  section about WHY something was done if this was not a normal implementation
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run new and existing relevant tests locally with my changes, and they passed
- [ ] I have provided screenshots, where applicable

## Changed
1. Added form setting to modify mobile layout order.
2. Added ability to configure the mobile stack order of layout regions.

**This breaks anyone using breakpoints for ordering**

## Screenshots

### Layout Builder

<img width="1383" height="721" alt="image" src="https://github.com/user-attachments/assets/9e3e4c88-f0fa-46bd-8bc2-e9dfa6ca94fa" />



### Theme Settings

<img width="1383" height="721" alt="image" src="https://github.com/user-attachments/assets/a1a31327-e5c0-4de5-966e-b3d80eeeaddc" />


<img width="1383" height="721" alt="image" src="https://github.com/user-attachments/assets/9e3e4c88-f0fa-46bd-8bc2-e9dfa6ca94fa" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mobile stack order customization for three-column layouts with per-region weights and UI to enable/configure it.
  * Template and layout support to apply custom mobile stacking rules and pass them to pages.

* **Chores**
  * Post-update routine adds default mobile stack settings for existing themes and updates saved layouts.

* **Documentation**
  * Added configuration schema and default settings for mobile stack order.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->