### PR TITLE
[#3581177] Updated form element description preprocess to check for description in webform help title field.

### DIFF
--- a/web/themes/contrib/civictheme/includes/form_element.inc
+++ b/web/themes/contrib/civictheme/includes/form_element.inc
@@ -569,6 +569,10 @@ function _civictheme_preprocess_form_element__classes(array &$variables): void {
 function _civictheme_preprocess_form_element__description(array &$variables): void {
   $variables['description'] = $variables['element']['#description'] ?? NULL;
   $variables['description_display'] = $variables['element']['#description_display'] ?? NULL;
+  if (!\Drupal::moduleHandler()->moduleExists('webform') && !WebformElementHelper::isWebformElement($variables['element'])) {
+    return;
+  }
+  $variables['description'] = $variables['description'] ?? $variables['element']['#help_title'] ?? NULL;
 }
 
 /**

--- a/web/themes/contrib/civictheme/includes/form_element.inc
+++ b/web/themes/contrib/civictheme/includes/form_element.inc
@@ -259,6 +259,7 @@ function civictheme_preprocess_fieldset__form_element__civictheme_field(array &$
   _civictheme_preprocess_form_element__classes($variables);
   _civictheme_preprocess_form_element__description($variables);
   _civictheme_preprocess_form_element__control($variables);
+  _civictheme_preprocess_form_element__webform__overrides($variables);
 }
 
 /**
@@ -376,6 +377,21 @@ function civictheme_preprocess_input__submit(array &$variables): void {
 }
 
 /**
+ * Implements template_preprocess_form_element_label().
+ */
+function civictheme_preprocess_form_element_label(array &$variables): void {
+  $variables['content'] = $variables['title'] ?? '';
+  $variables['tag'] = 'label';
+  $variables['size'] = 'regular';
+  $variables['is_required'] = $variables['required'] ?? FALSE;
+  $variables['required_text'] = $variables['is_required'] ? (string) t('(required)') : '';
+  $variables['for'] = $variables['attributes']['for'] ?? '';
+  $variables['theme'] = $variables['theme'] ?? 'light';
+  $variables['modifier_class'] = $variables['modifier_class'] ?? '';
+  unset($variables['attributes']['for']);
+}
+
+/**
  * Preprocesses a generic form element.
  *
  * @SuppressWarnings(PHPMD.CyclomaticComplexity)
@@ -421,8 +437,16 @@ function _civictheme_preprocess_form_element__generic(array &$variables): void {
     }
   }
   $variables['placeholder'] = $element['#placeholder'] ?? $element['#attributes']['placeholder'] ?? '';
-  $variables['prefix'] = $element['#field_prefix'] ?? $element['#prefix'] ?? '';
-  $variables['suffix'] = $element['#field_suffix'] ?? $element['#suffix'] ?? '';
+  $prefix = $element['#field_prefix'] ?? $element['#prefix'] ?? '';
+  $variables['prefix'] = !empty($prefix) ? [
+    '#type' => 'markup',
+    '#markup' => $prefix,
+  ] : $prefix;
+  $suffix = $element['#field_suffix'] ?? $element['#suffix'] ?? '';
+  $variables['suffix'] = !empty($suffix) ? [
+    '#type' => 'markup',
+    '#markup' => $suffix,
+  ] : $suffix;
 }
 
 /**
@@ -498,6 +522,34 @@ function _civictheme_preprocess_form_element__control(array &$variables): void {
 }
 
 /**
+ * Allows override of CivicTheme component settings from webform settings.
+ *
+ * These are set via customer settings (yaml) in webform elements.
+ *
+ * @see https://www.drupal.org/project/civictheme/issues/3581086
+ */
+function _civictheme_preprocess_form_element__webform__overrides(array &$variables): void {
+  $element = $variables['element'];
+  if (!civictheme_is_webform_element($element)) {
+    return;
+  }
+
+  $overrideable_settings = [
+    'theme',
+    'is_contained',
+    'vertical_spacing',
+    'with_background',
+    'modifier_class',
+  ];
+  foreach ($overrideable_settings as $setting) {
+    $webform_setting_id = '#' . $setting;
+    if (isset($element[$webform_setting_id])) {
+      $variables[$setting] = $element[$webform_setting_id];
+    }
+  }
+}
+
+/**
  * Sets form element theme based on attributes passed from parent components.
  */
 function _civictheme_preprocess_form_element__theme(array &$variables): void {
@@ -569,7 +621,7 @@ function _civictheme_preprocess_form_element__classes(array &$variables): void {
 function _civictheme_preprocess_form_element__description(array &$variables): void {
   $variables['description'] = $variables['element']['#description'] ?? NULL;
   $variables['description_display'] = $variables['element']['#description_display'] ?? NULL;
-  if (!\Drupal::moduleHandler()->moduleExists('webform') && !WebformElementHelper::isWebformElement($variables['element'])) {
+  if (civictheme_is_webform_element($variables['element'] ?? [])) {
     return;
   }
   $variables['description'] = $variables['description'] ?? $variables['element']['#help_title'] ?? NULL;

--- a/web/themes/contrib/civictheme/includes/utilities.inc
+++ b/web/themes/contrib/civictheme/includes/utilities.inc
@@ -804,6 +804,25 @@ function _civictheme_get_dom_document(string $content): \DOMDocument {
 }
 
 /**
+ * Check whether element is a webform element.
+ *
+ * Inlined to avoid a hard dependency on the webform module's classes.
+ *
+ * @see \Drupal\webform\Utility\WebformElementHelper::isWebformElement()
+ *
+ * @SuppressWarnings(PHPMD.StaticAccess)
+ */
+function civictheme_is_webform_element(array $element): bool {
+  if (!\Drupal::service('module_handler')->moduleExists('webform')) {
+    return FALSE;
+  }
+  if (isset($element['#webform_key']) || isset($element['#webform_element'])) {
+    return TRUE;
+  }
+  return \Drupal::service('webform.request')->isWebformAdminRoute();
+}
+
+/**
  * Check if the provided field is wysiwyg.
  *
  * @param string $field_type

--- a/web/themes/contrib/civictheme/includes/webform.inc
+++ b/web/themes/contrib/civictheme/includes/webform.inc
@@ -20,3 +20,15 @@ function civictheme_preprocess_paragraph__civictheme_webform(array &$variables):
     $variables['referenced_webform'] = $paragraph->get('field_c_p_webform')->view();
   }
 }
+
+/**
+ * Implements hook_preprocess_webform__container().
+ */
+function civictheme_preprocess_webform__container(array &$variables): void {
+  if (!civictheme_is_webform_element($variables['element'])) {
+    return;
+  }
+  _civictheme_preprocess_form_element__webform__overrides($variables);
+  $variables['content'] = $variables['children'];
+  unset($variables['children']);
+}


### PR DESCRIPTION
## JIRA ticket: #3581177

## Checklist before requesting a review
- [x] I have formatted the subject to include ticket number as 
- [x] I have added a link to the issue tracker
- [x] I have provided information in  section about WHY something was done if this was not a normal implementation
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run new and existing relevant tests locally with my changes, and they passed
- [ ] I have provided screenshots, where applicable

## Changed
1. [#3581177] Updated form element description preprocess to fall back to webform help_title field when description is absent.

## Screenshots


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved form element description handling to correctly display help text, particularly when the webform module is not available, with enhanced fallback logic for alternate help information sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->