### PR TITLE
Issue #3543033 by joshua1234511, fionamorrison23, richardgaunt: Show selected topics only in the Automated list filter

### DIFF
--- a/web/themes/contrib/civictheme/includes/views.inc
+++ b/web/themes/contrib/civictheme/includes/views.inc
@@ -14,6 +14,7 @@ use Drupal\Core\Cache\Cache;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Template\Attribute;
 use Drupal\Core\Url;
+use Drupal\taxonomy\Entity\Term;
 use Drupal\views\Plugin\views\filter\FilterPluginBase;
 use Drupal\views\ViewExecutable;
 use Drupal\views\Views;
@@ -128,12 +129,38 @@ function civictheme_preprocess_views_view_grid(array &$variables): void {
 /**
  * Implements hook_form_views_exposed_form_alter().
  */
-function civictheme_form_views_exposed_form_alter(array &$form, FormStateInterface $form_state): void {
+function civictheme_form_views_exposed_form_alter(array &$form, FormStateInterface $form_state, string $form_id): void {
   $storage = $form_state->getStorage();
   // Pass view ID in attributes to the exposed filter preprocessor.
   // @see civictheme_preprocess_views_exposed_form()
   if (!empty($storage['view'])) {
     $form['#attributes']['view_id'] = $storage['view']->id();
+  }
+
+  // Restrict Topics exposed filter to contextual filter term(s) when present.
+  if ($form_id !== 'views_exposed_form') {
+    return;
+  }
+  $view = $form_state->get('view');
+  if (!$view instanceof ViewExecutable || $view->id() !== 'civictheme_automated_list') {
+    return;
+  }
+  if (!isset($form['topic']) || !isset($form['topic']['#type'])) {
+    return;
+  }
+  try {
+    $context_tids = _civictheme_get_topics_contextual_argument_tids($view);
+    if ($context_tids !== []) {
+      $options = _civictheme_build_topic_options_from_tids($context_tids);
+      if ($options !== []) {
+        $form['topic']['#options'] = ['All' => '- Any -'] + $options;
+      }
+    }
+  }
+  catch (\Throwable $e) {
+    \Drupal::logger('civictheme')->warning('Exposed form alter failed: @message', [
+      '@message' => $e->getMessage(),
+    ]);
   }
 }
 
@@ -488,4 +515,76 @@ function _civictheme_preprocess_views_view__selected_filters_list__create_filter
       $value_label = $value;
   }
   return $filter_types[$key]['name'] . ': ' . $value_label;
+}
+
+/**
+ * Gets term IDs from the Topics contextual filter (term_node_tid_depth).
+ *
+ * @param \Drupal\views\ViewExecutable $view
+ *   The view.
+ *
+ * @return int[]
+ *   Term IDs from the contextual argument, or empty if none/any.
+ */
+function _civictheme_get_topics_contextual_argument_tids(ViewExecutable $view): array {
+  $display = $view->getDisplay();
+  if (!method_exists($display, 'getOption')) {
+    return [];
+  }
+
+  $argument_options = $display->getOption('arguments') ?? [];
+  if (!is_array($argument_options)) {
+    return [];
+  }
+
+  $argument_ids = array_keys($argument_options);
+  $pos = array_search('term_node_tid_depth', $argument_ids, TRUE);
+  if ($pos === FALSE) {
+    return [];
+  }
+
+  $args = $view->args;
+  if (!isset($args[$pos]) || $args[$pos] === '' || $args[$pos] === 'all') {
+    return [];
+  }
+
+  $parts = preg_split('/[\s+]+/', (string) $args[$pos]);
+  if ($parts === FALSE) {
+    return [];
+  }
+
+  $tids = [];
+  foreach ($parts as $part) {
+    $part = trim($part);
+    if ($part !== '' && is_numeric($part)) {
+      $tids[] = (int) $part;
+    }
+  }
+
+  return array_unique($tids);
+}
+
+/**
+ * Builds option list for the Topics exposed filter from term IDs.
+ *
+ * @param int[] $tids
+ *   Taxonomy term IDs (civictheme_topics).
+ *
+ * @return array<int|string, string>
+ *   Options array keyed by term ID, value is term name.
+ */
+function _civictheme_build_topic_options_from_tids(array $tids): array {
+  if ($tids === []) {
+    return [];
+  }
+
+  $terms = Term::loadMultiple($tids);
+  $options = [];
+  foreach ($terms as $term) {
+    if ($term !== NULL) {
+      $options[$term->id()] = (string) $term->label();
+    }
+  }
+
+  return $options;
 }

--- a/web/themes/contrib/civictheme/includes/views.inc
+++ b/web/themes/contrib/civictheme/includes/views.inc
@@ -131,7 +131,7 @@ function civictheme_preprocess_views_view_grid(array &$variables): void {
  *
  * @SuppressWarnings(PHPMD.CyclomaticComplexity)
  */
-function civictheme_form_views_exposed_form_alter(array &$form, FormStateInterface $form_state, string $form_id): void {
+function civictheme_form_views_exposed_form_alter(array &$form, FormStateInterface $form_state): void {
   $storage = $form_state->getStorage();
   // Pass view ID in attributes to the exposed filter preprocessor.
   // @see civictheme_preprocess_views_exposed_form()
@@ -140,9 +140,6 @@ function civictheme_form_views_exposed_form_alter(array &$form, FormStateInterfa
   }
 
   // Restrict Topics exposed filter to contextual filter term(s) when present.
-  if ($form_id !== 'views_exposed_form') {
-    return;
-  }
   $view = $form_state->get('view');
   if (!$view instanceof ViewExecutable || $view->id() !== 'civictheme_automated_list') {
     return;
@@ -151,11 +148,13 @@ function civictheme_form_views_exposed_form_alter(array &$form, FormStateInterfa
     return;
   }
   try {
-    $context_tids = _civictheme_get_topics_contextual_argument_tids($view);
-    if ($context_tids !== []) {
-      $options = _civictheme_build_topic_options_from_tids($context_tids);
+    $contextual_filter_tids = _civictheme_get_topics_contextual_argument_tids($view);
+    if ($contextual_filter_tids !== []) {
+      $options = _civictheme_build_topic_options_from_tids($contextual_filter_tids);
       if ($options !== []) {
-        $form['topic']['#options'] = ['All' => '- Any -'] + $options;
+        $form['topic']['#empty_option'] = t('- Any -');
+        $form['topic']['#empty_value'] = '';
+        $form['topic']['#options'] = $options;
       }
     }
   }
@@ -543,17 +542,17 @@ function _civictheme_get_topics_contextual_argument_tids(ViewExecutable $view): 
   }
 
   $argument_ids = array_keys($argument_options);
-  $pos = array_search('term_node_tid_depth', $argument_ids, TRUE);
-  if ($pos === FALSE) {
+  $argument_index = array_search('term_node_tid_depth', $argument_ids, TRUE);
+  if ($argument_index === FALSE) {
     return [];
   }
 
   $args = $view->args;
-  if (!isset($args[$pos]) || $args[$pos] === '' || $args[$pos] === 'all') {
+  if (!isset($args[$argument_index]) || $args[$argument_index] === '' || $args[$argument_index] === 'all') {
     return [];
   }
 
-  $parts = preg_split('/[\s+]+/', (string) $args[$pos]);
+  $parts = preg_split('/[\s+]+/', (string) $args[$argument_index]);
   if ($parts === FALSE) {
     return [];
   }

--- a/web/themes/contrib/civictheme/includes/views.inc
+++ b/web/themes/contrib/civictheme/includes/views.inc
@@ -128,6 +128,8 @@ function civictheme_preprocess_views_view_grid(array &$variables): void {
 
 /**
  * Implements hook_form_views_exposed_form_alter().
+ *
+ * @SuppressWarnings(PHPMD.CyclomaticComplexity)
  */
 function civictheme_form_views_exposed_form_alter(array &$form, FormStateInterface $form_state, string $form_id): void {
   $storage = $form_state->getStorage();
@@ -525,6 +527,9 @@ function _civictheme_preprocess_views_view__selected_filters_list__create_filter
  *
  * @return int[]
  *   Term IDs from the contextual argument, or empty if none/any.
+ *
+ * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+ * @SuppressWarnings(PHPMD.NPathComplexity)
  */
 function _civictheme_get_topics_contextual_argument_tids(ViewExecutable $view): array {
   $display = $view->getDisplay();
@@ -572,6 +577,8 @@ function _civictheme_get_topics_contextual_argument_tids(ViewExecutable $view): 
  *
  * @return array<int|string, string>
  *   Options array keyed by term ID, value is term name.
+ *
+ * @SuppressWarnings(PHPMD.StaticAccess)
  */
 function _civictheme_build_topic_options_from_tids(array $tids): array {
   if ($tids === []) {


### PR DESCRIPTION
https://www.drupal.org/project/civictheme/issues/3543033

## Checklist before requesting a review

- [x] I have formatted the subject to include ticket number as `Issue #123456 by drupal_org_username: Issue title`
- [x] I have added a link to the issue tracker
- [x] I have provided information in `Changed` section about WHY something was done if this was not a normal implementation
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run new and existing relevant tests locally with my changes, and they passed
- [ ] I have provided screenshots, where applicable

## Changed

1.

## Screenshots


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Topics filter for automated lists now shows contextually relevant options and includes a default "All" choice for easier filtering.
* **Bug Fixes**
  * More robust handling when building topic options prevents errors if contextual data is missing, ensuring the filter stays available and the page does not crash.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->