### PR TITLE
Updated the year in the copyright block to current year.

### DIFF
--- a/web/themes/contrib/civictheme/theme-settings.provision.inc
+++ b/web/themes/contrib/civictheme/theme-settings.provision.inc
@@ -929,7 +929,7 @@ function _civictheme_provision__blocks__copyright(array $block, $theme_name): vo
     'type' => 'civictheme_content',
   ]);
   $paragraph->set('field_c_p_content', [
-    'value' => "<p class=\"text-align-right ct-text-small\">©2024 Commonwealth of Australia</p>\r\n",
+    'value' => "<p class=\"text-align-right ct-text-small\">© 2026 Commonwealth of Australia</p>\r\n",
     'format' => 'civictheme_rich_text',
   ]);
   $paragraph->set('field_c_p_theme', CivicthemeConstants::THEME_DARK);

--- a/web/themes/contrib/civictheme/theme-settings.provision.inc
+++ b/web/themes/contrib/civictheme/theme-settings.provision.inc
@@ -929,7 +929,7 @@ function _civictheme_provision__blocks__copyright(array $block, $theme_name): vo
     'type' => 'civictheme_content',
   ]);
   $paragraph->set('field_c_p_content', [
-    'value' => "<p class=\"text-align-right ct-text-small\">© 2026 Commonwealth of Australia</p>\r\n",
+    'value' => "<p class=\"text-align-right ct-text-small\">© " . date('Y') . " Commonwealth of Australia</p>\r\n",
     'format' => 'civictheme_rich_text',
   ]);
   $paragraph->set('field_c_p_theme', CivicthemeConstants::THEME_DARK);


### PR DESCRIPTION
## Checklist before requesting a review

- [ ] I have formatted the subject to include ticket number as `Issue #123456 by drupal_org_username: Issue title`
- [ ] I have added a link to the issue tracker
- [ ] I have provided information in `Changed` section about WHY something was done if this was not a normal implementation
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run new and existing relevant tests locally with my changes, and they passed
- [ ] I have provided screenshots, where applicable

## Changed

1. Changed year to current year instead of 2024.
2. Added a space as this is standard between copyright symbol and year.

## Screenshots


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched the fixed copyright year to a dynamic current-year display so the theme footer always shows the correct year automatically (replacing a previously hard-coded year).
  * No other user-facing behavior or settings were changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->