### PR TITLE
[#3583803] Added schema for vertical spacing in layout sections.

### DIFF
--- a/web/themes/contrib/civictheme/config/schema/civictheme.schema.yml
+++ b/web/themes/contrib/civictheme/config/schema/civictheme.schema.yml
@@ -416,3 +416,6 @@ layout_plugin.settings.civictheme_three_columns:
     is_contained:
       type: boolean
       label: 'Is Contained'
+    vertical_spacing:
+      type: string
+      label: 'Vertical Spacing'

--- a/web/themes/contrib/civictheme/src/Plugin/Layout/ThreeColumnsLayout.php
+++ b/web/themes/contrib/civictheme/src/Plugin/Layout/ThreeColumnsLayout.php
@@ -17,7 +17,10 @@ class ThreeColumnsLayout extends LayoutDefault implements PluginFormInterface {
   public function defaultConfiguration() {
     $configuration = parent::defaultConfiguration();
 
-    return $configuration + ['is_contained' => FALSE];
+    return $configuration + [
+      'is_contained' => FALSE,
+      'vertical_spacing' => 'auto',
+    ];
   }
 
   /**


### PR DESCRIPTION
## JIRA ticket: #3583803

## Checklist before requesting a review
- [x] I have formatted the subject to include ticket number as 
- [x] I have added a link to the issue tracker
- [x] I have provided information in  section about WHY something was done if this was not a normal implementation
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run new and existing relevant tests locally with my changes, and they passed
- [ ] I have provided screenshots, where applicable

## Changed
1. [3583803] Added vertical_spacing schema field to civictheme layout plugin settings.

## Screenshots


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Vertical Spacing" setting to three-column layouts, letting users control vertical spacing between layout elements. The option defaults to "auto" and integrates with the layout configuration and editor form.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->