### PR TITLE
Issue #3612955 by alan.cole: Custom fonts served from assets path do not show in storybook.

### DIFF
--- a/web/themes/contrib/civictheme/.storybook/preview.js
+++ b/web/themes/contrib/civictheme/.storybook/preview.js
@@ -1,6 +1,6 @@
 // phpcs:ignoreFile
 import '../dist/civictheme.stories.css?module';
-import '../dist/civictheme.base.css';
+import '../dist/civictheme.stories.base.css';
 import '../dist/civictheme.variables.css';
 import '../dist/civictheme.base';
 

--- a/web/themes/contrib/civictheme/.storybook/preview.js
+++ b/web/themes/contrib/civictheme/.storybook/preview.js
@@ -1,6 +1,6 @@
 // phpcs:ignoreFile
 import '../dist/civictheme.stories.css?module';
-import '../dist/civictheme.stories.base.css';
+import '../dist/civictheme.base.storybook.css';
 import '../dist/civictheme.variables.css';
 import '../dist/civictheme.base';
 

--- a/web/themes/contrib/civictheme/build.js
+++ b/web/themes/contrib/civictheme/build.js
@@ -16,6 +16,8 @@ Notes:
 */
 
 import fs from 'fs'
+import { createRequire } from 'module';
+import { fileURLToPath } from 'url';
 import path from 'path'
 import { globSync } from 'glob'
 import { execSync, spawn } from 'child_process'
@@ -87,7 +89,7 @@ const DIR_OUT                   = fullPath('./dist/')
 const DIR_ASSETS_IN             = fullPath('./assets/')
 const DIR_ASSETS_OUT            = fullPath('./dist/assets/')
 
-const DIR_CIVICTHEME            = config.base ? null : getCivicthemeDir(PATH, 'themes', '/**/civictheme')
+const DIR_CIVICTHEME            = config.base || config.cli ? null : getCivicthemeDir(PATH, 'themes', '/**/civictheme')
 const DIR_UIKIT_COMPONENTS_IN   = config.base ? null : `${DIR_CIVICTHEME}/components/`
 const DIR_UIKIT_COPY_OUT        = config.base ? null : fullPath('./.components-civictheme/')
 const DIR_COMPONENTS_OUT        = config.base ? null : fullPath('./components_combined/')
@@ -121,7 +123,7 @@ const VAR_SB_ASSETS_DIRECTORY   = `$ct-assets-directory: '${DIR_SB_ASSETS}';`
 const JS_FILE_OUT               = `${DIR_OUT}/${SCRIPT_NAME}.js`
 const JS_STORYBOOK_FILE_OUT     = `${DIR_OUT}/${SCRIPT_NAME}.storybook.js`
 const JS_CIVIC_IMPORTS          = `${COMPONENT_DIR}/**/!(*.stories|*.stories.data|*.component|*.min|*.test|*.script|*.utils).js`
-const JS_LIB_IMPORTS            = [fullPath('./node_modules/@popperjs/core/dist/umd/popper.js')]
+const JS_LIB_IMPORTS            = [path.join(modulePath('@popperjs/core').replace('dist/cjs/popper.js', 'dist/umd/popper.js'))]
 const JS_ASSET_IMPORTS          = [
                                     DIR_CIVICTHEME ? `${DIR_CIVICTHEME}/assets/js/**/*.js` : false,
                                     `${DIR_ASSETS_IN}/js/**/*.js`,
@@ -135,11 +137,10 @@ const CONSTANTS_ICON_UTIL       = `${COMPONENT_DIR}/00-base/icon/icon.utils.js`
 const CONSTANTS_LOGO_UTIL       = `${COMPONENT_DIR}/02-molecules/logo/logo.utils.js`
 
 const STYLE_SDC_COMMON_INCLUDES      = [VAR_CT_ASSETS_DIRECTORY, `@import '00-base/variables';`]
-const STYLE_SDC_SB_COMMON_INCLUDES   = [VAR_SB_ASSETS_DIRECTORY, `@import '00-base/variables';`]
 const STYLE_SDC_MIXIN_IMPORTS        = `00-base/mixins/**/*.scss`
 const STYLE_SDC_BASE_IMPORTS         = `00-base/**/!(*.stories|variables|_variables.*).scss`
 const STYLE_SDC_BASE_FILE_OUT        = `${DIR_OUT}/${STYLE_NAME}.base.css`;
-const STYLE_SDC_SB_BASE_FILE_OUT     = `${DIR_OUT}/${STYLE_NAME}.stories.base.css`;
+const STYLE_SDC_SB_BASE_FILE_OUT     = `${DIR_OUT}/${STYLE_NAME}.base.storybook.css`;
 const JS_SDC_BASE_FILE_OUT           = `${DIR_OUT}/${SCRIPT_NAME}.drupal.base.js`
 const JS_SDC_STORYBOOK_BASE_FILE_OUT = `${DIR_OUT}/${SCRIPT_NAME}.base.js`
 const JS_SDC_BASE_IMPORTS            = `${COMPONENT_DIR}/00-base/**/!(*.stories|*.test|*.data|*.stories.data|*.utils).js`
@@ -281,15 +282,23 @@ function buildStylesTheme() {
 
 function buildStylesSdcBase() {
   if (config.sdc_base) {
-    const baseImports = getImportsFromGlob(STYLE_SDC_BASE_IMPORTS, COMPONENT_DIR)
-    const generateSdcBase = (commonIncludes, writeFile) => {
-      const baseCss = [...commonIncludes, baseImports].join('\n')
-      const compiled = sass.compileString(baseCss, { loadPaths: [COMPONENT_DIR] })
-      fs.writeFileSync(writeFile, SDC_HEADER + sortCssLines(compiled.css))
-    }
-    generateSdcBase(STYLE_SDC_COMMON_INCLUDES, STYLE_SDC_BASE_FILE_OUT) // CT Base
-    generateSdcBase(STYLE_SDC_SB_COMMON_INCLUDES, STYLE_SDC_SB_BASE_FILE_OUT) // Storybook Base
-    successReporter(`Saved: SDC styles (base) ${time()}`)
+    const baseCss = [
+      ...STYLE_SDC_COMMON_INCLUDES,
+      getImportsFromGlob(STYLE_SDC_BASE_IMPORTS, COMPONENT_DIR),
+    ].join('\n')
+    const compiled = sass.compileString(baseCss, { loadPaths: [COMPONENT_DIR] })
+    fs.writeFileSync(STYLE_SDC_BASE_FILE_OUT, SDC_HEADER + sortCssLines(compiled.css))
+    successReporter(`Saved: SDC base styles (base) ${time()}`)
+  }
+}
+
+function buildStylesSdcBaseStorybook() {
+  if (config.sdc_base && config.styles_storybook) {
+    // Replace the asset path.
+    let file = fs.readFileSync(STYLE_SDC_BASE_FILE_OUT, 'utf-8')
+    file = file.replaceAll(DIR_CT_ASSETS, DIR_SB_ASSETS)
+    fs.writeFileSync(STYLE_SDC_SB_BASE_FILE_OUT, file, 'utf-8')
+    successReporter(`Saved: SDC base styles (storybook) ${time()}`)
   }
 }
 
@@ -438,6 +447,7 @@ async function build() {
     buildStylesStories()
     buildStylesTheme()
     buildStylesSdcBase()
+    buildStylesSdcBaseStorybook()
     await buildStylesSdcComponents()
     buildStylesSdcCopyBack()
     buildJavascript()
@@ -542,6 +552,21 @@ function stripJS(js) {
 
 function fullPath(filepath) {
   return path.resolve(PATH, filepath)
+}
+
+function modulePath(moduleName) {
+  // Get the current file's directory
+  const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+  // Create a require function based on the current module
+  const require = createRequire(import.meta.url);
+
+  try {
+    // Try to resolve the module path using Node's resolution algorithm
+    return require.resolve(moduleName);
+  } catch (error) {
+    throw new Error(`Could not resolve module '${moduleName}'`);
+  }
 }
 
 function getCivicthemeDir(subthemeDir, parent, civicthemeGlob) {

--- a/web/themes/contrib/civictheme/build.js
+++ b/web/themes/contrib/civictheme/build.js
@@ -135,9 +135,11 @@ const CONSTANTS_ICON_UTIL       = `${COMPONENT_DIR}/00-base/icon/icon.utils.js`
 const CONSTANTS_LOGO_UTIL       = `${COMPONENT_DIR}/02-molecules/logo/logo.utils.js`
 
 const STYLE_SDC_COMMON_INCLUDES      = [VAR_CT_ASSETS_DIRECTORY, `@import '00-base/variables';`]
+const STYLE_SDC_SB_COMMON_INCLUDES   = [VAR_SB_ASSETS_DIRECTORY, `@import '00-base/variables';`]
 const STYLE_SDC_MIXIN_IMPORTS        = `00-base/mixins/**/*.scss`
 const STYLE_SDC_BASE_IMPORTS         = `00-base/**/!(*.stories|variables|_variables.*).scss`
 const STYLE_SDC_BASE_FILE_OUT        = `${DIR_OUT}/${STYLE_NAME}.base.css`;
+const STYLE_SDC_SB_BASE_FILE_OUT     = `${DIR_OUT}/${STYLE_NAME}.stories.base.css`;
 const JS_SDC_BASE_FILE_OUT           = `${DIR_OUT}/${SCRIPT_NAME}.drupal.base.js`
 const JS_SDC_STORYBOOK_BASE_FILE_OUT = `${DIR_OUT}/${SCRIPT_NAME}.base.js`
 const JS_SDC_BASE_IMPORTS            = `${COMPONENT_DIR}/00-base/**/!(*.stories|*.test|*.data|*.stories.data|*.utils).js`
@@ -279,12 +281,14 @@ function buildStylesTheme() {
 
 function buildStylesSdcBase() {
   if (config.sdc_base) {
-    const baseCss = [
-      ...STYLE_SDC_COMMON_INCLUDES,
-      getImportsFromGlob(STYLE_SDC_BASE_IMPORTS, COMPONENT_DIR),
-    ].join('\n')
-    const compiled = sass.compileString(baseCss, { loadPaths: [COMPONENT_DIR] })
-    fs.writeFileSync(STYLE_SDC_BASE_FILE_OUT, SDC_HEADER + sortCssLines(compiled.css))
+    const baseImports = getImportsFromGlob(STYLE_SDC_BASE_IMPORTS, COMPONENT_DIR)
+    const generateSdcBase = (commonIncludes, writeFile) => {
+      const baseCss = [...commonIncludes, baseImports].join('\n')
+      const compiled = sass.compileString(baseCss, { loadPaths: [COMPONENT_DIR] })
+      fs.writeFileSync(writeFile, SDC_HEADER + sortCssLines(compiled.css))
+    }
+    generateSdcBase(STYLE_SDC_COMMON_INCLUDES, STYLE_SDC_BASE_FILE_OUT) // CT Base
+    generateSdcBase(STYLE_SDC_SB_COMMON_INCLUDES, STYLE_SDC_SB_BASE_FILE_OUT) // Storybook Base
     successReporter(`Saved: SDC styles (base) ${time()}`)
   }
 }

--- a/web/themes/contrib/civictheme/civictheme_starter_kit/.storybook/preview.js
+++ b/web/themes/contrib/civictheme/civictheme_starter_kit/.storybook/preview.js
@@ -1,5 +1,5 @@
 import '../dist/styles.stories.css?module';
-import '../dist/styles.base.css';
+import '../dist/styles.stories.base.css';
 import '../dist/styles.variables.css';
 import '../dist/scripts.base';
 

--- a/web/themes/contrib/civictheme/civictheme_starter_kit/.storybook/preview.js
+++ b/web/themes/contrib/civictheme/civictheme_starter_kit/.storybook/preview.js
@@ -1,5 +1,5 @@
 import '../dist/styles.stories.css?module';
-import '../dist/styles.stories.base.css';
+import '../dist/styles.base.storybook.css';
 import '../dist/styles.variables.css';
 import '../dist/scripts.base';
 

--- a/web/themes/contrib/civictheme/civictheme_starter_kit/build.js
+++ b/web/themes/contrib/civictheme/civictheme_starter_kit/build.js
@@ -16,6 +16,8 @@ Notes:
 */
 
 import fs from 'fs'
+import { createRequire } from 'module';
+import { fileURLToPath } from 'url';
 import path from 'path'
 import { globSync } from 'glob'
 import { execSync, spawn } from 'child_process'
@@ -87,7 +89,7 @@ const DIR_OUT                   = fullPath('./dist/')
 const DIR_ASSETS_IN             = fullPath('./assets/')
 const DIR_ASSETS_OUT            = fullPath('./dist/assets/')
 
-const DIR_CIVICTHEME            = config.base ? null : getCivicthemeDir(PATH, 'themes', '/**/civictheme')
+const DIR_CIVICTHEME            = config.base || config.cli ? null : getCivicthemeDir(PATH, 'themes', '/**/civictheme')
 const DIR_UIKIT_COMPONENTS_IN   = config.base ? null : `${DIR_CIVICTHEME}/components/`
 const DIR_UIKIT_COPY_OUT        = config.base ? null : fullPath('./.components-civictheme/')
 const DIR_COMPONENTS_OUT        = config.base ? null : fullPath('./components_combined/')
@@ -121,7 +123,7 @@ const VAR_SB_ASSETS_DIRECTORY   = `$ct-assets-directory: '${DIR_SB_ASSETS}';`
 const JS_FILE_OUT               = `${DIR_OUT}/${SCRIPT_NAME}.js`
 const JS_STORYBOOK_FILE_OUT     = `${DIR_OUT}/${SCRIPT_NAME}.storybook.js`
 const JS_CIVIC_IMPORTS          = `${COMPONENT_DIR}/**/!(*.stories|*.stories.data|*.component|*.min|*.test|*.script|*.utils).js`
-const JS_LIB_IMPORTS            = [fullPath('./node_modules/@popperjs/core/dist/umd/popper.js')]
+const JS_LIB_IMPORTS            = [path.join(modulePath('@popperjs/core').replace('dist/cjs/popper.js', 'dist/umd/popper.js'))]
 const JS_ASSET_IMPORTS          = [
                                     DIR_CIVICTHEME ? `${DIR_CIVICTHEME}/assets/js/**/*.js` : false,
                                     `${DIR_ASSETS_IN}/js/**/*.js`,
@@ -135,11 +137,10 @@ const CONSTANTS_ICON_UTIL       = `${COMPONENT_DIR}/00-base/icon/icon.utils.js`
 const CONSTANTS_LOGO_UTIL       = `${COMPONENT_DIR}/02-molecules/logo/logo.utils.js`
 
 const STYLE_SDC_COMMON_INCLUDES      = [VAR_CT_ASSETS_DIRECTORY, `@import '00-base/variables';`]
-const STYLE_SDC_SB_COMMON_INCLUDES   = [VAR_SB_ASSETS_DIRECTORY, `@import '00-base/variables';`]
 const STYLE_SDC_MIXIN_IMPORTS        = `00-base/mixins/**/*.scss`
 const STYLE_SDC_BASE_IMPORTS         = `00-base/**/!(*.stories|variables|_variables.*).scss`
 const STYLE_SDC_BASE_FILE_OUT        = `${DIR_OUT}/${STYLE_NAME}.base.css`;
-const STYLE_SDC_SB_BASE_FILE_OUT     = `${DIR_OUT}/${STYLE_NAME}.stories.base.css`;
+const STYLE_SDC_SB_BASE_FILE_OUT     = `${DIR_OUT}/${STYLE_NAME}.base.storybook.css`;
 const JS_SDC_BASE_FILE_OUT           = `${DIR_OUT}/${SCRIPT_NAME}.drupal.base.js`
 const JS_SDC_STORYBOOK_BASE_FILE_OUT = `${DIR_OUT}/${SCRIPT_NAME}.base.js`
 const JS_SDC_BASE_IMPORTS            = `${COMPONENT_DIR}/00-base/**/!(*.stories|*.test|*.data|*.stories.data|*.utils).js`
@@ -281,15 +282,23 @@ function buildStylesTheme() {
 
 function buildStylesSdcBase() {
   if (config.sdc_base) {
-    const baseImports = getImportsFromGlob(STYLE_SDC_BASE_IMPORTS, COMPONENT_DIR)
-    const generateSdcBase = (commonIncludes, writeFile) => {
-      const baseCss = [...commonIncludes, baseImports].join('\n')
-      const compiled = sass.compileString(baseCss, { loadPaths: [COMPONENT_DIR] })
-      fs.writeFileSync(writeFile, SDC_HEADER + sortCssLines(compiled.css))
-    }
-    generateSdcBase(STYLE_SDC_COMMON_INCLUDES, STYLE_SDC_BASE_FILE_OUT) // CT Base
-    generateSdcBase(STYLE_SDC_SB_COMMON_INCLUDES, STYLE_SDC_SB_BASE_FILE_OUT) // Storybook Base
-    successReporter(`Saved: SDC styles (base) ${time()}`)
+    const baseCss = [
+      ...STYLE_SDC_COMMON_INCLUDES,
+      getImportsFromGlob(STYLE_SDC_BASE_IMPORTS, COMPONENT_DIR),
+    ].join('\n')
+    const compiled = sass.compileString(baseCss, { loadPaths: [COMPONENT_DIR] })
+    fs.writeFileSync(STYLE_SDC_BASE_FILE_OUT, SDC_HEADER + sortCssLines(compiled.css))
+    successReporter(`Saved: SDC base styles (base) ${time()}`)
+  }
+}
+
+function buildStylesSdcBaseStorybook() {
+  if (config.sdc_base && config.styles_storybook) {
+    // Replace the asset path.
+    let file = fs.readFileSync(STYLE_SDC_BASE_FILE_OUT, 'utf-8')
+    file = file.replaceAll(DIR_CT_ASSETS, DIR_SB_ASSETS)
+    fs.writeFileSync(STYLE_SDC_SB_BASE_FILE_OUT, file, 'utf-8')
+    successReporter(`Saved: SDC base styles (storybook) ${time()}`)
   }
 }
 
@@ -438,6 +447,7 @@ async function build() {
     buildStylesStories()
     buildStylesTheme()
     buildStylesSdcBase()
+    buildStylesSdcBaseStorybook()
     await buildStylesSdcComponents()
     buildStylesSdcCopyBack()
     buildJavascript()
@@ -542,6 +552,21 @@ function stripJS(js) {
 
 function fullPath(filepath) {
   return path.resolve(PATH, filepath)
+}
+
+function modulePath(moduleName) {
+  // Get the current file's directory
+  const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+  // Create a require function based on the current module
+  const require = createRequire(import.meta.url);
+
+  try {
+    // Try to resolve the module path using Node's resolution algorithm
+    return require.resolve(moduleName);
+  } catch (error) {
+    throw new Error(`Could not resolve module '${moduleName}'`);
+  }
 }
 
 function getCivicthemeDir(subthemeDir, parent, civicthemeGlob) {

--- a/web/themes/contrib/civictheme/civictheme_starter_kit/build.js
+++ b/web/themes/contrib/civictheme/civictheme_starter_kit/build.js
@@ -135,9 +135,11 @@ const CONSTANTS_ICON_UTIL       = `${COMPONENT_DIR}/00-base/icon/icon.utils.js`
 const CONSTANTS_LOGO_UTIL       = `${COMPONENT_DIR}/02-molecules/logo/logo.utils.js`
 
 const STYLE_SDC_COMMON_INCLUDES      = [VAR_CT_ASSETS_DIRECTORY, `@import '00-base/variables';`]
+const STYLE_SDC_SB_COMMON_INCLUDES   = [VAR_SB_ASSETS_DIRECTORY, `@import '00-base/variables';`]
 const STYLE_SDC_MIXIN_IMPORTS        = `00-base/mixins/**/*.scss`
 const STYLE_SDC_BASE_IMPORTS         = `00-base/**/!(*.stories|variables|_variables.*).scss`
 const STYLE_SDC_BASE_FILE_OUT        = `${DIR_OUT}/${STYLE_NAME}.base.css`;
+const STYLE_SDC_SB_BASE_FILE_OUT     = `${DIR_OUT}/${STYLE_NAME}.stories.base.css`;
 const JS_SDC_BASE_FILE_OUT           = `${DIR_OUT}/${SCRIPT_NAME}.drupal.base.js`
 const JS_SDC_STORYBOOK_BASE_FILE_OUT = `${DIR_OUT}/${SCRIPT_NAME}.base.js`
 const JS_SDC_BASE_IMPORTS            = `${COMPONENT_DIR}/00-base/**/!(*.stories|*.test|*.data|*.stories.data|*.utils).js`
@@ -279,12 +281,14 @@ function buildStylesTheme() {
 
 function buildStylesSdcBase() {
   if (config.sdc_base) {
-    const baseCss = [
-      ...STYLE_SDC_COMMON_INCLUDES,
-      getImportsFromGlob(STYLE_SDC_BASE_IMPORTS, COMPONENT_DIR),
-    ].join('\n')
-    const compiled = sass.compileString(baseCss, { loadPaths: [COMPONENT_DIR] })
-    fs.writeFileSync(STYLE_SDC_BASE_FILE_OUT, SDC_HEADER + sortCssLines(compiled.css))
+    const baseImports = getImportsFromGlob(STYLE_SDC_BASE_IMPORTS, COMPONENT_DIR)
+    const generateSdcBase = (commonIncludes, writeFile) => {
+      const baseCss = [...commonIncludes, baseImports].join('\n')
+      const compiled = sass.compileString(baseCss, { loadPaths: [COMPONENT_DIR] })
+      fs.writeFileSync(writeFile, SDC_HEADER + sortCssLines(compiled.css))
+    }
+    generateSdcBase(STYLE_SDC_COMMON_INCLUDES, STYLE_SDC_BASE_FILE_OUT) // CT Base
+    generateSdcBase(STYLE_SDC_SB_COMMON_INCLUDES, STYLE_SDC_SB_BASE_FILE_OUT) // Storybook Base
     successReporter(`Saved: SDC styles (base) ${time()}`)
   }
 }
@@ -484,8 +488,9 @@ function lintExclusions() {
   const header = `${JS_LINT_EXCLUSION_HEADER}\n`
   lintExclusionPaths.forEach((lintExclusionPath) => {
     globSync(lintExclusionPath).forEach(filename => {
+      console.log(`Adding lint exclusion header to ${filename}`)
       const data = fs.readFileSync(filename, 'utf-8')
-      if (data.substr(0, header.length) !== header) {
+      if (data.substring(0, header.length) !== header) {
         fs.writeFileSync(filename, `${header}${data}`, 'utf-8')
       }
     })


### PR DESCRIPTION
## Checklist before requesting a review

- [ ] I have formatted the subject to include ticket number as `Issue #123456 by drupal_org_username: Issue title`
- [ ] I have added a link to the issue tracker
- [ ] I have provided information in `Changed` section about WHY something was done if this was not a normal implementation
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run new and existing relevant tests locally with my changes, and they passed
- [ ] I have provided screenshots, where applicable

## Changed

1. Generate a separate styles.stories.base.css file to house the styles.base.css using the storybook asset path.
2. This file is then imported into just storybook stories. This should correctly resolve the asset path for things like fonts.

Work has also been done here: https://github.com/civictheme/uikit/pull/987

## Screenshots
