### PR TITLE
Issue #3606009 by  joshua1234511: Duplicate trailing breadcrumb item on listing/view pages where breadcrumb already ends with the current page

### DIFF
--- a/web/themes/contrib/civictheme/includes/banner.inc
+++ b/web/themes/contrib/civictheme/includes/banner.inc
@@ -205,10 +205,23 @@ function _civictheme_preprocess_block__civictheme_banner__breadcrumb(array &$var
     if (is_array($link_text)) {
       $link_text = (string) $renderer->renderInIsolation($link_text);
     }
-    // Check if the link already exists and add it if not.
-    if ($breadcrumb_last_link instanceof Link && ($breadcrumb_last_link->getText() !== $link_text || $breadcrumb_last_link->getUrl()->toString() !== $link->getUrl()->toString())) {
+    // Check if the current page is already the last breadcrumb item and only
+    // add it if it is not. The appended link always uses the '<none>' route, so
+    // its URL can never match the existing crumb's URL; comparing by URL would
+    // always append a duplicate trailing item when the breadcrumb already ends
+    // with the current page (e.g. on GovCMS). Compare the rendered text only.
+    $last_link_text = NULL;
+    if ($breadcrumb_last_link instanceof Link) {
+      $last_link_text = $breadcrumb_last_link->getText();
+      if (is_array($last_link_text)) {
+        $last_link_text = (string) $renderer->renderInIsolation($last_link_text);
+      }
+      $last_link_text = html_entity_decode(Xss::filter((string) $last_link_text));
+    }
+    $new_link_text = html_entity_decode(Xss::filter((string) $link_text));
+    if ($last_link_text !== $new_link_text) {
       $variables['breadcrumb']['links'][] = [
-        'text' => html_entity_decode(Xss::filter((string) $link_text)),
+        'text' => $new_link_text,
         'url' => $link->getUrl()->toString(),
       ];
     }


### PR DESCRIPTION
https://www.drupal.org/project/civictheme/issues/3606009

## Checklist before requesting a review

- [x] I have formatted the subject to include ticket number as `Issue #123456 by drupal_org_username: Issue title`
- [x] I have added a link to the issue tracker
- [x] I have provided information in `Changed` section about WHY something was done if this was not a normal implementation
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run new and existing relevant tests locally with my changes, and they passed
- [ ] I have provided screenshots, where applicable

## Changed

1. `_civictheme_preprocess_block__civictheme_banner__breadcrumb()` now compares the rendered, normalised text of the existing last crumb against the current page title and skips re-adding it. 

## Screenshots


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate breadcrumb entries from appearing at the end of banner navigation when the current page is already included.
  * Improved breadcrumb display consistency by comparing the visible text before adding the final item.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->