### PR TITLE
[#3609441] fix: #3609441 Update CK Editor styles to override new CK Editor variables

### DIFF
--- a/web/themes/contrib/civictheme/assets/sass/theme.editor.scss
+++ b/web/themes/contrib/civictheme/assets/sass/theme.editor.scss
@@ -9,7 +9,8 @@
 @import 'components/00-base/**/fonts';
 @import 'components/01-atoms/**/button/*.scss';
 
-.ck-editor__editable {
+.ck-editor__editable,
+.ck-content.ck-editor__editable {
   @include ct-content();
   @include ct-content-light();
 }

--- a/web/themes/contrib/civictheme/civictheme_starter_kit/assets/sass/theme.editor.scss
+++ b/web/themes/contrib/civictheme/civictheme_starter_kit/assets/sass/theme.editor.scss
@@ -9,7 +9,8 @@
 @import 'components_combined/00-base/**/fonts';
 @import 'components_combined/01-atoms/**/button/*.scss';
 
-.ck-editor__editable {
+.ck-editor__editable,
+.ck-content.ck-editor__editable {
   @include ct-content();
   @include ct-content-light();
 }


### PR DESCRIPTION
## JIRA ticket: [#3609441](https://www.drupal.org/project/civictheme/issues/3609441)

## Checklist before requesting a review
- [x] I have formatted the subject to include ticket number as 
- [x] I have added a link to the issue tracker
- [x] I have provided information in  section about WHY something was done if this was not a normal implementation
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run new and existing relevant tests locally with my changes, and they passed
- [ ] I have provided screenshots, where applicable

## Changed
1. fix: #3609441 Update CK Editor styles to override new CK Editor variables

## Screenshots

These were the offending inline styles now added by CK Editor
<img width="601" height="405" alt="image" src="https://github.com/user-attachments/assets/08de81cf-b2dd-440d-b477-0472d16439ce" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Editor content styling now applies consistently to both standard and nested editable areas, improving appearance in the rich text editor.
  * Updated the editor theme so editable content uses the intended formatting in more editing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->