### PR TITLE
#3586633 Added accessible datetime form element.

### DIFF
--- a/web/themes/contrib/civictheme/includes/form_element.inc
+++ b/web/themes/contrib/civictheme/includes/form_element.inc
@@ -111,6 +111,13 @@ function civictheme_theme_suggestions_form_element_alter(array &$suggestions, ar
     $suggestions[] = 'form_element__civictheme_field';
     $suggestions[] = 'form_element__civictheme_field__' . $variables['element']['#type'];
   }
+
+  // Datetime composite elements are rendered through a dedicated template
+  // that wraps the two inner date/time inputs inside a fieldset/legend for
+  // accessible grouping (a single <label for> cannot reference two inputs).
+  if (($variables['element']['#type'] ?? '') === 'datetime') {
+    $suggestions[] = 'form_element__datetime';
+  }
 }
 
 /**
@@ -224,6 +231,88 @@ function civictheme_preprocess_form_element__civictheme_field__search(array &$va
     $attributes->setAttribute('placeholder', $element['#attributes']['placeholder']);
   }
   $variables['control'][0]['attributes'] = $attributes;
+}
+
+/**
+ * Implements template_preprocess_form_element().
+ *
+ * Map the Drupal `webform_time` element type to the HTML5 `time` input type
+ * so the rendered input is a native time picker rather than a plain text
+ * input fallback (`<input type="webform_time">`).
+ */
+function civictheme_preprocess_form_element__civictheme_field__webform_time(array &$variables): void {
+  if (!empty($variables['control'][0])) {
+    $variables['control'][0]['type'] = 'time';
+  }
+}
+
+/**
+ * Implements template_preprocess_form_element().
+ *
+ * Map the Drupal `webform_date` element type to the HTML5 `date` input type.
+ */
+function civictheme_preprocess_form_element__civictheme_field__webform_date(array &$variables): void {
+  if (!empty($variables['control'][0])) {
+    $variables['control'][0]['type'] = 'date';
+  }
+}
+
+/**
+ * Implements hook_preprocess_HOOK() for form_element__datetime.
+ *
+ * Prepares variables for the accessible datetime composite wrapper so it is
+ * rendered through the CivicTheme Fieldset component, grouping the inner
+ * date and time inputs inside a <fieldset>/<legend>.
+ */
+function civictheme_preprocess_form_element__datetime(array &$variables): void {
+  $element = $variables['element'];
+
+  $classes = $variables['attributes']['class'] ?? [];
+  if (is_string($classes)) {
+    $classes = [$classes];
+  }
+  $classes[] = 'ct-field';
+  $variables['attributes']['class'] = $classes;
+
+  $variables['legend_title'] = (string) ($element['#title'] ?? '');
+  $variables['is_required'] = !empty($element['#required']);
+  $variables['description'] = $element['#description'] ?? '';
+}
+
+/**
+ * Implements hook_preprocess_HOOK() for datetime_form.
+ *
+ * Replaces the inner datetime_form content with a CivicTheme Grid component
+ * that lays out the date and time sub-elements side-by-side.
+ */
+function civictheme_preprocess_datetime_form(array &$variables): void {
+  $element = $variables['element'];
+  if (empty($element['date']) || empty($element['time'])) {
+    return;
+  }
+
+  $variables['type'] = 'datetime';
+  if (!empty($element['#name'])) {
+    $variables['name'] = $element['#name'];
+  }
+  _civictheme_preprocess_form_element__classes($variables);
+
+  $grid_attributes = new Attribute($variables['attributes'] ?? []);
+  $variables['attributes'] = [];
+
+  $variables['content'] = [
+    '#type' => 'component',
+    '#component' => 'civictheme:grid',
+    '#props' => [
+      'template_column_count' => 2,
+      'use_container' => FALSE,
+      'attributes' => $grid_attributes,
+      'items' => [
+        $element['date'],
+        $element['time'],
+      ],
+    ],
+  ];
 }
 
 /**

--- a/web/themes/contrib/civictheme/includes/form_element.inc
+++ b/web/themes/contrib/civictheme/includes/form_element.inc
@@ -41,6 +41,7 @@
  * | Theme Hook Suggestions Generated                   |
  * | - form_element__civictheme_field                   |
  * | - form_element__civictheme_field__<type>           |
+ * | - form_element__datetime (for datetime composites) |
  * | - fieldset__form_element__civictheme_field         |
  * | - fieldset__form_element__civictheme_field__<type> |
  * +----------------------------------------------------+
@@ -235,25 +236,19 @@ function civictheme_preprocess_form_element__civictheme_field__search(array &$va
 
 /**
  * Implements template_preprocess_form_element().
- *
- * Map the Drupal `webform_time` element type to the HTML5 `time` input type
- * so the rendered input is a native time picker rather than a plain text
- * input fallback (`<input type="webform_time">`).
  */
 function civictheme_preprocess_form_element__civictheme_field__webform_time(array &$variables): void {
-  if (!empty($variables['control'][0])) {
-    $variables['control'][0]['type'] = 'time';
+  if (!empty($variables['type']) && $variables['type'] === 'webform_time') {
+    $variables['type'] = 'time';
   }
 }
 
 /**
  * Implements template_preprocess_form_element().
- *
- * Map the Drupal `webform_date` element type to the HTML5 `date` input type.
  */
 function civictheme_preprocess_form_element__civictheme_field__webform_date(array &$variables): void {
-  if (!empty($variables['control'][0])) {
-    $variables['control'][0]['type'] = 'date';
+  if (!empty($variables['type']) && $variables['type'] === 'webform_date') {
+    $variables['type'] = 'date';
   }
 }
 

--- a/web/themes/contrib/civictheme/templates/form/form-element--datetime.html.twig
+++ b/web/themes/contrib/civictheme/templates/form/form-element--datetime.html.twig
@@ -14,7 +14,7 @@
  */
 #}
 {% include 'civictheme:fieldset' with {
-  theme: 'light',
+  theme: theme|default('light'),
   legend: legend_title,
   is_required: is_required,
   required_text: is_required ? '(required)'|t : '',

--- a/web/themes/contrib/civictheme/templates/form/form-element--datetime.html.twig
+++ b/web/themes/contrib/civictheme/templates/form/form-element--datetime.html.twig
@@ -1,0 +1,24 @@
+{#
+/**
+ * @file
+ * CivicTheme override for the `datetime` composite form element.
+ *
+ * Renders the outer wrapper as a CivicTheme Fieldset (<fieldset>/<legend>)
+ * so screen readers announce the two inner inputs (date + time) as a
+ * single labelled group. The inner inputs keep their own per-input labels
+ * (one label per input), satisfying the HTML rule that a single <label>
+ * cannot reference two form controls.
+ *
+ * @see civictheme_preprocess_form_element__datetime()
+ * @see civictheme_preprocess_datetime_form()
+ */
+#}
+{% include 'civictheme:fieldset' with {
+  theme: 'light',
+  legend: legend_title,
+  is_required: is_required,
+  required_text: is_required ? '(required)'|t : '',
+  description: description,
+  attributes: attributes,
+  fields: children,
+} only %}


### PR DESCRIPTION
## Checklist before requesting a review
- [x] This PR does not have an associated ticket
- [x] I have provided information in  section about WHY something was done if this was not a normal implementation
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run new and existing relevant tests locally with my changes, and they passed
- [ ] I have provided screenshots, where applicable

## Changed
1. Added accessible datetime composite form element template for datetime.

It has a fieldgroup and legend wrapping the composite form element. Each input has a visually hidden label.
Added preprocess to fix the time input which had `webform_time` and `webform_date` as types.

Reference: https://www.w3.org/WAI/tutorials/forms/grouping/

## Screenshots

### Datetime with webform

<img width="2371" height="1069" alt="image" src="https://github.com/user-attachments/assets/24e47e98-0184-4432-bf48-f5954cbf7106" />

## Summary by CodeRabbit

* **New Features**
  * Enhanced datetime form element rendering with improved theme suggestions for better form organization and accessibility
  * Improved display of webform date and time fields with proper HTML5 input type mappings
  * Better form element styling and layout using fieldset component wrapper for composite datetime elements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced datetime form field rendering with improved layout and styling for date and time inputs displayed side-by-side.
  * Better visual structure and labeling for composite datetime form fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->