### PR TITLE
Issue #3613662 by joshua1234511: Add optional Schema.org JSON-LD structured data emitted from theme settings

### DIFF
--- a/web/themes/contrib/civictheme/README.md
+++ b/web/themes/contrib/civictheme/README.md
@@ -27,6 +27,50 @@ already included as a set of compiled assets.
 
 See [Sub-theme](https://github.com/civictheme/docs/blob/main/development/drupal-theme/sub-theme.md)
 
+## Structured data (JSON-LD)
+
+CivicTheme can emit Schema.org JSON-LD structured data in the page head of
+canonical, published node pages. The feature is **disabled by default** and is
+enabled in _Appearance → CivicTheme settings → Structured data (JSON-LD)_.
+
+A single `<script type="application/ld+json">` element is emitted containing an
+`@graph` with:
+
+- `Organization` - the publisher and author, using the site name, the configured
+  logo and the official profile URLs.
+- `WebSite` - linked to the Organization.
+- The content entity - `WebPage`, one of the article types (`Article`,
+  `NewsArticle`, `BlogPosting`, `Report`) or `Event`, depending on the type
+  mapped to the content type.
+- `BreadcrumbList` - mirrors the breadcrumb rendered by the Banner component
+  (the site breadcrumb followed by the current page), omitted when it would only
+  contain a single item.
+
+Settings:
+
+| Setting | Description |
+| --- | --- |
+| Enable JSON-LD structured data | Master switch for the feature. |
+| Content type mapping | Schema.org type per content type. Content types left as _None_ receive no markup. |
+| Organization | Official profile URLs (`sameAs`) and the path to a raster logo. The organisation name comes from the site name. |
+| Image style | Image style applied to the featured image. Defaults to _Social share_ (1200x630). |
+| Description length | Maximum length of the description sourced from the content summary. |
+
+Values are read from the standard CivicTheme fields when they exist on the
+bundle - `field_c_n_summary`, `field_c_n_thumbnail`, `field_c_n_topics`,
+`field_c_n_custom_last_updated` and, for events, `field_c_n_date_range` and
+`field_c_n_location`.
+
+Site-specific properties, additional graph nodes and additional Schema.org types
+are added from a sub-theme or a module with
+`hook_civictheme_structured_data_alter()` and
+`hook_civictheme_structured_data_types_alter()` - see
+[civictheme.api.php](civictheme.api.php).
+
+The output can be validated with the
+[Schema Markup Validator](https://validator.schema.org) or Google's
+[Rich Results Test](https://search.google.com/test/rich-results).
+
 ## Development
 
 ### Local development

--- a/web/themes/contrib/civictheme/README.md
+++ b/web/themes/contrib/civictheme/README.md
@@ -52,7 +52,7 @@ Settings:
 | --- | --- |
 | Enable JSON-LD structured data | Master switch for the feature. |
 | Content type mapping | Schema.org type per content type. Content types left as _None_ receive no markup. |
-| Organization | Official profile URLs (`sameAs`) and the path to a raster logo. The organisation name comes from the site name. |
+| Organization | Official profile URLs (`sameAs`) and the path to a raster logo. The organization name comes from the site name. |
 | Image style | Image style applied to the featured image. Defaults to _Social share_ (1200x630). |
 | Description length | Maximum length of the description sourced from the content summary. |
 

--- a/web/themes/contrib/civictheme/civictheme.api.php
+++ b/web/themes/contrib/civictheme/civictheme.api.php
@@ -121,3 +121,89 @@ function hook_civictheme_layout_suppress_page_regions_alter(array &$variables, a
     );
   }
 }
+
+/**
+ * Alter the Schema.org JSON-LD structured data graph before it is rendered.
+ *
+ * CivicTheme emits the properties that it can derive from its own fields. Use
+ * this hook to add site-specific properties, to add additional graph nodes or
+ * to remove the ones that are not wanted.
+ *
+ * The hook is only invoked when structured data is enabled in the theme
+ * settings and the node bundle is mapped to a Schema.org type.
+ *
+ * @param array $graph
+ *   The '@graph' array to alter, passed by reference. Graph nodes provided by
+ *   CivicTheme are, in order: Organization, WebSite, the content entity
+ *   (WebPage, Article family or Event) and, when available, BreadcrumbList.
+ * @param array $context
+ *   Context data with the following keys:
+ *   - node: (NodeInterface) The node the graph is built for, in the language
+ *     that is shown on the page.
+ *   - route_match: (RouteMatchInterface) The current route match.
+ *   - definition: (array) The type definition mapped to the node bundle.
+ * @param array $build
+ *   Render array to apply cacheability metadata to, passed by reference. Add
+ *   the cacheability of any additional data used here so that the markup is
+ *   invalidated with it.
+ *
+ * @SuppressWarnings(PHPMD.StaticAccess)
+ */
+function hook_civictheme_structured_data_alter(array &$graph, array $context, array &$build): void {
+  /** @var \Drupal\node\NodeInterface $node */
+  $node = $context['node'];
+
+  foreach ($graph as &$item) {
+    // Only alter the node of the content entity itself.
+    if (!str_ends_with((string) $item['@id'], '#article')) {
+      continue;
+    }
+
+    // Keywords from the taxonomy fields of a custom content type. Passing
+    // $build collects the cacheability of the referenced terms.
+    $keywords = civictheme_get_referenced_entity_labels($node, 'field_program', $build);
+    if ($keywords) {
+      $item['keywords'] = array_values(array_unique($keywords));
+    }
+
+    // Publication status of a custom content type.
+    $status = civictheme_get_referenced_entity_labels($node, 'field_status', $build);
+    if ($status) {
+      $item['creativeWorkStatus'] = reset($status);
+    }
+
+    // All content on this site is publicly available.
+    $item['isAccessibleForFree'] = TRUE;
+  }
+}
+
+/**
+ * Alter the Schema.org types available for content type mapping.
+ *
+ * The types defined here appear in the content type mapping in the theme
+ * settings and drive the markup that is emitted for the mapped bundles.
+ *
+ * @param array $types
+ *   Type definitions keyed by the value stored in the theme settings. Each
+ *   definition has the following keys:
+ *   - label: (string) Human-readable label shown in the settings form.
+ *   - types: (array) Schema.org types emitted as '@type'. A single type is
+ *     emitted as a string, multiple types as an array.
+ *   - fragment: (string) Fragment appended to the node URL to form the '@id'.
+ *   - builder: (callable) Function that builds the graph node. It receives the
+ *     node, the type definition and the render array to apply cacheability
+ *     metadata to.
+ */
+function hook_civictheme_structured_data_types_alter(array &$types): void {
+  // Add a type for a custom "dataset" content type, reusing the generic
+  // CivicTheme builder for creative works.
+  $types['Dataset'] = [
+    'label' => 'Dataset',
+    'types' => ['Dataset'],
+    'fragment' => 'dataset',
+    'builder' => '_civictheme_structured_data_creative_work',
+  ];
+
+  // Emit a bare Article instead of a Report for publications.
+  $types['Report']['types'] = ['Article'];
+}

--- a/web/themes/contrib/civictheme/civictheme.info.yml
+++ b/web/themes/contrib/civictheme/civictheme.info.yml
@@ -589,6 +589,7 @@ config_devel:
     - image.style.civictheme_promo_card
     - image.style.civictheme_publication_card
     - image.style.civictheme_slider_slide
+    - image.style.civictheme_social_share
     - image.style.civictheme_subject_card
     - media.type.civictheme_audio
     - media.type.civictheme_document

--- a/web/themes/contrib/civictheme/civictheme.post_update.php
+++ b/web/themes/contrib/civictheme/civictheme.post_update.php
@@ -1357,3 +1357,108 @@ function civictheme_post_update_add_fast_fact_card_form_display(): string {
 
   return (string) new TranslatableMarkup('Created form display for civictheme_fast_fact_card paragraph.');
 }
+
+/**
+ * Add structured data settings and the Social share image style.
+ *
+ * The structured data feature is disabled by default, so existing sites are not
+ * affected until it is enabled in the theme settings.
+ *
+ * @SuppressWarnings(PHPMD.StaticAccess)
+ */
+function civictheme_post_update_add_structured_data_settings(): string {
+  $messages = [];
+
+  if (_civictheme_post_update_create_social_share_image_style()) {
+    $messages[] = (string) new TranslatableMarkup('Created the "Social share" image style.');
+  }
+
+  $seeded = _civictheme_post_update_seed_structured_data_settings();
+  if (!empty($seeded)) {
+    $messages[] = (string) new TranslatableMarkup('Added structured data settings (disabled) for: @themes.', [
+      '@themes' => implode(', ', $seeded),
+    ]);
+  }
+
+  return $messages === []
+    ? (string) new TranslatableMarkup('Structured data settings and the "Social share" image style are already in place.')
+    : implode(' ', $messages);
+}
+
+/**
+ * Creates the Social share image style from the theme install config.
+ *
+ * @return bool
+ *   TRUE if the image style was created.
+ *
+ * @SuppressWarnings(PHPMD.StaticAccess)
+ */
+function _civictheme_post_update_create_social_share_image_style(): bool {
+  /** @var \Drupal\Core\Config\Entity\ConfigEntityStorageInterface $storage */
+  $storage = \Drupal::entityTypeManager()->getStorage('image_style');
+  if ($storage->load(CivicthemeConstants::SOCIAL_SHARE_IMAGE_STYLE)) {
+    return FALSE;
+  }
+
+  $config_path = \Drupal::service('extension.list.theme')->getPath('civictheme') . '/config/install';
+  $source = new FileStorage($config_path);
+  $config_data = $source->read('image.style.' . CivicthemeConstants::SOCIAL_SHARE_IMAGE_STYLE);
+  if (!is_array($config_data)) {
+    return FALSE;
+  }
+
+  $storage->createFromStorageRecord($config_data)->save();
+
+  return TRUE;
+}
+
+/**
+ * Seeds the structured data settings for CivicTheme and all its subthemes.
+ *
+ * Existing values are preserved.
+ *
+ * @return string[]
+ *   Names of the themes that were updated.
+ *
+ * @SuppressWarnings(PHPMD.StaticAccess)
+ */
+function _civictheme_post_update_seed_structured_data_settings(): array {
+  $defaults = [
+    'structured_data.enabled' => FALSE,
+    'structured_data.bundles' => [
+      'civictheme_page' => 'WebPage',
+      'civictheme_event' => 'Event',
+    ],
+    'structured_data.organization.same_as' => [],
+    'structured_data.organization.logo_path' => '',
+    'structured_data.image_style' => CivicthemeConstants::SOCIAL_SHARE_IMAGE_STYLE,
+    'structured_data.description_length' => CivicthemeConstants::STRUCTURED_DATA_DESCRIPTION_LENGTH,
+  ];
+
+  $config_factory = \Drupal::configFactory();
+  $helper = \Drupal::classResolver(CivicthemeUpdateHelper::class);
+  $theme_names = $helper->themesWithCivicthemeBase(\Drupal::service('extension.list.theme')->getList());
+
+  $updated_themes = [];
+  foreach ($theme_names as $theme_name) {
+    $config = $config_factory->getEditable($theme_name . '.settings');
+    if ($config->isNew()) {
+      continue;
+    }
+
+    $updated = FALSE;
+    foreach ($defaults as $key => $value) {
+      if ($config->get($key) === NULL) {
+        $config->set($key, $value);
+        $updated = TRUE;
+      }
+    }
+
+    if ($updated) {
+      $config->save();
+      $updated_themes[] = $theme_name;
+    }
+  }
+
+  return $updated_themes;
+}

--- a/web/themes/contrib/civictheme/civictheme.theme
+++ b/web/themes/contrib/civictheme/civictheme.theme
@@ -54,6 +54,7 @@ require_once __DIR__ . '/includes/skip_link.inc';
 require_once __DIR__ . '/includes/slider.inc';
 require_once __DIR__ . '/includes/snippet.inc';
 require_once __DIR__ . '/includes/social_links.inc';
+require_once __DIR__ . '/includes/structured_data.inc';
 require_once __DIR__ . '/includes/system_branding.inc';
 require_once __DIR__ . '/includes/table.inc';
 require_once __DIR__ . '/includes/views.inc';
@@ -297,4 +298,6 @@ function civictheme_page_attachments_alter(array &$attachments): void {
     \Drupal::logger('civictheme')->error('Unable to find alert component: %message', ['%message' => $exception->getMessage()]);
   }
   $attachments['#cache']['contexts'] = Cache::mergeContexts($attachments['#cache']['contexts'] ?? [], ['url.query_args']);
+
+  _civictheme_page_attachments_alter__structured_data($attachments);
 }

--- a/web/themes/contrib/civictheme/config/install/civictheme.settings.yml
+++ b/web/themes/contrib/civictheme/config/install/civictheme.settings.yml
@@ -124,3 +124,13 @@ colors:
       error: '#e85653'
       success: '#14b0ae'
 optouts: {  }
+structured_data:
+  enabled: false
+  bundles:
+    civictheme_page: WebPage
+    civictheme_event: Event
+  organization:
+    same_as: {  }
+    logo_path: ''
+  image_style: civictheme_social_share
+  description_length: 300

--- a/web/themes/contrib/civictheme/config/install/image.style.civictheme_social_share.yml
+++ b/web/themes/contrib/civictheme/config/install/image.style.civictheme_social_share.yml
@@ -1,0 +1,16 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - focal_point
+name: civictheme_social_share
+label: 'Social share'
+effects:
+  fb1d4b6a-b1ec-49a4-a788-969ba6b20b16:
+    uuid: fb1d4b6a-b1ec-49a4-a788-969ba6b20b16
+    id: focal_point_scale_and_crop
+    weight: 1
+    data:
+      width: 1200
+      height: 630
+      crop_type: focal_point

--- a/web/themes/contrib/civictheme/config/schema/civictheme.schema.yml
+++ b/web/themes/contrib/civictheme/config/schema/civictheme.schema.yml
@@ -408,6 +408,38 @@ civictheme.settings:
     optouts:
       type: mapping
       label: 'Opt-out flags'
+    structured_data:
+      type: mapping
+      label: 'Structured data (JSON-LD)'
+      mapping:
+        enabled:
+          label: 'Enable JSON-LD structured data'
+          type: boolean
+        bundles:
+          label: 'Content type mapping'
+          type: sequence
+          sequence:
+            label: 'Schema.org type'
+            type: string
+        organization:
+          label: Organization
+          type: mapping
+          mapping:
+            same_as:
+              label: 'Official profile URLs'
+              type: sequence
+              sequence:
+                label: URL
+                type: string
+            logo_path:
+              label: 'Organization logo path'
+              type: string
+        image_style:
+          label: 'Image style'
+          type: string
+        description_length:
+          label: 'Description length'
+          type: integer
 
 layout_plugin.settings.civictheme_three_columns:
   type: layout_plugin.settings

--- a/web/themes/contrib/civictheme/includes/structured_data.inc
+++ b/web/themes/contrib/civictheme/includes/structured_data.inc
@@ -1,0 +1,913 @@
+<?php
+
+/**
+ * @file
+ * Schema.org JSON-LD structured data.
+ *
+ * Emits a single <script type="application/ld+json"> element containing an.
+ * @graph on canonical, published node pages of the mapped bundles.
+ *
+ * The feature is disabled by default and is enabled per-site in the theme
+ * settings, where each node bundle is mapped to a Schema.org type.
+ *
+ * Site-specific additions (extra properties, additional graph nodes, custom
+ * types) are made from a sub-theme or a module via
+ * hook_civictheme_structured_data_alter() and
+ * hook_civictheme_structured_data_types_alter().
+ *
+ * @see civictheme.api.php
+ */
+
+declare(strict_types=1);
+
+use Drupal\civictheme\CivicthemeConstants;
+use Drupal\Component\Utility\Unicode;
+use Drupal\Core\Cache\CacheableMetadata;
+use Drupal\Core\Link;
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\Url;
+use Drupal\file\Entity\File;
+use Drupal\file\FileInterface;
+use Drupal\image\Entity\ImageStyle;
+use Drupal\media\MediaInterface;
+use Drupal\node\NodeInterface;
+use Drupal\paragraphs\ParagraphInterface;
+
+/**
+ * Attaches the JSON-LD structured data to the page head.
+ *
+ * Called from civictheme_page_attachments_alter().
+ *
+ * @param array<string, mixed> $attachments
+ *   Page attachments as provided by hook_page_attachments_alter().
+ *
+ * @SuppressWarnings(PHPMD.StaticAccess)
+ */
+function _civictheme_page_attachments_alter__structured_data(array &$attachments): void {
+  if (!civictheme_get_theme_config_manager()->load('structured_data.enabled', FALSE)) {
+    return;
+  }
+
+  /** @var \Drupal\Core\Routing\RouteMatchInterface $route_match */
+  $route_match = \Drupal::service('current_route_match');
+  if ($route_match->getRouteName() !== 'entity.node.canonical') {
+    return;
+  }
+
+  $node = $route_match->getParameter('node');
+  if (!$node instanceof NodeInterface || !$node->isPublished()) {
+    return;
+  }
+
+  // Use the translation that is shown on the page so that the emitted values
+  // match the rendered content.
+  $node = \Drupal::service('entity.repository')->getTranslationFromContext($node);
+  if (!$node instanceof NodeInterface) {
+    return;
+  }
+
+  // Seed a render array for the civictheme_* field helpers to attach cacheable
+  // metadata to (referenced media/terms). A non-empty array also avoids their
+  // deprecated no-$build code path.
+  $build = ['#cache' => []];
+  $graph = _civictheme_structured_data_build($node, $route_match, $build);
+  if (empty($graph)) {
+    return;
+  }
+
+  $json = json_encode([
+    '@context' => 'https://schema.org',
+    '@graph' => array_values($graph),
+  ], JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE
+    | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_QUOT | JSON_HEX_APOS);
+
+  if ($json === FALSE) {
+    \Drupal::logger('civictheme')->error('Unable to encode structured data for node @nid.', [
+      '@nid' => $node->id(),
+    ]);
+
+    return;
+  }
+
+  $attachments['#attached']['html_head'][] = [
+    [
+      '#type' => 'html_tag',
+      '#tag' => 'script',
+      '#attributes' => ['type' => 'application/ld+json'],
+      '#value' => $json,
+    ],
+    'civictheme_structured_data',
+  ];
+
+  // Merge cacheability: existing attachments + the node + the referenced
+  // media/terms and the breadcrumb collected on $build (so the markup
+  // invalidates when any of them changes, including an image or its alt text)
+  // + the theme settings that drive the output.
+  $cache = CacheableMetadata::createFromRenderArray($attachments);
+  $cache->addCacheableDependency($node);
+  // merge() returns a new instance rather than mutating, so capture it.
+  $cache = $cache->merge(CacheableMetadata::createFromRenderArray($build));
+  $cache->addCacheableDependency(\Drupal::config(\Drupal::theme()->getActiveTheme()->getName() . '.settings'));
+  $cache->applyTo($attachments);
+}
+
+/**
+ * Builds the JSON-LD @graph for a node.
+ *
+ * @param \Drupal\node\NodeInterface $node
+ *   The node to build the graph for.
+ * @param \Drupal\Core\Routing\RouteMatchInterface $route_match
+ *   The current route match, used to build the breadcrumb.
+ * @param array<string, mixed> $build
+ *   Render array to apply cacheability metadata to.
+ *
+ * @return array<int, array<string, mixed>>
+ *   The graph nodes or an empty array if the bundle is not mapped.
+ *
+ * @SuppressWarnings(PHPMD.StaticAccess)
+ */
+function _civictheme_structured_data_build(NodeInterface $node, RouteMatchInterface $route_match, array &$build): array {
+  $definition = _civictheme_structured_data_node_type_definition($node->bundle());
+  if (!$definition) {
+    return [];
+  }
+
+  $graph = [
+    _civictheme_structured_data_organization(),
+    _civictheme_structured_data_website(),
+  ];
+
+  $breadcrumb = _civictheme_structured_data_breadcrumb($node, $route_match, $build);
+
+  $entity = $definition['builder']($node, $definition, $build);
+  if ($breadcrumb) {
+    $entity['breadcrumb'] = ['@id' => $breadcrumb['@id']];
+  }
+  $graph[] = $entity;
+
+  if ($breadcrumb) {
+    $graph[] = $breadcrumb;
+  }
+
+  $context = [
+    'node' => $node,
+    'route_match' => $route_match,
+    'definition' => $definition,
+  ];
+  \Drupal::moduleHandler()->alter('civictheme_structured_data', $graph, $context, $build);
+  \Drupal::service('theme.manager')->alter('civictheme_structured_data', $graph, $context, $build);
+
+  return $graph;
+}
+
+/**
+ * Definitions of the Schema.org types available for bundle mapping.
+ *
+ * The array key is the value stored in the theme settings.
+ *
+ * @return array<string, array<string, mixed>>
+ *   Type definitions keyed by the setting value. Each definition has keys:
+ *   - label: (string) Human-readable label used in the settings form.
+ *   - types: (array) Schema.org types to emit as '@type'.
+ *   - fragment: (string) Fragment appended to the node URL to form the '@id'.
+ *   - builder: (callable) Function building the graph node.
+ */
+function _civictheme_structured_data_type_definitions(): array {
+  return [
+    'WebPage' => [
+      'label' => 'Web page',
+      'types' => ['WebPage'],
+      'fragment' => 'webpage',
+      'builder' => '_civictheme_structured_data_webpage',
+    ],
+    'Article' => [
+      'label' => 'Article',
+      'types' => ['Article'],
+      'fragment' => 'article',
+      'builder' => '_civictheme_structured_data_creative_work',
+    ],
+    'NewsArticle' => [
+      'label' => 'News article',
+      'types' => ['NewsArticle', 'Article'],
+      'fragment' => 'article',
+      'builder' => '_civictheme_structured_data_creative_work',
+    ],
+    'BlogPosting' => [
+      'label' => 'Blog posting',
+      'types' => ['BlogPosting', 'Article'],
+      'fragment' => 'article',
+      'builder' => '_civictheme_structured_data_creative_work',
+    ],
+    'Report' => [
+      'label' => 'Report',
+      'types' => ['Report', 'Article'],
+      'fragment' => 'article',
+      'builder' => '_civictheme_structured_data_creative_work',
+    ],
+    'Event' => [
+      'label' => 'Event',
+      'types' => ['Event'],
+      'fragment' => 'event',
+      'builder' => '_civictheme_structured_data_event',
+    ],
+  ];
+}
+
+/**
+ * Schema.org type definitions after alterations.
+ *
+ * @return array<string, array<string, mixed>>
+ *   Type definitions keyed by the setting value.
+ *
+ * @see _civictheme_structured_data_type_definitions()
+ * @see hook_civictheme_structured_data_types_alter()
+ *
+ * @SuppressWarnings(PHPMD.StaticAccess)
+ */
+function _civictheme_structured_data_types(): array {
+  $types = _civictheme_structured_data_type_definitions();
+
+  \Drupal::moduleHandler()->alter('civictheme_structured_data_types', $types);
+  \Drupal::service('theme.manager')->alter('civictheme_structured_data_types', $types);
+
+  return array_filter($types, static function (array $definition): bool {
+    return !empty($definition['types']) && !empty($definition['builder']) && is_callable($definition['builder']);
+  });
+}
+
+/**
+ * The type definition mapped to a node bundle in the theme settings.
+ *
+ * @param string $bundle
+ *   The node bundle.
+ *
+ * @return array<string, mixed>|null
+ *   The type definition or NULL if the bundle is not mapped.
+ */
+function _civictheme_structured_data_node_type_definition(string $bundle): ?array {
+  $bundles = civictheme_get_theme_config_manager()->load('structured_data.bundles', []);
+  $type = is_array($bundles) ? ($bundles[$bundle] ?? NULL) : NULL;
+
+  if (empty($type) || !is_string($type)) {
+    return NULL;
+  }
+
+  $definition = _civictheme_structured_data_types()[$type] ?? NULL;
+
+  return $definition ? $definition + ['fragment' => 'webpage'] : NULL;
+}
+
+/**
+ * Sitewide base URL (no trailing slash), used to namespace '@id' values.
+ *
+ * @SuppressWarnings(PHPMD.StaticAccess)
+ */
+function _civictheme_structured_data_base_url(): string {
+  $request = \Drupal::request();
+
+  return rtrim($request->getSchemeAndHttpHost() . $request->getBasePath(), '/');
+}
+
+/**
+ * Converts a root-relative URL into an absolute one.
+ *
+ * @SuppressWarnings(PHPMD.StaticAccess)
+ */
+function _civictheme_structured_data_absolute_url(string $url): string {
+  if (preg_match('#^(https?:)?//#', $url)) {
+    return $url;
+  }
+
+  // Root-relative URLs already contain the base path, so only the scheme and
+  // the host are prepended.
+  return \Drupal::request()->getSchemeAndHttpHost() . '/' . ltrim($url, '/');
+}
+
+/**
+ * The publishing Organization. Reused as publisher and author by '@id'.
+ *
+ * @return array<string, mixed>
+ *   The Organization graph node.
+ *
+ * @SuppressWarnings(PHPMD.StaticAccess)
+ */
+function _civictheme_structured_data_organization(): array {
+  $base = _civictheme_structured_data_base_url();
+
+  $data = [
+    '@type' => 'Organization',
+    '@id' => $base . '/#organization',
+    'name' => \Drupal::config('system.site')->get('name'),
+    'url' => $base . '/',
+  ];
+
+  $logo = _civictheme_structured_data_logo();
+  if ($logo) {
+    $data['logo'] = $logo;
+  }
+
+  $same_as = civictheme_get_theme_config_manager()->load('structured_data.organization.same_as', []);
+  if (is_array($same_as) && !empty($same_as)) {
+    $data['sameAs'] = array_values($same_as);
+  }
+
+  return $data;
+}
+
+/**
+ * The Organization logo as an ImageObject.
+ *
+ * @return array<string, mixed>|null
+ *   The ImageObject or NULL if no logo path is configured.
+ *
+ * @SuppressWarnings(PHPMD.StaticAccess)
+ */
+function _civictheme_structured_data_logo(): ?array {
+  $config = civictheme_get_theme_config_manager();
+
+  $path = trim((string) $config->load('structured_data.organization.logo_path', ''));
+  if ($path === '') {
+    $path = trim((string) $config->load('components.logo.primary.light.desktop.path', ''));
+  }
+
+  if ($path === '') {
+    return NULL;
+  }
+
+  $path = ltrim($path, '/');
+
+  $logo = [
+    '@type' => 'ImageObject',
+    'url' => Url::fromUri('base:' . $path, ['absolute' => TRUE])->toString(),
+  ];
+
+  // Dimensions are only available for raster images (SVG is not supported by
+  // image toolkits) and are optional in the Organization markup.
+  $image = \Drupal::service('image.factory')->get(\Drupal::root() . '/' . $path);
+  if ($image->isValid()) {
+    $logo['width'] = $image->getWidth();
+    $logo['height'] = $image->getHeight();
+  }
+
+  return $logo;
+}
+
+/**
+ * The WebSite node, linked to the Organization as publisher.
+ *
+ * @return array<string, mixed>
+ *   The WebSite graph node.
+ *
+ * @SuppressWarnings(PHPMD.StaticAccess)
+ */
+function _civictheme_structured_data_website(): array {
+  $base = _civictheme_structured_data_base_url();
+
+  return [
+    '@type' => 'WebSite',
+    '@id' => $base . '/#website',
+    'name' => \Drupal::config('system.site')->get('name'),
+    'url' => $base . '/',
+    'publisher' => ['@id' => $base . '/#organization'],
+  ];
+}
+
+/**
+ * Properties shared by all mapped node types.
+ *
+ * @param \Drupal\node\NodeInterface $node
+ *   The node.
+ * @param array<string, mixed> $definition
+ *   The type definition.
+ * @param array<string, mixed> $build
+ *   Render array to apply cacheability metadata to.
+ *
+ * @return array<string, mixed>
+ *   The graph node.
+ */
+function _civictheme_structured_data_node(NodeInterface $node, array $definition, array &$build): array {
+  $base = _civictheme_structured_data_base_url();
+  $url = $node->toUrl('canonical', ['absolute' => TRUE])->toString();
+  $types = array_values((array) $definition['types']);
+  // The created field value is a string when the node is loaded from storage.
+  $published = (int) $node->getCreatedTime();
+
+  $data = [
+    '@type' => count($types) > 1 ? $types : reset($types),
+    '@id' => $url . '#' . $definition['fragment'],
+    'name' => trim((string) $node->label()),
+    'url' => $url,
+    'mainEntityOfPage' => $url,
+    'inLanguage' => $node->language()->getId(),
+    'datePublished' => civictheme_format_datetime_iso($published),
+    'dateModified' => _civictheme_structured_data_modified($node, $published),
+    'isPartOf' => ['@id' => $base . '/#website'],
+    'publisher' => ['@id' => $base . '/#organization'],
+  ];
+
+  $description = _civictheme_structured_data_description($node);
+  if ($description !== '') {
+    $data['description'] = $description;
+  }
+
+  $about = civictheme_get_referenced_entity_labels($node, 'field_c_n_topics', $build);
+  if (!empty($about)) {
+    $data['about'] = array_values($about);
+  }
+
+  return $data;
+}
+
+/**
+ * WebPage mapping.
+ *
+ * @param \Drupal\node\NodeInterface $node
+ *   The node.
+ * @param array<string, mixed> $definition
+ *   The type definition.
+ * @param array<string, mixed> $build
+ *   Render array to apply cacheability metadata to.
+ *
+ * @return array<string, mixed>
+ *   The graph node.
+ */
+function _civictheme_structured_data_webpage(NodeInterface $node, array $definition, array &$build): array {
+  $data = _civictheme_structured_data_node($node, $definition, $build);
+
+  $image = _civictheme_structured_data_image($node, $build);
+  if ($image) {
+    $data['primaryImageOfPage'] = $image;
+  }
+
+  return $data;
+}
+
+/**
+ * Article, NewsArticle, BlogPosting and Report mapping.
+ *
+ * @param \Drupal\node\NodeInterface $node
+ *   The node.
+ * @param array<string, mixed> $definition
+ *   The type definition.
+ * @param array<string, mixed> $build
+ *   Render array to apply cacheability metadata to.
+ *
+ * @return array<string, mixed>
+ *   The graph node.
+ *
+ * @SuppressWarnings(PHPMD.StaticAccess)
+ */
+function _civictheme_structured_data_creative_work(NodeInterface $node, array $definition, array &$build): array {
+  $data = _civictheme_structured_data_node($node, $definition, $build);
+
+  $base = _civictheme_structured_data_base_url();
+  $data['headline'] = _civictheme_structured_data_truncate((string) $node->label(), CivicthemeConstants::STRUCTURED_DATA_HEADLINE_LENGTH);
+  $data['author'] = ['@id' => $base . '/#organization'];
+
+  $image = _civictheme_structured_data_image($node, $build);
+  if ($image) {
+    $data['image'] = $image;
+  }
+
+  return $data;
+}
+
+/**
+ * Event mapping.
+ *
+ * @param \Drupal\node\NodeInterface $node
+ *   The node.
+ * @param array<string, mixed> $definition
+ *   The type definition.
+ * @param array<string, mixed> $build
+ *   Render array to apply cacheability metadata to.
+ *
+ * @return array<string, mixed>
+ *   The graph node.
+ */
+function _civictheme_structured_data_event(NodeInterface $node, array $definition, array &$build): array {
+  $data = _civictheme_structured_data_node($node, $definition, $build);
+
+  $date = civictheme_get_field_value($node, 'field_c_n_date_range', TRUE);
+  if ($date) {
+    $start = $date->get('value')->getDateTime();
+    if ($start) {
+      $data['startDate'] = civictheme_format_datetime_iso($start);
+    }
+    $end = $date->get('end_value')->getDateTime();
+    if ($end) {
+      $data['endDate'] = civictheme_format_datetime_iso($end);
+    }
+  }
+
+  $location = _civictheme_structured_data_event_location($node, $build);
+  if ($location) {
+    $data['location'] = $location;
+  }
+
+  $image = _civictheme_structured_data_image($node, $build);
+  if ($image) {
+    $data['image'] = $image;
+  }
+
+  return $data;
+}
+
+/**
+ * Event location as a Place, sourced from the Map location paragraph.
+ *
+ * @param \Drupal\node\NodeInterface $node
+ *   The node.
+ * @param array<string, mixed> $build
+ *   Render array to apply cacheability metadata to.
+ *
+ * @return array<string, mixed>|null
+ *   The Place or NULL if no address is available.
+ */
+function _civictheme_structured_data_event_location(NodeInterface $node, array &$build): ?array {
+  $paragraphs = civictheme_get_field_value($node, 'field_c_n_location', FALSE, [], $build);
+
+  foreach ((array) $paragraphs as $paragraph) {
+    if (!$paragraph instanceof ParagraphInterface || $paragraph->bundle() !== 'civictheme_map') {
+      continue;
+    }
+
+    $address = trim((string) civictheme_get_field_value($paragraph, 'field_c_p_address', FALSE, ''));
+    if ($address === '') {
+      continue;
+    }
+
+    return [
+      '@type' => 'Place',
+      'address' => $address,
+    ];
+  }
+
+  return NULL;
+}
+
+/**
+ * BreadcrumbList for the current route.
+ *
+ * Mirrors the breadcrumb rendered by the Banner component: the links provided
+ * by the breadcrumb builders, followed by the current page when it is not
+ * already the last item.
+ *
+ * @param \Drupal\node\NodeInterface $node
+ *   The node.
+ * @param \Drupal\Core\Routing\RouteMatchInterface $route_match
+ *   The current route match.
+ * @param array<string, mixed> $build
+ *   Render array to apply cacheability metadata to.
+ *
+ * @return array<string, mixed>|null
+ *   The BreadcrumbList or NULL if the breadcrumb is unavailable or has fewer
+ *   than two items.
+ *
+ * @see _civictheme_preprocess_block__civictheme_banner__breadcrumb()
+ *
+ * @SuppressWarnings(PHPMD.StaticAccess)
+ * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+ */
+function _civictheme_structured_data_breadcrumb(NodeInterface $node, RouteMatchInterface $route_match, array &$build): ?array {
+  // The breadcrumb is not rendered on the front page.
+  if (\Drupal::service('path.matcher')->isFrontPage()) {
+    return NULL;
+  }
+
+  try {
+    $breadcrumb = \Drupal::service('breadcrumb')->build($route_match);
+  }
+  catch (\Exception $exception) {
+    // A failing breadcrumb builder must not break the page: the rest of the
+    // graph is still valid without a BreadcrumbList.
+    \Drupal::logger('civictheme')->warning('Unable to build the structured data breadcrumb: @message', [
+      '@message' => $exception->getMessage(),
+    ]);
+
+    return NULL;
+  }
+
+  // Capture the breadcrumb's cacheability (e.g. route/path contexts) so the
+  // rendered markup invalidates with it.
+  CacheableMetadata::createFromRenderArray($build)
+    ->merge(CacheableMetadata::createFromObject($breadcrumb))
+    ->applyTo($build);
+
+  $items = [];
+  $last_text = '';
+  foreach ($breadcrumb->getLinks() as $link) {
+    $item = _civictheme_structured_data_breadcrumb_item($link, count($items) + 1);
+    if ($item) {
+      $items[] = $item;
+      $last_text = $item['name'];
+    }
+  }
+
+  // Append the current page, unless a breadcrumb builder already did so.
+  $title = trim((string) $node->label());
+  if ($title !== '' && $title !== $last_text) {
+    $items[] = [
+      '@type' => 'ListItem',
+      'position' => count($items) + 1,
+      'name' => $title,
+    ];
+  }
+
+  if (count($items) < 2) {
+    return NULL;
+  }
+
+  return [
+    '@type' => 'BreadcrumbList',
+    '@id' => $node->toUrl('canonical', ['absolute' => TRUE])->toString() . '#breadcrumb',
+    'itemListElement' => $items,
+  ];
+}
+
+/**
+ * A single BreadcrumbList item built from a breadcrumb link.
+ *
+ * @param \Drupal\Core\Link $link
+ *   The breadcrumb link.
+ * @param int $position
+ *   The 1-based position of the item in the list.
+ *
+ * @return array<string, mixed>|null
+ *   The ListItem or NULL if the link has no text.
+ */
+function _civictheme_structured_data_breadcrumb_item(Link $link, int $position): ?array {
+  $text = _civictheme_structured_data_link_text($link->getText());
+  if ($text === '') {
+    return NULL;
+  }
+
+  $item = [
+    '@type' => 'ListItem',
+    'position' => $position,
+    'name' => $text,
+  ];
+
+  // Omit 'item' on routeless links (e.g. the current page) - an empty string is
+  // invalid, while a name-only last entry is allowed.
+  try {
+    $url = $link->getUrl()->setAbsolute()->toString();
+    if ($url !== '') {
+      $item['item'] = $url;
+    }
+  }
+  catch (\Exception) {
+    // Routeless link - name only.
+  }
+
+  return $item;
+}
+
+/**
+ * Plain text of a breadcrumb link.
+ *
+ * @param mixed $link_text
+ *   The link text, which may be a string, a markup object or a render array.
+ *
+ * @return string
+ *   The plain text, or an empty string when there is none.
+ *
+ * @SuppressWarnings(PHPMD.StaticAccess)
+ */
+function _civictheme_structured_data_link_text(mixed $link_text): string {
+  if (is_array($link_text)) {
+    // Rendering in isolation keeps any cacheable metadata of the render array
+    // from leaking into the page head.
+    $link_text = \Drupal::service('renderer')->renderInIsolation($link_text);
+  }
+
+  return trim(strip_tags(html_entity_decode((string) $link_text)));
+}
+
+/**
+ * Featured image as an ImageObject.
+ *
+ * @param \Drupal\node\NodeInterface $node
+ *   The node.
+ * @param array<string, mixed> $build
+ *   Render array to apply cacheability metadata to.
+ *
+ * @return array<string, mixed>|null
+ *   The ImageObject or NULL if the node has no usable image.
+ */
+function _civictheme_structured_data_image(NodeInterface $node, array &$build): ?array {
+  $media = civictheme_get_field_value($node, 'field_c_n_thumbnail', TRUE, NULL, $build);
+  if (!$media instanceof MediaInterface) {
+    return NULL;
+  }
+
+  $image_style = trim((string) civictheme_get_theme_config_manager()->load('structured_data.image_style', CivicthemeConstants::SOCIAL_SHARE_IMAGE_STYLE));
+
+  $variables = civictheme_media_image_get_variables($media, $image_style !== '' ? $image_style : NULL);
+  if (!is_array($variables) || empty($variables['url'])) {
+    return NULL;
+  }
+
+  $image = [
+    '@type' => 'ImageObject',
+    'url' => _civictheme_structured_data_absolute_url((string) $variables['url']),
+  ];
+
+  // Image styles are not applied to SVG images.
+  if (($variables['ext'] ?? '') === 'svg') {
+    $image_style = '';
+  }
+
+  return $image + _civictheme_structured_data_image_dimensions($media, $image_style);
+}
+
+/**
+ * Dimensions of the media image after the image style is applied.
+ *
+ * The dimensions are derived from the stored source dimensions rather than from
+ * the derivative file, so no derivative generation is triggered.
+ *
+ * @param \Drupal\media\MediaInterface $media
+ *   The image media entity.
+ * @param string $image_style
+ *   The image style name or an empty string for the original image.
+ *
+ * @return array<string, int>
+ *   Array with 'width' and 'height' keys, or an empty array if the dimensions
+ *   are not available.
+ *
+ * @SuppressWarnings(PHPMD.StaticAccess)
+ * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+ */
+function _civictheme_structured_data_image_dimensions(MediaInterface $media, string $image_style): array {
+  $values = _civictheme_structured_data_image_values($media);
+
+  $dimensions = _civictheme_structured_data_source_dimensions($values);
+  if ($dimensions === []) {
+    return [];
+  }
+
+  $style = $image_style === '' ? NULL : ImageStyle::load($image_style);
+  if ($style) {
+    $style->transformDimensions($dimensions, _civictheme_structured_data_file_uri($values));
+  }
+
+  // Some image effects cannot predict the resulting dimensions and set them to
+  // NULL - such values are omitted rather than emitted as zeroes.
+  return array_filter($dimensions);
+}
+
+/**
+ * The stored dimensions of an image field item.
+ *
+ * @param array<string, mixed> $values
+ *   The image field item values.
+ *
+ * @return array<string, int>
+ *   Array with 'width' and 'height' keys, or an empty array when either of the
+ *   dimensions is missing.
+ */
+function _civictheme_structured_data_source_dimensions(array $values): array {
+  $width = (int) ($values['width'] ?? 0);
+  $height = (int) ($values['height'] ?? 0);
+
+  return $width > 0 && $height > 0 ? ['width' => $width, 'height' => $height] : [];
+}
+
+/**
+ * Values of the source field item of an image media entity.
+ *
+ * @param \Drupal\media\MediaInterface $media
+ *   The image media entity.
+ *
+ * @return array<string, mixed>
+ *   The field item values or an empty array if there is no image.
+ */
+function _civictheme_structured_data_image_values(MediaInterface $media): array {
+  $source_field = $media->getSource()->getConfiguration()['source_field'] ?? NULL;
+  if (!$source_field || !civictheme_field_has_value($media, $source_field)) {
+    return [];
+  }
+
+  $item = $media->get($source_field)->first();
+
+  return $item ? $item->getValue() : [];
+}
+
+/**
+ * The file URI referenced by the image field item values.
+ *
+ * @param array<string, mixed> $values
+ *   The image field item values.
+ *
+ * @return string
+ *   The file URI or an empty string if the file is not available.
+ *
+ * @SuppressWarnings(PHPMD.StaticAccess)
+ */
+function _civictheme_structured_data_file_uri(array $values): string {
+  $file = empty($values['target_id']) ? NULL : File::load($values['target_id']);
+
+  return $file instanceof FileInterface ? (string) $file->getFileUri() : '';
+}
+
+/**
+ * The 'dateModified' value, clamped to never precede the published date.
+ *
+ * @param \Drupal\node\NodeInterface $node
+ *   The node.
+ * @param int $published
+ *   The published timestamp.
+ *
+ * @return string
+ *   The date as an ISO 8601 date or date and time string.
+ */
+function _civictheme_structured_data_modified(NodeInterface $node, int $published): string {
+  $last_updated = NULL;
+  if (civictheme_field_has_value($node, 'field_c_n_custom_last_updated')) {
+    $item = civictheme_get_field_value($node, 'field_c_n_custom_last_updated', TRUE);
+    $last_updated = $item?->value;
+  }
+
+  $value = _civictheme_structured_data_modified_value(
+    is_string($last_updated) ? $last_updated : NULL,
+    (int) $node->getChangedTime(),
+    $published
+  );
+
+  return is_int($value) ? civictheme_format_datetime_iso($value) : $value;
+}
+
+/**
+ * Resolves the 'dateModified' value from the available dates.
+ *
+ * The "last updated" field is date-only, so on the day a node is first
+ * published its midnight value would sort before the timestamped
+ * 'datePublished', which search engines flag as an error. When that happens the
+ * published date is used instead, so that modified equals published.
+ *
+ * @param string|null $last_updated
+ *   The value of the custom "last updated" field, if any.
+ * @param int $changed
+ *   The node changed timestamp.
+ * @param int $published
+ *   The published timestamp.
+ *
+ * @return int|string
+ *   A timestamp to format, or the "last updated" value as-is when it is a valid
+ *   ISO 8601 date that does not precede the published date.
+ */
+function _civictheme_structured_data_modified_value(?string $last_updated, int $changed, int $published): int|string {
+  if ($last_updated !== NULL && trim($last_updated) !== '') {
+    $timestamp = strtotime($last_updated);
+
+    return $timestamp !== FALSE && $timestamp >= $published ? $last_updated : $published;
+  }
+
+  return max($changed, $published);
+}
+
+/**
+ * Plain-text description sourced from the summary field.
+ *
+ * @param \Drupal\node\NodeInterface $node
+ *   The node.
+ *
+ * @return string
+ *   The description or an empty string if the node has no summary.
+ */
+function _civictheme_structured_data_description(NodeInterface $node): string {
+  // The summary is a 'string_long' field, so civictheme_get_field_value()
+  // returns the value with tags already stripped.
+  $summary = trim((string) civictheme_get_field_value($node, 'field_c_n_summary', FALSE, ''));
+  if ($summary === '') {
+    return '';
+  }
+
+  $length = (int) civictheme_get_theme_config_manager()->load('structured_data.description_length', CivicthemeConstants::STRUCTURED_DATA_DESCRIPTION_LENGTH);
+
+  return _civictheme_structured_data_truncate($summary, $length);
+}
+
+/**
+ * Truncates text to the given length, appending an ellipsis when trimmed.
+ *
+ * @param string $text
+ *   The text to truncate.
+ * @param int $length
+ *   The maximum length. Values below 1 disable truncation.
+ *
+ * @return string
+ *   The truncated text.
+ *
+ * @SuppressWarnings(PHPMD.StaticAccess)
+ */
+function _civictheme_structured_data_truncate(string $text, int $length): string {
+  $text = trim($text);
+
+  if ($length < 1 || mb_strlen($text) <= $length) {
+    return $text;
+  }
+
+  return Unicode::truncate($text, $length, TRUE, TRUE);
+}

--- a/web/themes/contrib/civictheme/includes/structured_data.inc
+++ b/web/themes/contrib/civictheme/includes/structured_data.inc
@@ -44,6 +44,13 @@ use Drupal\paragraphs\ParagraphInterface;
  * @SuppressWarnings(PHPMD.StaticAccess)
  */
 function _civictheme_page_attachments_alter__structured_data(array &$attachments): void {
+  // Depend on the theme settings before anything else, so that enabling the
+  // feature invalidates pages that were cached while it was disabled.
+  $settings = \Drupal::config(\Drupal::theme()->getActiveTheme()->getName() . '.settings');
+  $cache = CacheableMetadata::createFromRenderArray($attachments);
+  $cache->addCacheableDependency($settings);
+  $cache->applyTo($attachments);
+
   if (!civictheme_get_theme_config_manager()->load('structured_data.enabled', FALSE)) {
     return;
   }
@@ -99,15 +106,14 @@ function _civictheme_page_attachments_alter__structured_data(array &$attachments
     'civictheme_structured_data',
   ];
 
-  // Merge cacheability: existing attachments + the node + the referenced
-  // media/terms and the breadcrumb collected on $build (so the markup
-  // invalidates when any of them changes, including an image or its alt text)
-  // + the theme settings that drive the output.
+  // Merge cacheability: the attachments (which already carry the theme settings
+  // dependency added above) + the node + the referenced media/terms and the
+  // breadcrumb collected on $build, so that the markup invalidates when any of
+  // them changes, including an image or its alt text.
   $cache = CacheableMetadata::createFromRenderArray($attachments);
   $cache->addCacheableDependency($node);
   // merge() returns a new instance rather than mutating, so capture it.
   $cache = $cache->merge(CacheableMetadata::createFromRenderArray($build));
-  $cache->addCacheableDependency(\Drupal::config(\Drupal::theme()->getActiveTheme()->getName() . '.settings'));
   $cache->applyTo($attachments);
 }
 

--- a/web/themes/contrib/civictheme/src/CivicthemeConstants.php
+++ b/web/themes/contrib/civictheme/src/CivicthemeConstants.php
@@ -174,7 +174,20 @@ final class CivicthemeConstants {
   const PROMO_CARD_IMAGE_STYLE = 'civictheme_promo_card';
   const PUBLICATION_CARD_IMAGE_STYLE = 'civictheme_publication_card';
   const SLIDER_SLIDE_IMAGE_STYLE = 'civictheme_slider_slide';
+  const SOCIAL_SHARE_IMAGE_STYLE = 'civictheme_social_share';
   const SUBJECT_CARD_IMAGE_STYLE = 'civictheme_subject_card';
+
+  /**
+   * Defines the default structured data description length.
+   */
+  const STRUCTURED_DATA_DESCRIPTION_LENGTH = 300;
+
+  /**
+   * Defines the maximum structured data headline length.
+   *
+   * Search engines recommend keeping the headline within 110 characters.
+   */
+  const STRUCTURED_DATA_HEADLINE_LENGTH = 110;
 
   /**
    * Defines an optout string for views exposed filters.

--- a/web/themes/contrib/civictheme/src/CivicthemeUpdateHelper.php
+++ b/web/themes/contrib/civictheme/src/CivicthemeUpdateHelper.php
@@ -311,9 +311,22 @@ final class CivicthemeUpdateHelper implements ContainerInjectionInterface {
    *   Theme machine names.
    */
   public function logoAltThemesWithCivicthemeBase(array $themes): array {
+    return $this->themesWithCivicthemeBase($themes);
+  }
+
+  /**
+   * Returns theme names that are CivicTheme or have CivicTheme as a base theme.
+   *
+   * @param \Drupal\Core\Extension\Extension[] $themes
+   *   Theme extension list keyed by theme name.
+   *
+   * @return string[]
+   *   Theme machine names.
+   */
+  public function themesWithCivicthemeBase(array $themes): array {
     $result = [];
     foreach (array_keys($themes) as $theme_name) {
-      if ($this->logoAltThemeExtendsCivictheme($themes, $theme_name)) {
+      if ($this->themeExtendsCivictheme($themes, $theme_name)) {
         $result[] = $theme_name;
       }
     }
@@ -332,6 +345,21 @@ final class CivicthemeUpdateHelper implements ContainerInjectionInterface {
    *   TRUE if the theme is CivicTheme or has it in its base theme chain.
    */
   public function logoAltThemeExtendsCivictheme(array $themes, string $theme_name): bool {
+    return $this->themeExtendsCivictheme($themes, $theme_name);
+  }
+
+  /**
+   * Checks if a theme is CivicTheme or has CivicTheme in its base theme chain.
+   *
+   * @param \Drupal\Core\Extension\Extension[] $themes
+   *   Theme extension list keyed by theme name.
+   * @param string $theme_name
+   *   Theme machine name.
+   *
+   * @return bool
+   *   TRUE if the theme is CivicTheme or has it in its base theme chain.
+   */
+  public function themeExtendsCivictheme(array $themes, string $theme_name): bool {
     if ($theme_name === 'civictheme') {
       return TRUE;
     }
@@ -339,7 +367,7 @@ final class CivicthemeUpdateHelper implements ContainerInjectionInterface {
       return FALSE;
     }
     $base_theme = $themes[$theme_name]->info['base theme'];
-    return $this->logoAltThemeExtendsCivictheme($themes, $base_theme);
+    return $this->themeExtendsCivictheme($themes, $base_theme);
   }
 
 }

--- a/web/themes/contrib/civictheme/src/Settings/CivicthemeSettingsFormSectionBase.php
+++ b/web/themes/contrib/civictheme/src/Settings/CivicthemeSettingsFormSectionBase.php
@@ -8,6 +8,7 @@ use Drupal\civictheme\CivicthemeConfigManager;
 use Drupal\Component\Utility\NestedArray;
 use Drupal\Core\Config\ConfigManager;
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Drupal\Core\Entity\EntityTypeBundleInfoInterface;
 use Drupal\Core\Extension\ThemeExtensionList;
 use Drupal\Core\File\FileSystemInterface;
 use Drupal\Core\File\FileUrlGenerator;
@@ -49,8 +50,10 @@ abstract class CivicthemeSettingsFormSectionBase implements ContainerInjectionIn
    *   Theme config manager.
    * @param \Drupal\Core\Image\ImageFactory $imageFactory
    *   The image factory.
+   * @param \Drupal\Core\Entity\EntityTypeBundleInfoInterface|null $entityTypeBundleInfo
+   *   The entity type bundle info service.
    */
-  public function __construct(protected ThemeManager $themeManager, protected ThemeExtensionList $themeExtensionList, protected FileSystemInterface $fileSystem, protected FileUrlGenerator $fileUrlgenerator, protected Messenger $messenger, protected ConfigManager $configManager, protected CivicthemeConfigManager $themeConfigManager, protected ImageFactory $imageFactory) {
+  public function __construct(protected ThemeManager $themeManager, protected ThemeExtensionList $themeExtensionList, protected FileSystemInterface $fileSystem, protected FileUrlGenerator $fileUrlgenerator, protected Messenger $messenger, protected ConfigManager $configManager, protected CivicthemeConfigManager $themeConfigManager, protected ImageFactory $imageFactory, protected ?EntityTypeBundleInfoInterface $entityTypeBundleInfo = NULL) {
   }
 
   /**
@@ -65,7 +68,8 @@ abstract class CivicthemeSettingsFormSectionBase implements ContainerInjectionIn
       $container->get('messenger'),
       $container->get('config.manager'),
       $container->get('class_resolver')->getInstanceFromDefinition(CivicthemeConfigManager::class),
-      $container->get('image.factory')
+      $container->get('image.factory'),
+      $container->get('entity_type.bundle.info')
     );
   }
 
@@ -81,6 +85,14 @@ abstract class CivicthemeSettingsFormSectionBase implements ContainerInjectionIn
    */
   public function weight(): int {
     return 0;
+  }
+
+  /**
+   * Convert element value from multiline string to an array.
+   */
+  public static function multilineToArray(array $element, FormStateInterface $form_state): void {
+    $lines = is_array($element['#value']) ? $element['#value'] : explode("\n", str_replace("\r\n", "\n", (string) $element['#value']));
+    $form_state->setValueForElement($element, array_values(array_filter(array_map('trim', $lines))));
   }
 
   /**

--- a/web/themes/contrib/civictheme/src/Settings/CivicthemeSettingsFormSectionOptout.php
+++ b/web/themes/contrib/civictheme/src/Settings/CivicthemeSettingsFormSectionOptout.php
@@ -59,12 +59,4 @@ class CivicthemeSettingsFormSectionOptout extends CivicthemeSettingsFormSectionB
     ];
   }
 
-  /**
-   * Convert element value from multiline string to an array.
-   */
-  public static function multilineToArray(array $element, FormStateInterface $form_state): void {
-    $lines = is_array($element['#value']) ? $element['#value'] : explode("\n", str_replace("\r\n", "\n", (string) $element['#value']));
-    $form_state->setValueForElement($element, array_values(array_filter(array_map('trim', $lines))));
-  }
-
 }

--- a/web/themes/contrib/civictheme/src/Settings/CivicthemeSettingsFormSectionStructuredData.php
+++ b/web/themes/contrib/civictheme/src/Settings/CivicthemeSettingsFormSectionStructuredData.php
@@ -1,0 +1,172 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\civictheme\Settings;
+
+use Drupal\civictheme\CivicthemeConstants;
+use Drupal\Component\Utility\UrlHelper;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\image\Entity\ImageStyle;
+
+/**
+ * CivicTheme settings section for Schema.org JSON-LD structured data.
+ */
+class CivicthemeSettingsFormSectionStructuredData extends CivicthemeSettingsFormSectionBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function weight(): int {
+    return 40;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function form(array &$form, FormStateInterface $form_state): void {
+    $form['structured_data'] = [
+      '#type' => 'details',
+      '#title' => $this->t('Structured data (JSON-LD)'),
+      '#description' => $this->t('Emit Schema.org JSON-LD structured data in the page head of published content pages. Only the content types mapped to a Schema.org type below receive the markup.'),
+      '#open' => FALSE,
+      '#weight' => 70,
+      '#tree' => TRUE,
+    ];
+
+    $form['structured_data']['enabled'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Enable JSON-LD structured data'),
+      '#default_value' => $this->themeConfigManager->load('structured_data.enabled', FALSE),
+    ];
+
+    $visible_when_enabled = [
+      'visible' => [
+        ':input[name="structured_data[enabled]"]' => ['checked' => TRUE],
+      ],
+    ];
+
+    $form['structured_data']['bundles'] = [
+      '#type' => 'fieldset',
+      '#title' => $this->t('Content type mapping'),
+      '#description' => $this->t('Content types without a Schema.org type do not receive any markup.'),
+      '#description_display' => 'before',
+      '#states' => $visible_when_enabled,
+      '#tree' => TRUE,
+    ];
+
+    $bundles = $this->entityTypeBundleInfo ? $this->entityTypeBundleInfo->getBundleInfo('node') : [];
+    $mapping = $this->themeConfigManager->load('structured_data.bundles', []);
+    $mapping = is_array($mapping) ? $mapping : [];
+    $type_options = $this->typeOptions();
+
+    foreach ($bundles as $bundle => $bundle_info) {
+      $form['structured_data']['bundles'][$bundle] = [
+        '#type' => 'select',
+        '#title' => $bundle_info['label'] ?? $bundle,
+        '#options' => $type_options,
+        '#empty_option' => $this->t('- None -'),
+        '#empty_value' => '',
+        '#default_value' => $mapping[$bundle] ?? '',
+      ];
+    }
+
+    $form['structured_data']['organization'] = [
+      '#type' => 'details',
+      '#title' => $this->t('Organization'),
+      '#description' => $this->t('The publishing organisation, referenced as the publisher and the author of the mapped content. The organisation name is taken from the <em>Site name</em> in the basic site settings.'),
+      '#open' => TRUE,
+      '#states' => $visible_when_enabled,
+      '#tree' => TRUE,
+    ];
+
+    $form['structured_data']['organization']['same_as'] = [
+      '#type' => 'textarea',
+      '#title' => $this->t('Official profile URLs'),
+      '#rows' => 4,
+      '#description' => $this->t('Absolute URLs of the official pages and profiles of the organisation, one per line. Only include pages that the organisation controls, such as a government register record or its own social media profiles.'),
+      '#element_validate' => [[self::class, 'validateSameAs']],
+      '#default_value' => implode("\n", (array) $this->themeConfigManager->load('structured_data.organization.same_as', [])),
+    ];
+
+    $form['structured_data']['organization']['logo_path'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Organization logo path'),
+      '#description' => $this->t('Path to the logo image relative to the Drupal root. Leave empty to use the Primary light desktop logo. Search engines expect a raster image (PNG, JPG or GIF), so a dedicated image is usually required as the CivicTheme default logo is an SVG.'),
+      '#default_value' => $this->themeConfigManager->load('structured_data.organization.logo_path', ''),
+    ];
+
+    $form['structured_data']['image_style'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Image style'),
+      '#description' => $this->t('Image style applied to the featured image of the content. Use <em>Original image</em> to reference the uploaded file.'),
+      '#options' => $this->imageStyleOptions(),
+      '#empty_option' => $this->t('Original image'),
+      '#empty_value' => '',
+      '#states' => $visible_when_enabled,
+      '#default_value' => $this->themeConfigManager->load('structured_data.image_style', CivicthemeConstants::SOCIAL_SHARE_IMAGE_STYLE),
+    ];
+
+    $form['structured_data']['description_length'] = [
+      '#type' => 'number',
+      '#title' => $this->t('Description length'),
+      '#description' => $this->t('Maximum length of the description sourced from the content summary.'),
+      '#min' => 0,
+      '#states' => $visible_when_enabled,
+      '#default_value' => $this->themeConfigManager->load('structured_data.description_length', CivicthemeConstants::STRUCTURED_DATA_DESCRIPTION_LENGTH),
+    ];
+  }
+
+  /**
+   * Schema.org type options for the content type mapping.
+   *
+   * @return array<string, string>
+   *   Type labels keyed by the setting value.
+   */
+  protected function typeOptions(): array {
+    $options = [];
+
+    foreach (_civictheme_structured_data_types() as $type => $definition) {
+      $options[$type] = (string) ($definition['label'] ?? $type);
+    }
+
+    return $options;
+  }
+
+  /**
+   * Image style options.
+   *
+   * @return array<string, string>
+   *   Image style labels keyed by the image style name.
+   *
+   * @SuppressWarnings(PHPMD.StaticAccess)
+   */
+  protected function imageStyleOptions(): array {
+    $options = [];
+
+    foreach (ImageStyle::loadMultiple() as $name => $image_style) {
+      $options[$name] = (string) $image_style->label();
+    }
+
+    return $options;
+  }
+
+  /**
+   * Convert the value to an array and validate that all lines are URLs.
+   *
+   * @SuppressWarnings(PHPMD.StaticAccess)
+   */
+  public static function validateSameAs(array $element, FormStateInterface $form_state): void {
+    static::multilineToArray($element, $form_state);
+
+    foreach ($form_state->getValue($element['#parents']) as $url) {
+      if (!UrlHelper::isValid($url, TRUE)) {
+        $form_state->setError($element, new TranslatableMarkup('The URL @url is not a valid absolute URL.', ['@url' => $url]));
+
+        return;
+      }
+    }
+  }
+
+}

--- a/web/themes/contrib/civictheme/src/Settings/CivicthemeSettingsFormSectionStructuredData.php
+++ b/web/themes/contrib/civictheme/src/Settings/CivicthemeSettingsFormSectionStructuredData.php
@@ -75,7 +75,7 @@ class CivicthemeSettingsFormSectionStructuredData extends CivicthemeSettingsForm
     $form['structured_data']['organization'] = [
       '#type' => 'details',
       '#title' => $this->t('Organization'),
-      '#description' => $this->t('The publishing organisation, referenced as the publisher and the author of the mapped content. The organisation name is taken from the <em>Site name</em> in the basic site settings.'),
+      '#description' => $this->t('The publishing organization, referenced as the publisher and the author of the mapped content. The organization name is taken from the <em>Site name</em> in the basic site settings.'),
       '#open' => TRUE,
       '#states' => $visible_when_enabled,
       '#tree' => TRUE,
@@ -85,7 +85,7 @@ class CivicthemeSettingsFormSectionStructuredData extends CivicthemeSettingsForm
       '#type' => 'textarea',
       '#title' => $this->t('Official profile URLs'),
       '#rows' => 4,
-      '#description' => $this->t('Absolute URLs of the official pages and profiles of the organisation, one per line. Only include pages that the organisation controls, such as a government register record or its own social media profiles.'),
+      '#description' => $this->t('Absolute URLs of the official pages and profiles of the organization, one per line. Only include pages that the organization controls, such as a government register record or its own social media profiles.'),
       '#element_validate' => [[self::class, 'validateSameAs']],
       '#default_value' => implode("\n", (array) $this->themeConfigManager->load('structured_data.organization.same_as', [])),
     ];

--- a/web/themes/contrib/civictheme/tests/src/Unit/CivicthemeStructuredDataUnitTest.php
+++ b/web/themes/contrib/civictheme/tests/src/Unit/CivicthemeStructuredDataUnitTest.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\civictheme\Unit;
+
+/**
+ * Class CivicthemeStructuredDataUnitTest.
+ *
+ * Test cases for the structured data helper functions.
+ *
+ * @group CivicTheme
+ * @group site:unit
+ */
+class CivicthemeStructuredDataUnitTest extends CivicthemeUnitTestBase {
+
+  /**
+   * Test for _civictheme_structured_data_truncate().
+   *
+   * @dataProvider dataProviderTruncate
+   */
+  public function testTruncate(string $text, int $length, string $expected): void {
+    $this->assertEquals($expected, _civictheme_structured_data_truncate($text, $length));
+  }
+
+  /**
+   * Data provider for testTruncate().
+   */
+  public static function dataProviderTruncate(): array {
+    return [
+      // Empty.
+      ['', 10, ''],
+      // Whitespace is trimmed.
+      ['  Summary  ', 10, 'Summary'],
+      // Shorter than the limit.
+      ['Summary', 10, 'Summary'],
+      // Exactly at the limit.
+      ['Summarybox', 10, 'Summarybox'],
+      // Truncated on a word boundary with an ellipsis.
+      ['One two three four five', 12, 'One two…'],
+      // Truncation disabled.
+      ['One two three four five', 0, 'One two three four five'],
+      ['One two three four five', -1, 'One two three four five'],
+      // Multibyte text is measured in characters, not bytes.
+      ['Ærøskøbing Ærøskøbing', 12, 'Ærøskøbing…'],
+    ];
+  }
+
+  /**
+   * Test that the truncated value never exceeds the requested length.
+   */
+  public function testTruncateLength(): void {
+    $text = str_repeat('Lorem ipsum dolor sit amet ', 20);
+
+    foreach ([1, 5, 20, 110, 300] as $length) {
+      $actual = _civictheme_structured_data_truncate($text, $length);
+      $this->assertLessThanOrEqual($length, mb_strlen($actual), sprintf('Truncated to %s characters.', $length));
+    }
+  }
+
+  /**
+   * Test for _civictheme_structured_data_modified_value().
+   *
+   * @dataProvider dataProviderModifiedValue
+   */
+  public function testModifiedValue(?string $last_updated, int $changed, int $published, int|string $expected): void {
+    $this->assertSame($expected, _civictheme_structured_data_modified_value($last_updated, $changed, $published));
+  }
+
+  /**
+   * Data provider for testModifiedValue().
+   */
+  public static function dataProviderModifiedValue(): array {
+    $published = (int) strtotime('2026-06-25T10:00:00+00:00');
+
+    return [
+      // Without the "last updated" value - the changed date is used.
+      [NULL, $published + 3600, $published, $published + 3600],
+      // The changed date is clamped to the published date.
+      [NULL, $published - 3600, $published, $published],
+      // An empty "last updated" value is ignored.
+      ['', $published + 3600, $published, $published + 3600],
+      ['   ', $published + 3600, $published, $published + 3600],
+      // A date-only value after the published date is used as-is.
+      ['2026-06-26', $published, $published, '2026-06-26'],
+      // A date-only value on the day of publishing resolves to midnight, which
+      // precedes the published date, so the published date is used instead.
+      ['2026-06-25', $published, $published, $published],
+      // A date-only value before the published date is clamped.
+      ['2026-06-24', $published, $published, $published],
+      // An invalid value is clamped.
+      ['not a date', $published, $published, $published],
+    ];
+  }
+
+  /**
+   * Test for _civictheme_structured_data_type_definitions().
+   */
+  public function testTypeDefinitions(): void {
+    $definitions = _civictheme_structured_data_type_definitions();
+
+    $this->assertNotEmpty($definitions);
+
+    foreach ($definitions as $type => $definition) {
+      $this->assertNotEmpty($definition['label'], sprintf('Type %s has a label.', $type));
+      $this->assertNotEmpty($definition['types'], sprintf('Type %s has Schema.org types.', $type));
+      $this->assertNotEmpty($definition['fragment'], sprintf('Type %s has a fragment.', $type));
+      $this->assertIsCallable($definition['builder'], sprintf('Type %s has a callable builder.', $type));
+      $this->assertContains($type, $definition['types'], sprintf('Type %s is the primary Schema.org type.', $type));
+    }
+
+    // Single and multiple type mappings.
+    $this->assertEquals(['WebPage'], $definitions['WebPage']['types']);
+    $this->assertEquals(['NewsArticle', 'Article'], $definitions['NewsArticle']['types']);
+    $this->assertEquals(['Report', 'Article'], $definitions['Report']['types']);
+
+    // Bundles of the same family share the '@id' fragment and the builder.
+    $this->assertEquals('article', $definitions['Report']['fragment']);
+    $this->assertEquals($definitions['Article']['builder'], $definitions['Report']['builder']);
+    $this->assertEquals('event', $definitions['Event']['fragment']);
+  }
+
+}


### PR DESCRIPTION
https://www.drupal.org/project/civictheme/issues/3613662

## Checklist before requesting a review

- [x] I have formatted the subject to include ticket number as `Issue #123456 by drupal_org_username: Issue title`
- [x] I have added a link to the issue tracker
- [x] I have provided information in `Changed` section about WHY something was done if this was not a normal implementation
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run new and existing relevant tests locally with my changes, and they passed
- [x] I have provided screenshots, where applicable

## Changed

1. **`includes/structured_data.inc` (new)** — emits a single `<script type="application/ld+json">` in the head of canonical, published node pages of the mapped bundles, containing an `@graph` of `Organization`, `WebSite`, the content entity (`WebPage`, the article family or `Event`) and `BreadcrumbList`, all linked by `@id`. Called from the existing `civictheme_page_attachments_alter()` rather than adding a second implementation of the hook.
2. **`src/Settings/CivicthemeSettingsFormSectionStructuredData.php` (new)** — theme settings section (weight 40), auto-discovered by `CivicthemeSettingsFormManager`: enable toggle, a Schema.org type select per node bundle, organisation profile URLs and logo path, image style and description length.
3. **Config** — `structured_data` added to the settings schema and install defaults; new `image.style.civictheme_social_share` (1200x630) registered in `config_devel`; `civictheme_post_update_add_structured_data_settings()` creates the image style and seeds the defaults for CivicTheme and its sub-themes.
4. **Hooks + docs** — `hook_civictheme_structured_data_alter()` and `hook_civictheme_structured_data_types_alter()` documented in `civictheme.api.php`, plus a "Structured data (JSON-LD)" section in `README.md`.
5. **Tests** — `CivicthemeStructuredDataUnitTest` covers the pure helpers: truncation boundaries (including multibyte), `dateModified` clamping and the type definitions.

### Why it was done this way

- **Base theme, not the starter kit** — starter-kit files are copied at sub-theme creation and immediately diverge, and the starter kit has no `.theme` file. Base-theme `hook_page_attachments_alter()` runs for sub-themes and `theme_get_setting()` merges base-theme settings, so every sub-theme inherits both the code and the defaults.
- **Disabled by default** — enabling structured data is an explicit per-site SEO decision, so existing sites are unaffected until the toggle is switched on.
- **Bundle mapping in the UI, field names in code** — the mapping is the part that differs per site (custom publication/news/review bundles), while the field names are CivicTheme's own. Anything beyond that is added via the alter hooks instead of growing the settings form.
- **No `isAccessibleForFree`** — the base theme should not assert a site's access policy; sites add it in `hook_civictheme_structured_data_alter()` (shown in the api.php example).
- **`dateModified` clamping** — the custom "last updated" field is date-only, so on the day a node is first published its midnight value sorts before the timestamped `datePublished`, which search engines flag as an error. The published date is used instead in that case.
- **Image dimensions via `ImageStyle::transformDimensions()`** — derived from the stored source dimensions, so rendering the head never triggers derivative generation, and the numbers stay correct for any configured style.
- **Breadcrumb mirrors the Banner component** — the raw breadcrumb service returns only "Home" on most CivicTheme pages; the visible breadcrumb appends the current page in `_civictheme_preprocess_block__civictheme_banner__breadcrumb()`. The JSON-LD does the same so the markup matches what visitors see, and is omitted entirely when it would hold a single item.
- **Cacheability** — the node, referenced media and terms, the breadcrumb and the theme settings config are all merged into the page attachments, so the markup invalidates when any of them changes (including an image or its alt text).
- **Shared-code changes instead of duplication** — `CivicthemeSettingsFormSectionBase` gained an optional `EntityTypeBundleInfoInterface` argument (appended, so existing sections are unaffected) and `multilineToArray()` moved up from `CivicthemeSettingsFormSectionOptout`, where it stays callable through the sub-class. `CivicthemeUpdateHelper` gained generically named `themesWithCivicthemeBase()`/`themeExtendsCivictheme()`, with the previous `logoAlt*` methods kept as thin aliases.

## Testing

- `ahoy drush updb` — creates the image style and seeds the settings (disabled) for `civictheme` and sub-themes.
- Manual, with the toggle enabled on a sub-theme: a `civictheme_page` node emits `Organization | WebSite | WebPage | BreadcrumbList`, and a `civictheme_event` node emits `Organization | WebSite | Event | BreadcrumbList` with `startDate`/`endDate`, a `Place` address from the Map location paragraph and a 1200x630 `civictheme_social_share` image. With the toggle off, no `application/ld+json` element is emitted.
- Output validated against the Schema Markup Validator / Rich Results Test, including a node published today with a "last updated" date set (no `dateModified` before `datePublished`).

## Screenshots

<img width="1179" height="772" alt="Screenshot 2026-07-28 at 10 44 45 PM" src="https://github.com/user-attachments/assets/e05e6375-b0b4-4978-ab74-2317e53de7f0" />
<img width="963" height="635" alt="Screenshot 2026-07-28 at 10 48 03 PM" src="https://github.com/user-attachments/assets/c86ca8f0-9c2a-40f8-8723-c6092168987d" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional Schema.org JSON-LD structured data for published canonical content pages.
  * Added configuration for content-type mappings, organization details, images, and descriptions.
  * Added support for WebPage, Article, Event, breadcrumb, organization, and website metadata.
  * Added a Social share image style and automatic upgrade setup.

* **Documentation**
  * Documented configuration, output structure, customization options, and validation resources.

* **Tests**
  * Added coverage for structured data type mappings, truncation, and publication date handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->