### PR TITLE
[#3581160] Updated webform markup preprocess to render markup with CivicTheme components and styles.

### DIFF
--- a/web/themes/contrib/civictheme/includes/webform.inc
+++ b/web/themes/contrib/civictheme/includes/webform.inc
@@ -7,6 +7,8 @@
 
 declare(strict_types=1);
 
+use Drupal\Core\Render\Markup;
+
 /**
  * Pre-process for Webform paragraph.
  */
@@ -19,4 +21,27 @@ function civictheme_preprocess_paragraph__civictheme_webform(array &$variables):
   if ($paragraph && civictheme_field_has_value($paragraph, 'field_c_p_webform')) {
     $variables['referenced_webform'] = $paragraph->get('field_c_p_webform')->view();
   }
+}
+
+/**
+ * Implements hook_preprocess_webform_html_editor_markup().
+ *
+ * @SuppressWarnings(PHPMD.StaticAccess)
+ */
+function civictheme_preprocess_webform_html_editor_markup(array &$variables) {
+  $markup = (string) $variables['markup'];
+  $processed = Markup::create(_civictheme_process__html_content($markup));
+  $variables['content'] = [
+    '#type' => 'component',
+    '#component' => 'civictheme:basic-content',
+    '#props' => [
+      'vertical_spacing' => 'both',
+      'is_contained' => TRUE,
+    ],
+    '#slots' => [
+      'content' => [
+        '#markup' => $processed,
+      ],
+    ],
+  ];
 }

--- a/web/themes/contrib/civictheme/includes/webform.inc
+++ b/web/themes/contrib/civictheme/includes/webform.inc
@@ -7,8 +7,6 @@
 
 declare(strict_types=1);
 
-use Drupal\Core\Render\Markup;
-
 /**
  * Pre-process for Webform paragraph.
  */
@@ -25,12 +23,10 @@ function civictheme_preprocess_paragraph__civictheme_webform(array &$variables):
 
 /**
  * Implements hook_preprocess_webform_html_editor_markup().
- *
- * @SuppressWarnings(PHPMD.StaticAccess)
  */
 function civictheme_preprocess_webform_html_editor_markup(array &$variables) {
   $markup = (string) $variables['markup'];
-  $processed = Markup::create(_civictheme_process__html_content($markup));
+  $processed = _civictheme_process__html_content($markup);
   $variables['content'] = [
     '#type' => 'component',
     '#component' => 'civictheme:basic-content',


### PR DESCRIPTION
## JIRA ticket: #3581160

## Checklist before requesting a review
- [x] I have formatted the subject to include ticket number as 
- [x] I have added a link to the issue tracker
- [x] I have provided information in  section about WHY something was done if this was not a normal implementation
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run new and existing relevant tests locally with my changes, and they passed
- [ ] I have provided screenshots, where applicable

## Changed
1. [#3581160] Added webform markup preprocess.

## Screenshots


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Webform HTML editor content now renders with improved consistency, utilizing standardized vertical spacing and contained layout for enhanced visual presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->