### PR TITLE
[#3581084] Added fallback label template to map to civictheme:label component.

### DIFF
--- a/web/themes/contrib/civictheme/includes/form_element.inc
+++ b/web/themes/contrib/civictheme/includes/form_element.inc
@@ -379,11 +379,14 @@ function civictheme_preprocess_input__submit(array &$variables): void {
  * Implements template_preprocess_form_element_label().
  */
 function civictheme_preprocess_form_element_label(array &$variables): void {
-  $variables['content'] = $variables['title'];
+  $variables['content'] = $variables['title'] ?? '';
   $variables['tag'] = 'label';
   $variables['size'] = 'regular';
   $variables['is_required'] = $variables['required'] ?? FALSE;
+  $variables['required_text'] = $variables['is_required'] ? (string) t('(required)') : '';
   $variables['for'] = $variables['attributes']['for'] ?? '';
+  $variables['theme'] = $variables['theme'] ?? 'light';
+  $variables['modifier_class'] = $variables['modifier_class'] ?? '';
   unset($variables['attributes']['for']);
 }
 

--- a/web/themes/contrib/civictheme/includes/form_element.inc
+++ b/web/themes/contrib/civictheme/includes/form_element.inc
@@ -376,6 +376,18 @@ function civictheme_preprocess_input__submit(array &$variables): void {
 }
 
 /**
+ * Implements template_preprocess_form_element_label().
+ */
+function civictheme_preprocess_form_element_label(array &$variables): void {
+  $variables['content'] = $variables['title'];
+  $variables['tag'] = 'label';
+  $variables['size'] = 'regular';
+  $variables['is_required'] = $variables['required'] ?? FALSE;
+  $variables['for'] = $variables['attributes']['for'] ?? '';
+  unset($variables['attributes']['for']);
+}
+
+/**
  * Preprocesses a generic form element.
  *
  * @SuppressWarnings(PHPMD.CyclomaticComplexity)

--- a/web/themes/contrib/civictheme/templates/form/form-element-label.html.twig
+++ b/web/themes/contrib/civictheme/templates/form/form-element-label.html.twig
@@ -1,0 +1,24 @@
+{#
+/**
+ * @file
+ * Fallback CivicTheme theme implementation for a form element label.
+
+ * Only used when the form element being rendered is not a CivicTheme supported element.
+ *
+ * Available variables:
+ * - theme: [string] Theme variation (light or dark).
+ * - tag: [string] HTML tag to use (label, legend).
+ * - content: [string] The label's content.
+ * - size: [string] Label size (extra-large, large, regular, small, extra-small).
+ * - is_required: [boolean] Whether the label is required.
+ * - required_text: [string,null] Text to display within label element when required.
+ * - for: [string,null] Form element ID this label belongs to.
+ * - modifier_class: [string] Additional CSS classes.
+ * - attributes: [Drupal\Core\Template\Attribute] Additional HTML attributes.
+ *
+ * @see civictheme_preprocess_form_element_label()
+ *
+ * @ingroup themeable
+ */
+#}
+{% include 'civictheme:label' %}


### PR DESCRIPTION
## JIRA ticket: #3581084

## Checklist before requesting a review
- [x] I have formatted the subject to include ticket number as 
- [x] I have added a link to the issue tracker
- [x] I have provided information in  section about WHY something was done if this was not a normal implementation
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run new and existing relevant tests locally with my changes, and they passed
- [ ] I have provided screenshots, where applicable

## Changed
1. [#3581084] Added fallback label template to map to civictheme:label.

## Screenshots


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Form element labels now render with consistent, customizable styling and label variables for improved visual consistency across the site.
  * Required fields display a clear required indicator and proper accessibility attributes.
  * Label rendering includes a robust fallback for form element types not using the theme’s native controls, ensuring consistent output site-wide.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->