### PR TITLE
Issue #3593631 by alan.cole: Fix encoded (&amp;) ampersands showing in breadcrumbs.

### DIFF
--- a/web/themes/contrib/civictheme/includes/banner.inc
+++ b/web/themes/contrib/civictheme/includes/banner.inc
@@ -185,7 +185,7 @@ function _civictheme_preprocess_block__civictheme_banner__breadcrumb(array &$var
       $link_text = (string) $renderer->renderInIsolation($link_text);
     }
     $variables['breadcrumb']['links'][] = [
-      'text' => Xss::filter((string) $link_text),
+      'text' => html_entity_decode(Xss::filter((string) $link_text)),
       'url' => $link->getUrl()->toString(),
     ];
   }
@@ -208,7 +208,7 @@ function _civictheme_preprocess_block__civictheme_banner__breadcrumb(array &$var
     // Check if the link already exists and add it if not.
     if ($breadcrumb_last_link instanceof Link && ($breadcrumb_last_link->getText() !== $link_text || $breadcrumb_last_link->getUrl()->toString() !== $link->getUrl()->toString())) {
       $variables['breadcrumb']['links'][] = [
-        'text' => Xss::filter((string) $link_text),
+        'text' => html_entity_decode(Xss::filter((string) $link_text)),
         'url' => $link->getUrl()->toString(),
       ];
     }


### PR DESCRIPTION
https://www.drupal.org/project/civictheme/issues/3593631

## Checklist before requesting a review

- [x] I have formatted the subject to include ticket number as `Issue #123456 by drupal_org_username: Issue title`
- [x] I have added a link to the issue tracker
- [x] I have provided information in `Changed` section about WHY something was done if this was not a normal implementation
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run new and existing relevant tests locally with my changes, and they passed
- [x] I have provided screenshots, where applicable

## Changed

1. Run html_entity_decode over the XSS filtered link text in breadcrumbs.

## Screenshots

Before:

<img width="1280" height="1024" alt="Screen Shot 2026-06-04 at 15 03 26" src="https://github.com/user-attachments/assets/d40ebdf5-1540-4633-8652-0b8cd494ee6b" />

After:

<img width="1280" height="1024" alt="Screen Shot 2026-06-04 at 15 03 41" src="https://github.com/user-attachments/assets/81fbff5b-7761-4689-8613-2b6e1d80180c" />
