### PR TITLE
Issue #3589650 by r.imassi: Navigation component isn't passed 'theme'

### DIFF
--- a/web/themes/contrib/civictheme/templates/block/block--menu-block--civictheme-primary-navigation.html.twig
+++ b/web/themes/contrib/civictheme/templates/block/block--menu-block--civictheme-primary-navigation.html.twig
@@ -8,6 +8,7 @@
 
 {% block content_block %}
   {% include 'civictheme:navigation' with {
+    theme,
     items,
     type: dropdown == 'none' ? 'inline' : dropdown,
     dropdown_columns,

--- a/web/themes/contrib/civictheme/templates/block/block--menu-block--civictheme-secondary-navigation.html.twig
+++ b/web/themes/contrib/civictheme/templates/block/block--menu-block--civictheme-secondary-navigation.html.twig
@@ -8,6 +8,7 @@
 
 {% block content_block %}
   {% include 'civictheme:navigation' with {
+    theme,
     items,
     type: dropdown == 'none' ? 'inline' : dropdown,
     dropdown_columns,


### PR DESCRIPTION
Issue: https://www.drupal.org/project/civictheme/issues/3589650

## Changed

1. Pass the 'theme' variable from the primary/secondary navigation block templates to the 'civictheme:navigation' component.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated navigation block templates to pass additional theme configuration parameters for improved consistency.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/civictheme/monorepo-drupal/pull/1521)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->