### PR TITLE
 Issue #3467058 by alan.cole: Fixed duplicate main; moved main to page / layout to use div.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,22 +1,21 @@
 {
-  "name": "civictheme",
+  "name": "civictheme-monorepo",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "civictheme",
       "workspaces": [
         "scripts/civictheme-uikit-version-manager",
         "scripts/civictheme-dependency-checker"
       ],
       "dependencies": {
-        "@civictheme/sdc": "1.13.0"
+        "@civictheme/uikit": "github:civictheme/uikit#83c43d321c0decb76ac1b2d135e37a288d8467a6"
       }
     },
-    "node_modules/@civictheme/sdc": {
+    "node_modules/@civictheme/uikit": {
       "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/@civictheme/sdc/-/sdc-1.13.0.tgz",
-      "integrity": "sha512-cRJA1Q02P1qCyct7ocJke5T2Me+yLOp4Fe/zbJQLGc19KNNhlZzDuJIU2wPRAQ0MH31UnMFuIS6zdikK6Y/pug==",
+      "resolved": "git+ssh://git@github.com/civictheme/uikit.git#83c43d321c0decb76ac1b2d135e37a288d8467a6",
+      "integrity": "sha512-voFSk44+YjNYLYcqvM8RCVa5kB/nXgdeQS/0Z37fKmhl0YMoQUkhokErpY4ylXE2A5OvzQPfo2CYMWE4gUJShg==",
       "cpu": [
         "x64",
         "arm",
@@ -29,11 +28,11 @@
         "linux",
         "win32"
       ],
-      "dependencies": {
-        "@popperjs/core": "^2.11.8"
-      },
-      "engines": {
-        "node": ">=22.6.0"
+      "workspaces": [
+        "packages/*"
+      ],
+      "optionalDependencies": {
+        "@rollup/rollup-darwin-arm64": "^4.40.2"
       }
     },
     "node_modules/@inquirer/ansi": {
@@ -370,15 +369,17 @@
         }
       }
     },
-    "node_modules/@popperjs/core": {
-      "version": "2.11.8",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
-      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/popperjs"
-      }
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.61.1.tgz",
+      "integrity": "sha512-0F1L/Z3Eqv8mT2n3dCpeO8GcTvHvVqkP5/t6DMsn0KzhYVcg+s7Ncl5DS8qjKYEeio6Az0Gt6nyBORay5qIlCA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
     },
     "node_modules/ansi-regex": {
       "version": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "scripts/civictheme-dependency-checker"
   ],
   "dependencies": {
-    "@civictheme/sdc": "1.13.0"
+    "@civictheme/uikit": "github:civictheme/uikit#83c43d321c0decb76ac1b2d135e37a288d8467a6"
   },
   "scripts": {
     "uikit-change": "npm start --workspace=civictheme-uikit-version-change",

--- a/web/themes/contrib/civictheme/package-lock.json
+++ b/web/themes/contrib/civictheme/package-lock.json
@@ -21,7 +21,7 @@
         "win32"
       ],
       "dependencies": {
-        "@civictheme/sdc": "1.13.0",
+        "@civictheme/uikit": "github:civictheme/uikit#83c43d321c0decb76ac1b2d135e37a288d8467a6",
         "@popperjs/core": "^2.11.8"
       },
       "devDependencies": {
@@ -165,10 +165,10 @@
       "dev": true,
       "license": "GPL-2.0-or-later"
     },
-    "node_modules/@civictheme/sdc": {
+    "node_modules/@civictheme/uikit": {
       "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/@civictheme/sdc/-/sdc-1.13.0.tgz",
-      "integrity": "sha512-cRJA1Q02P1qCyct7ocJke5T2Me+yLOp4Fe/zbJQLGc19KNNhlZzDuJIU2wPRAQ0MH31UnMFuIS6zdikK6Y/pug==",
+      "resolved": "git+ssh://git@github.com/civictheme/uikit.git#83c43d321c0decb76ac1b2d135e37a288d8467a6",
+      "integrity": "sha512-voFSk44+YjNYLYcqvM8RCVa5kB/nXgdeQS/0Z37fKmhl0YMoQUkhokErpY4ylXE2A5OvzQPfo2CYMWE4gUJShg==",
       "cpu": [
         "x64",
         "arm",
@@ -181,11 +181,11 @@
         "linux",
         "win32"
       ],
-      "dependencies": {
-        "@popperjs/core": "^2.11.8"
-      },
-      "engines": {
-        "node": ">=22.6.0"
+      "workspaces": [
+        "packages/*"
+      ],
+      "optionalDependencies": {
+        "@rollup/rollup-darwin-arm64": "^4.40.2"
       }
     },
     "node_modules/@csstools/css-calc": {
@@ -1132,7 +1132,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [

--- a/web/themes/contrib/civictheme/package.json
+++ b/web/themes/contrib/civictheme/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "@popperjs/core": "^2.11.8",
-    "@civictheme/sdc": "1.13.0"
+    "@civictheme/uikit": "github:civictheme/uikit#83c43d321c0decb76ac1b2d135e37a288d8467a6"
   },
   "devDependencies": {
     "@civictheme/scss-variables-extractor": "^0.2.1",

--- a/web/themes/contrib/civictheme/templates/layout/layout--three-columns.html.twig
+++ b/web/themes/contrib/civictheme/templates/layout/layout--three-columns.html.twig
@@ -45,7 +45,7 @@
 {% set modifier_class = modifier_class|trim %}
 
 {% if content %}
-  <main class="ct-layout {{ modifier_class -}}" role="main" data-layout-builder-layout="true" {% if attributes is not empty %}{{- attributes -}}{% endif %}>
+  <div class="ct-layout {{ modifier_class -}}" data-layout-builder-layout="true" {% if attributes is not empty %}{{- attributes -}}{% endif %}>
     {% block content_top_block %}
       {% if content.content_top is not empty %}
         {{- content.content_top -}}
@@ -99,5 +99,5 @@
         {{- content.content_bottom -}}
       {% endif %}
     {% endblock %}
-  </main>
+  </div>
 {% endif %}


### PR DESCRIPTION
https://www.drupal.org/project/civictheme/issues/3467058

## Checklist before requesting a review

- [x] I have formatted the subject to include ticket number as `Issue #123456 by drupal_org_username: Issue title`
- [x] I have added a link to the issue tracker
- [x] I have provided information in `Changed` section about WHY something was done if this was not a normal implementation
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have run new and existing relevant tests locally with my changes, and they passed
- [x] I have provided screenshots, where applicable

## Changed

1. `civictheme:layout` component to use `<div>` instead of `<main>`. Remove `role="main"` as well.
2. `civictheme:page` should then wrap the following slots (`banner_block`, `highlighted_block`, `content_block`) in a `<main>`.
3. Update `/templates/layout/layout--three-columns.html.twig` to remove main too (this was based off layout).
4. Removed logic to place skip link on banner or layout as `<main>` is now the single place to skip to.

This should ensure a single main exists, and wraps the non-header / non-footer content in a `<main>`.

Given that page handles the `header` and `footer` slot - it would make sense for it to handle the `main` slot as well.

## Screenshots
<img width="2106" height="570" alt="image" src="https://github.com/user-attachments/assets/4671b997-c6ec-4c50-9eb4-edde3a1a07e3" />
