### PR TITLE
Issue #3576871 by sonictruth: Sometimes breadcrumb links are render arrays

### DIFF
--- a/web/themes/contrib/civictheme/includes/banner.inc
+++ b/web/themes/contrib/civictheme/includes/banner.inc
@@ -178,10 +178,14 @@ function _civictheme_preprocess_block__civictheme_banner__breadcrumb(array &$var
 
   // Gather existing links. Note that some profiles (GovCMS) may already have
   // the functionality to add current page as a last item implemented.
+  $renderer = \Drupal::service('renderer');
   foreach ($breadcrumb->getLinks() as $link) {
     $link_text = $link->getText();
+    if (is_array($link_text)) {
+      $link_text = (string) $renderer->renderInIsolation($link_text);
+    }
     $variables['breadcrumb']['links'][] = [
-      'text' => (string) (is_array($link_text) ? implode(' ', $link_text) : Xss::filter((string) $link_text)),
+      'text' => Xss::filter((string) $link_text),
       'url' => $link->getUrl()->toString(),
     ];
   }
@@ -200,8 +204,11 @@ function _civictheme_preprocess_block__civictheme_banner__breadcrumb(array &$var
     // Check if the link already exists and add it if not.
     if ($breadcrumb_last_link instanceof Link && ($breadcrumb_last_link->getText() != $link->getText() || $breadcrumb_last_link->getUrl() != $breadcrumb_last_link->getUrl())) {
       $link_text = $link->getText();
+      if (is_array($link_text)) {
+        $link_text = (string) $renderer->renderInIsolation($link_text);
+      }
       $variables['breadcrumb']['links'][] = [
-        'text' => is_array($link_text) ? (string) ($link_text['#markup'] ?? '') : (string) $link_text,
+        'text' => Xss::filter((string) $link_text),
         'url' => $link->getUrl()->toString(),
       ];
     }

--- a/web/themes/contrib/civictheme/includes/banner.inc
+++ b/web/themes/contrib/civictheme/includes/banner.inc
@@ -202,7 +202,7 @@ function _civictheme_preprocess_block__civictheme_banner__breadcrumb(array &$var
     $breadcrumb_last_link = end($breadcrumb_links);
     $link = Link::createFromRoute($title, '<none>');
     // Check if the link already exists and add it if not.
-    if ($breadcrumb_last_link instanceof Link && ($breadcrumb_last_link->getText() != $link->getText() || $breadcrumb_last_link->getUrl() != $breadcrumb_last_link->getUrl())) {
+    if ($breadcrumb_last_link instanceof Link && ($breadcrumb_last_link->getText() != $link->getText() || $breadcrumb_last_link->getUrl() != $link->getUrl())) {
       $link_text = $link->getText();
       if (is_array($link_text)) {
         $link_text = (string) $renderer->renderInIsolation($link_text);


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have formatted the subject to include ticket number as `Issue #123456 by drupal_org_username: Issue title`
- [x] I have added a link to the issue tracker
- [x] I have provided information in `Changed` section about WHY something was done if this was not a normal implementation
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run new and existing relevant tests locally with my changes, and they passed
- [ ] I have provided screenshots, where applicable

https://www.drupal.org/project/civictheme/issues/3576871

After installing Civic Theme on GovCMS D11, the user/x page was throwing this error:

```
The website encountered an unexpected error. Try again later.

TypeError: trim(): Argument #1 ($string) must be of type string, array given in trim() (line 1202 of /app/vendor/twig/twig/src/Extension/CoreExtension.php).
Twig\Extension\CoreExtension::trim() (Line: 70)
__TwigTemplate_36e03f6549d5af72865f0c414d519792->{closure}()
iterator_to_array() (Line: 53)
__TwigTemplate_36e03f6549d5af72865f0c414d519792->doDisplay() (Line: 402)
Twig\Template->yield() (Line: 77)
__TwigTemplate_78669e3f548ae0d08d01d9e91f08bbc1->{closure}()
iterator_to_array() (Line: 74)
__TwigTemplate_78669e3f548ae0d08d01d9e91f08bbc1->doDisplay() (Line: 402)
Twig\Template->yield() (Line: 170)
__TwigTemplate_c45de4997cde0b7ed6a86ae096c68ace->{closure}()
iterator_to_array() (Line: 167)
__TwigTemplate_c45de4997cde0b7ed6a86ae096c68ace->doDisplay() (Line: 402)
Twig\Template->yield() (Line: 301)
__TwigTemplate_443c3c868d2d328429df37755376aac1->block_breadcrumb_block() (Line: 446)
Twig\Template->yieldBlock() (Line: 132)
__TwigTemplate_443c3c868d2d328429df37755376aac1->doDisplay() (Line: 402)
Twig\Template->yield() (Line: 44)
__TwigTemplate_2c51b6ddc275d32cc88d44bba9564bc8->doDisplay() (Line: 402)
Twig\Template->yield() (Line: 386)
Twig\Template->render() (Line: 51)
Twig\TemplateWrapper->render() (Line: 35)
Drupal\Core\Template\TwigThemeEngine->renderTemplate() (Line: 428)
Drupal\Core\Theme\ThemeManager->render() (Line: 500)
Drupal\Core\Render\Renderer->doRender() (Line: 253)
Drupal\Core\Render\Renderer->doRenderRoot() (Line: 143)
Drupal\Core\Render\Renderer->Drupal\Core\Render\{closure}() (Line: 634)
Drupal\Core\Render\Renderer::Drupal\Core\Render\{closure}()
Fiber->resume() (Line: 649)
Drupal\Core\Render\Renderer->executeInRenderContext() (Line: 142)
Drupal\Core\Render\Renderer->renderInIsolation() (Line: 169)
Drupal\Core\Render\Renderer->doRenderPlaceholder() (Line: 760)
Drupal\Core\Render\Renderer->Drupal\Core\Render\{closure}()
Fiber->resume() (Line: 771)
Drupal\Core\Render\Renderer->replacePlaceholders() (Line: 265)
Drupal\Core\Render\Renderer->doRenderRoot() (Line: 143)
Drupal\Core\Render\Renderer->Drupal\Core\Render\{closure}() (Line: 634)
Drupal\Core\Render\Renderer::Drupal\Core\Render\{closure}()
Fiber->resume() (Line: 649)
Drupal\Core\Render\Renderer->executeInRenderContext() (Line: 142)
Drupal\Core\Render\Renderer->renderInIsolation() (Line: 113)
Drupal\Core\Render\Renderer->renderRoot() (Line: 253)
Drupal\Core\Render\HtmlResponseAttachmentsProcessor->renderPlaceholders() (Line: 93)
Drupal\Core\Render\HtmlResponseAttachmentsProcessor->processAttachments() (Line: 45)
Drupal\Core\EventSubscriber\HtmlResponseSubscriber->onRespond() (Line: 246)
Symfony\Component\EventDispatcher\EventDispatcher::Symfony\Component\EventDispatcher\{closure}() (Line: 206)
Symfony\Component\EventDispatcher\EventDispatcher->callListeners() (Line: 56)
Symfony\Component\EventDispatcher\EventDispatcher->dispatch() (Line: 216)
Symfony\Component\HttpKernel\HttpKernel->filterResponse() (Line: 204)
Symfony\Component\HttpKernel\HttpKernel->handleRaw() (Line: 76)
Symfony\Component\HttpKernel\HttpKernel->handle() (Line: 53)
Drupal\Core\StackMiddleware\Session->handle() (Line: 48)
Drupal\Core\StackMiddleware\KernelPreHandle->handle() (Line: 28)
Drupal\Core\StackMiddleware\ContentLength->handle() (Line: 118)
Drupal\page_cache\StackMiddleware\PageCache->pass() (Line: 92)
Drupal\page_cache\StackMiddleware\PageCache->handle() (Line: 263)
Drupal\shield\ShieldMiddleware->bypass() (Line: 219)
Drupal\shield\ShieldMiddleware->handle() (Line: 50)
Drupal\ban\BanMiddleware->handle() (Line: 48)
Drupal\Core\StackMiddleware\ReverseProxyMiddleware->handle() (Line: 51)
Drupal\Core\StackMiddleware\NegotiationMiddleware->handle() (Line: 53)
Drupal\Core\StackMiddleware\AjaxPageState->handle() (Line: 54)
Drupal\Core\StackMiddleware\StackedHttpKernel->handle() (Line: 745)
Drupal\Core\DrupalKernel->handle() (Line: 19)
```

I asked my friendly neighbourhood robot what the problem was and they replied thusly:

The error `trim(): Argument #1 ($string) must be of type string, array given` happens because:
1. Drupal’s Link::getText() can return a render array – On user pages (e.g. /user/1), breadcrumb link text (like the username) can be a render array instead of a string.
2. The theme was passing that array through – In banner.inc, when $link_text was an array, the code stored it directly in 'text':
'text' => is_array($link_text) ? $link_text : Xss::filter((string) $link_text),
3. Twig’s trim filter received an array – That text value is passed to the link component → text-icon component, which does text|trim|split(' ') in text-icon.twig line 36. When text is an array, trim() fails.

As this is my first one, please forgive me if I'm not following preferred process and let me know so I can adjust for next time. 

## Changed
1. Render the link in isolation before passing it the the 'text' 
2. run it through xss filter to prevent nasties.

## Screenshots


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved breadcrumb link text rendering and normalization for consistent display.
  * Fixed the logic for correctly identifying the final breadcrumb item in navigation paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->