### PR TITLE
Issue #3614823 by alan.cole: Footer menu blocks with title show double title.

### DIFF
--- a/web/themes/contrib/civictheme/civictheme.theme
+++ b/web/themes/contrib/civictheme/civictheme.theme
@@ -24,6 +24,7 @@ require_once __DIR__ . '/includes/campaign.inc';
 require_once __DIR__ . '/includes/content.inc';
 require_once __DIR__ . '/includes/manual_list.inc';
 require_once __DIR__ . '/includes/cards.inc';
+require_once __DIR__ . '/includes/footer.inc';
 require_once __DIR__ . '/includes/form_element.inc';
 require_once __DIR__ . '/includes/form.inc';
 require_once __DIR__ . '/includes/iframe.inc';
@@ -239,6 +240,7 @@ function civictheme_preprocess_block(array &$variables): void {
   _civictheme_preprocess_block__content($variables);
   _civictheme_preprocess_block__civictheme_mobile_navigation($variables);
   _civictheme_preprocess_block__civictheme_social_links($variables);
+  _civictheme_preprocess_block__footer($variables);
 }
 
 /**

--- a/web/themes/contrib/civictheme/includes/footer.inc
+++ b/web/themes/contrib/civictheme/includes/footer.inc
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * @file
+ * Footer related functions.
+ */
+
+declare(strict_types=1);
+
+/**
+ * Preprocess for footer menu block.
+ */
+function _civictheme_preprocess_block__footer(array &$variables): void {
+  if (($variables['base_plugin_id'] ?? '') !== 'menu_block') {
+    return;
+  }
+
+  $menu_name = strtr((string) ($variables['elements']['#derivative_plugin_id'] ?? ''), '-', '_');
+
+  // The footer template is selected by the block's suggestion, so it takes
+  // precedence over the menu name.
+  $suggestion = $variables['elements']['#configuration']['suggestion'] ?? '';
+  if ($suggestion === 'civictheme_footer') {
+    $menu_name = $suggestion;
+  }
+
+  // Remove the block heading from footer menu blocks: the heading is rendered
+  // by the navigation component from the 'title' variable set in
+  // _civictheme_preprocess_block__navigation().
+  if ($menu_name === 'civictheme_footer') {
+    $variables['label'] = '';
+  }
+}


### PR DESCRIPTION
https://www.drupal.org/project/civictheme/issues/3614823

## Checklist before requesting a review

- [x] I have formatted the subject to include ticket number as `Issue #123456 by drupal_org_username: Issue title`
- [x] I have added a link to the issue tracker
- [x] I have provided information in `Changed` section about WHY something was done if this was not a normal implementation
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have run new and existing relevant tests locally with my changes, and they passed
- [x] I have provided screenshots, where applicable

## Changed

1. Unset the `label` for footer menus. This allows the navigation to render the `title` without the block picking up the leftover `label`.

## Screenshots

Before:
<img width="1280" height="1024" alt="Screen Shot 2026-08-04 at 21 36 25" src="https://github.com/user-attachments/assets/3f7f48a8-c37f-4b56-aaf1-3c3a241d3bcc" />

After:
<img width="1280" height="1024" alt="Screen Shot 2026-08-04 at 21 37 06" src="https://github.com/user-attachments/assets/63b0e806-dd99-4522-b93a-d60484f69fc6" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added specialized footer menu handling for CivicTheme.
  * Footer menu blocks now use the appropriate footer styling and display without a block label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->