### PR TITLE
Use @civictheme/drupal-attribute and drupal-twig-extensions forks in Storybook

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,18 +4,17 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "civictheme",
       "workspaces": [
         "scripts/civictheme-uikit-version-manager",
         "scripts/civictheme-dependency-checker"
       ],
       "dependencies": {
-        "@civictheme/uikit": "github:civictheme/uikit#83c43d321c0decb76ac1b2d135e37a288d8467a6"
+        "@civictheme/uikit": "github:civictheme/uikit#2f205010a77a16af4ab70bc7d5c9216353168183"
       }
     },
     "node_modules/@civictheme/uikit": {
       "version": "1.13.0",
-      "resolved": "git+ssh://git@github.com/civictheme/uikit.git#83c43d321c0decb76ac1b2d135e37a288d8467a6",
+      "resolved": "git+ssh://git@github.com/civictheme/uikit.git#2f205010a77a16af4ab70bc7d5c9216353168183",
       "integrity": "sha512-voFSk44+YjNYLYcqvM8RCVa5kB/nXgdeQS/0Z37fKmhl0YMoQUkhokErpY4ylXE2A5OvzQPfo2CYMWE4gUJShg==",
       "cpu": [
         "x64",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,10 @@
 {
-  "name": "civictheme-monorepo",
+  "name": "civictheme",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
+      "name": "civictheme",
       "workspaces": [
         "scripts/civictheme-uikit-version-manager",
         "scripts/civictheme-dependency-checker"
@@ -484,9 +485,19 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,13 @@
         "scripts/civictheme-dependency-checker"
       ],
       "dependencies": {
-        "@civictheme/uikit": "github:civictheme/uikit#2f205010a77a16af4ab70bc7d5c9216353168183"
+        "@civictheme/uikit": "github:civictheme/uikit#2f763a2176858e496274fb059bc8d3ef8a758b66"
       }
     },
     "node_modules/@civictheme/uikit": {
       "version": "1.13.0",
-      "resolved": "git+ssh://git@github.com/civictheme/uikit.git#2f205010a77a16af4ab70bc7d5c9216353168183",
-      "integrity": "sha512-voFSk44+YjNYLYcqvM8RCVa5kB/nXgdeQS/0Z37fKmhl0YMoQUkhokErpY4ylXE2A5OvzQPfo2CYMWE4gUJShg==",
+      "resolved": "git+ssh://git@github.com/civictheme/uikit.git#2f763a2176858e496274fb059bc8d3ef8a758b66",
+      "integrity": "sha512-SdsQXHEVt2jmYg96ool3hBYgqkk8vJt39Z9CB7tAI212noMssHLuq9sNTAZKW3wpFFUYtMluHFQU7jnNZ/BZOg==",
       "cpu": [
         "x64",
         "arm",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,17 +4,18 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "civictheme",
       "workspaces": [
         "scripts/civictheme-uikit-version-manager",
         "scripts/civictheme-dependency-checker"
       ],
       "dependencies": {
-        "@civictheme/uikit": "github:civictheme/uikit#2f763a2176858e496274fb059bc8d3ef8a758b66"
+        "@civictheme/uikit": "github:civictheme/uikit#d822368599a8f91d7af91d82f061f50508301368"
       }
     },
     "node_modules/@civictheme/uikit": {
       "version": "1.13.0",
-      "resolved": "git+ssh://git@github.com/civictheme/uikit.git#2f763a2176858e496274fb059bc8d3ef8a758b66",
+      "resolved": "git+ssh://git@github.com/civictheme/uikit.git#d822368599a8f91d7af91d82f061f50508301368",
       "integrity": "sha512-SdsQXHEVt2jmYg96ool3hBYgqkk8vJt39Z9CB7tAI212noMssHLuq9sNTAZKW3wpFFUYtMluHFQU7jnNZ/BZOg==",
       "cpu": [
         "x64",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "scripts/civictheme-dependency-checker"
   ],
   "dependencies": {
-    "@civictheme/uikit": "github:civictheme/uikit#2f763a2176858e496274fb059bc8d3ef8a758b66"
+    "@civictheme/uikit": "github:civictheme/uikit#d822368599a8f91d7af91d82f061f50508301368"
   },
   "scripts": {
     "uikit-change": "npm start --workspace=civictheme-uikit-version-change",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "scripts/civictheme-dependency-checker"
   ],
   "dependencies": {
-    "@civictheme/uikit": "github:civictheme/uikit#2f205010a77a16af4ab70bc7d5c9216353168183"
+    "@civictheme/uikit": "github:civictheme/uikit#2f763a2176858e496274fb059bc8d3ef8a758b66"
   },
   "scripts": {
     "uikit-change": "npm start --workspace=civictheme-uikit-version-change",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "scripts/civictheme-dependency-checker"
   ],
   "dependencies": {
-    "@civictheme/uikit": "github:civictheme/uikit#83c43d321c0decb76ac1b2d135e37a288d8467a6"
+    "@civictheme/uikit": "github:civictheme/uikit#2f205010a77a16af4ab70bc7d5c9216353168183"
   },
   "scripts": {
     "uikit-change": "npm start --workspace=civictheme-uikit-version-change",

--- a/scripts/civictheme-uikit-version-manager/index.mjs
+++ b/scripts/civictheme-uikit-version-manager/index.mjs
@@ -27,6 +27,8 @@ const THEME_PACKAGE_JSON = path.join(ROOT_DIR, 'web/themes/contrib/civictheme/pa
 
 // GitHub repository information
 const GITHUB_API_URL = 'https://api.github.com/repos/civictheme/uikit/branches';
+// GitHub returns 30 branches per page by default; max is 100.
+const GITHUB_BRANCHES_PER_PAGE = 60;
 const GITHUB_COMMITS_API_URL = 'https://api.github.com/repos/civictheme/uikit/commits/';
 const GITHUB_REPO_URL = 'github:civictheme/uikit';
 const NPM_RELEASE_PACKAGE_NAME = '@civictheme/sdc';
@@ -83,14 +85,14 @@ async function handleReleaseInstallation() {
       source: async (input) => {
         if (input === undefined) {
           // Show first 20 versions by default
-          return availableVersions.slice(0, 20);
+          return availableVersions.slice(0, 100);
         }
         // Filter versions based on input
         return availableVersions
           .filter((ver) => ver.toLowerCase().includes(input.toLowerCase()))
-          .slice(0, 20); // Limit results for better performance
+          .slice(0, 100); // Limit results for better performance
       },
-      pageSize: 20
+      pageSize: 100
     });
 
     // Update package.json files
@@ -115,6 +117,7 @@ async function handleDevInstallation() {
     // Fetch branches from GitHub repository
     console.log('Fetching branches from GitHub...');
     const branches = await fetchGitHubBranches();
+    console.log('Number of Branches from GitHub... ' + branches.length);
     if (!branches || branches.length === 0) {
       throw new Error('No branches found or error fetching branches');
     }
@@ -137,7 +140,7 @@ async function handleDevInstallation() {
             return branch.toLowerCase().includes(input.toLowerCase())
           });
       },
-      pageSize: 50
+      pageSize: 100
     });
 
     // Fetch the latest commit hash for the selected branch
@@ -206,7 +209,7 @@ async function fetchNpmVersions(packageName) {
  */
 async function fetchGitHubBranches() {
   try {
-    const response = await fetch(GITHUB_API_URL, {
+    const response = await fetch(`${GITHUB_API_URL}?per_page=${GITHUB_BRANCHES_PER_PAGE}`, {
       headers: {
         'Accept': 'application/vnd.github+json'
       }

--- a/web/themes/contrib/civictheme/.storybook/preview.js
+++ b/web/themes/contrib/civictheme/.storybook/preview.js
@@ -6,13 +6,9 @@ import '../dist/civictheme.base.css';
 import '../dist/civictheme.variables.css';
 import '../dist/civictheme.base';
 
-// Every Twig module compiled by vite-plugin-twig-drupal calls
-// addDrupalExtensions(Twig) at import time, re-registering
-// drupal-twig-extensions' create_attribute(). That implementation builds its
-// collection with Object.keys(), which renders Twig.js' internal `_keys`
-// bookkeeping as an attribute and loses the authored key order. Patching
-// extendFunction makes every re-registration resolve back to the fixed
-// implementation from @civictheme/drupal-attribute.
+// drupal-twig-extensions' create_attribute() reads Object.keys(), so
+// attributes lose their template order. Patch rather than register once:
+// every compiled Twig module re-runs addDrupalExtensions(Twig).
 const extendFunction = Twig.extendFunction.bind(Twig);
 Twig.extendFunction = (name, definition) => extendFunction(name, name === 'create_attribute' ? createAttribute : definition);
 Twig.extendFunction('create_attribute', createAttribute);

--- a/web/themes/contrib/civictheme/.storybook/preview.js
+++ b/web/themes/contrib/civictheme/.storybook/preview.js
@@ -1,8 +1,21 @@
 // phpcs:ignoreFile
+import Twig from 'twig';
+import { createAttribute } from '@civictheme/drupal-attribute';
 import '../dist/civictheme.stories.css?module';
 import '../dist/civictheme.base.css';
 import '../dist/civictheme.variables.css';
 import '../dist/civictheme.base';
+
+// Every Twig module compiled by vite-plugin-twig-drupal calls
+// addDrupalExtensions(Twig) at import time, re-registering
+// drupal-twig-extensions' create_attribute(). That implementation builds its
+// collection with Object.keys(), which renders Twig.js' internal `_keys`
+// bookkeeping as an attribute and loses the authored key order. Patching
+// extendFunction makes every re-registration resolve back to the fixed
+// implementation from @civictheme/drupal-attribute.
+const extendFunction = Twig.extendFunction.bind(Twig);
+Twig.extendFunction = (name, definition) => extendFunction(name, name === 'create_attribute' ? createAttribute : definition);
+Twig.extendFunction('create_attribute', createAttribute);
 
 export default {
   parameters: {

--- a/web/themes/contrib/civictheme/civictheme_starter_kit/.storybook/preview.js
+++ b/web/themes/contrib/civictheme/civictheme_starter_kit/.storybook/preview.js
@@ -6,13 +6,9 @@ import '../dist/styles.base.css';
 import '../dist/styles.variables.css';
 import '../dist/scripts.base';
 
-// Every Twig module compiled by vite-plugin-twig-drupal calls
-// addDrupalExtensions(Twig) at import time, re-registering
-// drupal-twig-extensions' create_attribute(). That implementation builds its
-// collection with Object.keys(), which renders Twig.js' internal `_keys`
-// bookkeeping as an attribute and loses the authored key order. Patching
-// extendFunction makes every re-registration resolve back to the fixed
-// implementation from @civictheme/drupal-attribute.
+// drupal-twig-extensions' create_attribute() reads Object.keys(), so
+// attributes lose their template order. Patch rather than register once:
+// every compiled Twig module re-runs addDrupalExtensions(Twig).
 const extendFunction = Twig.extendFunction.bind(Twig);
 Twig.extendFunction = (name, definition) => extendFunction(name, name === 'create_attribute' ? createAttribute : definition);
 Twig.extendFunction('create_attribute', createAttribute);

--- a/web/themes/contrib/civictheme/civictheme_starter_kit/.storybook/preview.js
+++ b/web/themes/contrib/civictheme/civictheme_starter_kit/.storybook/preview.js
@@ -1,7 +1,21 @@
+// phpcs:ignoreFile
+import Twig from 'twig';
+import { createAttribute } from '@civictheme/drupal-attribute';
 import '../dist/styles.stories.css?module';
 import '../dist/styles.base.css';
 import '../dist/styles.variables.css';
 import '../dist/scripts.base';
+
+// Every Twig module compiled by vite-plugin-twig-drupal calls
+// addDrupalExtensions(Twig) at import time, re-registering
+// drupal-twig-extensions' create_attribute(). That implementation builds its
+// collection with Object.keys(), which renders Twig.js' internal `_keys`
+// bookkeeping as an attribute and loses the authored key order. Patching
+// extendFunction makes every re-registration resolve back to the fixed
+// implementation from @civictheme/drupal-attribute.
+const extendFunction = Twig.extendFunction.bind(Twig);
+Twig.extendFunction = (name, definition) => extendFunction(name, name === 'create_attribute' ? createAttribute : definition);
+Twig.extendFunction('create_attribute', createAttribute);
 
 export default {
   parameters: {

--- a/web/themes/contrib/civictheme/civictheme_starter_kit/package-lock.json
+++ b/web/themes/contrib/civictheme/civictheme_starter_kit/package-lock.json
@@ -40,7 +40,7 @@
         "stylelint-config-standard-scss": "^17.0.0",
         "twig": "^3.0.0",
         "vite": "^6.4.2",
-        "vite-plugin-twig-drupal": "^1.7.0"
+        "vite-plugin-twig-drupal": "git+https://github.com/civictheme/vite-plugin-twig-drupal.git#semver:^1.7.1-ct.1"
       },
       "engines": {
         "node": ">=22.6.0"
@@ -2284,25 +2284,13 @@
       "license": "MIT",
       "peer": true
     },
-    "node_modules/drupal-attribute": {
-      "name": "@civictheme/drupal-attribute",
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@civictheme/drupal-attribute/-/drupal-attribute-2.0.1.tgz",
-      "integrity": "sha512-9ivuchfqO7n9MTwwUabi2UBZ3wmdC3IF1ylulR+Ore5bQUEgTLkTGh867WCNiCuhEjNeprVzRA9vyUaNDJXM+w==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=20"
-      }
-    },
     "node_modules/drupal-twig-extensions": {
-      "version": "1.0.0-beta.5",
-      "resolved": "git+ssh://git@github.com/civictheme/drupal-twig-extensions.git#092058b870917ffd6e15ce07503e32a471484147",
-      "integrity": "sha512-w514xeaPhDNqUiyH3yIj6pZTuKDIW7+CZAFxBid8rTRr5LVjrgFgq2iD4Zf2SEekT3Z5g6fsDHU44liONUXISw==",
+      "version": "1.0.0-beta.5.ct.1",
+      "resolved": "git+ssh://git@github.com/civictheme/drupal-twig-extensions.git#a893a09d3526c0de0f5414ddc5d24755479ef46f",
       "dev": true,
       "license": "(MIT OR GPL-2.0-only)",
       "dependencies": {
-        "drupal-attribute": "^1.0.2",
+        "@civictheme/drupal-attribute": "^2.0.1",
         "locutus": "^3.0.24",
         "lodash.clonedeep": "^4.5.0"
       }
@@ -5257,14 +5245,13 @@
       }
     },
     "node_modules/vite-plugin-twig-drupal": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/vite-plugin-twig-drupal/-/vite-plugin-twig-drupal-1.7.0.tgz",
-      "integrity": "sha512-yJI5JHm+COQObytCrxiuWanh5m6fZuy2MrIsPFJeeAIPG/OBW2wpdq2q7xLk5Nd+gfzT133j+L6zTmSyYWzOJw==",
+      "version": "1.7.1-ct.1",
+      "resolved": "git+ssh://git@github.com/civictheme/vite-plugin-twig-drupal.git#752b285ac7aa66e83e5560af0d120ccf52957b57",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "drupal-attribute": "^1.0.2",
-        "drupal-twig-extensions": "^1.0.0-beta.5",
+        "@civictheme/drupal-attribute": "^2.0.1",
+        "drupal-twig-extensions": "github:civictheme/drupal-twig-extensions#semver:^1.0.0-beta.5.ct.1",
         "twig": "^1.16.0 || ^2 || ^3"
       },
       "peerDependencies": {

--- a/web/themes/contrib/civictheme/civictheme_starter_kit/package-lock.json
+++ b/web/themes/contrib/civictheme/civictheme_starter_kit/package-lock.json
@@ -21,6 +21,7 @@
         "@popperjs/core": "^2.11.8"
       },
       "devDependencies": {
+        "@civictheme/drupal-attribute": "^2.0.0",
         "@civictheme/scss-variables-extractor": "^0.2.1",
         "@eslint/js": "^10.0.1",
         "@storybook/addon-docs": "10.2.13",
@@ -37,8 +38,9 @@
         "stylelint": "^17.4.0",
         "stylelint-config-standard": "^40.0.0",
         "stylelint-config-standard-scss": "^17.0.0",
+        "twig": "^3.0.0",
         "vite": "^6.4.2",
-        "vite-plugin-twig-drupal": "^1.6.0"
+        "vite-plugin-twig-drupal": "^1.7.0"
       },
       "engines": {
         "node": ">=22.6.0"
@@ -152,6 +154,16 @@
       "license": "MIT",
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
+      }
+    },
+    "node_modules/@civictheme/drupal-attribute": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@civictheme/drupal-attribute/-/drupal-attribute-2.0.0.tgz",
+      "integrity": "sha512-Uj9BpGrHC5GM82amQ/8A5sn8bH+/9JpnkfZCaxnESkaKLCOUh5bEEcuUQqVf6gJ1tGBS1/kQVdjK2jIIPL88VA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@civictheme/scss-variables-extractor": {
@@ -2082,13 +2094,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/cosmiconfig": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.1.tgz",
@@ -2280,11 +2285,15 @@
       "peer": true
     },
     "node_modules/drupal-attribute": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/drupal-attribute/-/drupal-attribute-1.2.1.tgz",
-      "integrity": "sha512-SM0Htd9sBEM08X9/6uqIgm9PzWWKY/Bdef/xsuaTzzzmv6eKPuin1QgwY+Vsp3lX4uYWgrKzXehpp6vqFmpxDQ==",
+      "name": "@civictheme/drupal-attribute",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@civictheme/drupal-attribute/-/drupal-attribute-2.0.0.tgz",
+      "integrity": "sha512-Uj9BpGrHC5GM82amQ/8A5sn8bH+/9JpnkfZCaxnESkaKLCOUh5bEEcuUQqVf6gJ1tGBS1/kQVdjK2jIIPL88VA==",
       "dev": true,
-      "license": "MIT License"
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/drupal-twig-extensions": {
       "version": "1.0.0-beta.5",
@@ -5065,53 +5074,33 @@
       "license": "0BSD"
     },
     "node_modules/twig": {
-      "version": "1.17.1",
-      "resolved": "https://registry.npmjs.org/twig/-/twig-1.17.1.tgz",
-      "integrity": "sha512-atxccyr/BHtb1gPMA7Lvki0OuU17XBqHsNH9lzDHt9Rr1293EVZOosSZabEXz/DPVikIW8ZDqSkEddwyJnQN2w==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/twig/-/twig-3.0.0.tgz",
+      "integrity": "sha512-cMfYLWAgdW15B7L5wmanmga113e4phQmo3rk5EFuUrQd99g7I3ncxgynS38P01m4ZXBDSdMYUTV1g3A66/Y56Q==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "@babel/runtime": "^7.8.4",
-        "locutus": "^2.0.11",
-        "minimatch": "3.0.x",
+        "locutus": "^3.0.9",
+        "minimatch": "^10",
         "walk": "2.3.x"
       },
       "bin": {
         "twigjs": "bin/twigjs"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=22"
       }
     },
-    "node_modules/twig/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/twig/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+    "node_modules/twig/node_modules/locutus": {
+      "version": "3.0.36",
+      "resolved": "https://registry.npmjs.org/locutus/-/locutus-3.0.36.tgz",
+      "integrity": "sha512-ilsz33lqEd+KerV9JnSHM9EApVYOZ86/JTGKyafmWvhTFtjYauzT1WmZgdJ4JBGR3dY0N0PTfIq2uLvazw5QsQ==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/twig/node_modules/minimatch": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.8.tgz",
-      "integrity": "sha512-6FsRAQsxQ61mw+qP1ZzbL9Bc78x2p5OqNgNpnoAFLTrX8n5Kxph0CsnhmKKNXTWjXqU5L0pGPR7hYk+XWZr60Q==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
       "engines": {
-        "node": "*"
+        "node": ">= 22",
+        "yarn": ">= 1"
       }
     },
     "node_modules/type-check": {
@@ -5279,15 +5268,15 @@
       }
     },
     "node_modules/vite-plugin-twig-drupal": {
-      "version": "1.6.4",
-      "resolved": "https://registry.npmjs.org/vite-plugin-twig-drupal/-/vite-plugin-twig-drupal-1.6.4.tgz",
-      "integrity": "sha512-MoXL7RXzGV9E6hOygEgP/QNWZHLfc+MsWajYuVtWcY3u2ntWaJmaFVmR71UaOsXKSSVl2bBW/UaK3xHQUZTc6g==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-twig-drupal/-/vite-plugin-twig-drupal-1.7.0.tgz",
+      "integrity": "sha512-yJI5JHm+COQObytCrxiuWanh5m6fZuy2MrIsPFJeeAIPG/OBW2wpdq2q7xLk5Nd+gfzT133j+L6zTmSyYWzOJw==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "drupal-attribute": "^1.0.2",
         "drupal-twig-extensions": "^1.0.0-beta.5",
-        "twig": "^1.16.0"
+        "twig": "^1.16.0 || ^2 || ^3"
       },
       "peerDependencies": {
         "vite": "^4.4.11 || ^5 || ^6 || ^7 || ^8"

--- a/web/themes/contrib/civictheme/civictheme_starter_kit/package-lock.json
+++ b/web/themes/contrib/civictheme/civictheme_starter_kit/package-lock.json
@@ -1958,16 +1958,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -2611,9 +2611,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "dev": true,
       "funding": [
         {
@@ -2947,9 +2947,9 @@
       }
     },
     "node_modules/immutable": {
-      "version": "4.3.8",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.8.tgz",
-      "integrity": "sha512-d/Ld9aLbKpNwyl0KiM2CT1WYvkitQ1TSvmRtkcV8FKStiDoA7Slzgjmb/1G2yhKM1p0XeNOieaTbFZmU1d3Xuw==",
+      "version": "4.3.9",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.9.tgz",
+      "integrity": "sha512-ObHy4YN7ycwZOUCLI1/6svfyAFu7vL8RhAvVu/bh/RZW9EPlOyDaQ9jDQWCtdqzaXUjgXZCW1migtHE7YI7UGQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -3163,10 +3163,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -3419,9 +3429,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
       "dev": true,
       "funding": [
         {
@@ -3630,9 +3640,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.14",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
-      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "dev": true,
       "funding": [
         {
@@ -3650,7 +3660,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -5170,9 +5180,9 @@
       "license": "MIT"
     },
     "node_modules/vite": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
-      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+      "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5830,9 +5840,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "version": "8.21.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.2.tgz",
+      "integrity": "sha512-54dMVAo4WIe6SKy3vBgN+9bJZqqQ8IMRevAkOLQALhi49qkkQDQfWdAZ8KQlXiEabw88ARXXdUrlvtbKQX+aKw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/web/themes/contrib/civictheme/civictheme_starter_kit/package-lock.json
+++ b/web/themes/contrib/civictheme/civictheme_starter_kit/package-lock.json
@@ -21,7 +21,7 @@
         "@popperjs/core": "^2.11.8"
       },
       "devDependencies": {
-        "@civictheme/drupal-attribute": "^2.0.0",
+        "@civictheme/drupal-attribute": "^2.0.1",
         "@civictheme/scss-variables-extractor": "^0.2.1",
         "@eslint/js": "^10.0.1",
         "@storybook/addon-docs": "10.2.13",
@@ -157,9 +157,9 @@
       }
     },
     "node_modules/@civictheme/drupal-attribute": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@civictheme/drupal-attribute/-/drupal-attribute-2.0.0.tgz",
-      "integrity": "sha512-Uj9BpGrHC5GM82amQ/8A5sn8bH+/9JpnkfZCaxnESkaKLCOUh5bEEcuUQqVf6gJ1tGBS1/kQVdjK2jIIPL88VA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@civictheme/drupal-attribute/-/drupal-attribute-2.0.1.tgz",
+      "integrity": "sha512-9ivuchfqO7n9MTwwUabi2UBZ3wmdC3IF1ylulR+Ore5bQUEgTLkTGh867WCNiCuhEjNeprVzRA9vyUaNDJXM+w==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -2286,9 +2286,9 @@
     },
     "node_modules/drupal-attribute": {
       "name": "@civictheme/drupal-attribute",
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@civictheme/drupal-attribute/-/drupal-attribute-2.0.0.tgz",
-      "integrity": "sha512-Uj9BpGrHC5GM82amQ/8A5sn8bH+/9JpnkfZCaxnESkaKLCOUh5bEEcuUQqVf6gJ1tGBS1/kQVdjK2jIIPL88VA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@civictheme/drupal-attribute/-/drupal-attribute-2.0.1.tgz",
+      "integrity": "sha512-9ivuchfqO7n9MTwwUabi2UBZ3wmdC3IF1ylulR+Ore5bQUEgTLkTGh867WCNiCuhEjNeprVzRA9vyUaNDJXM+w==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -2297,13 +2297,13 @@
     },
     "node_modules/drupal-twig-extensions": {
       "version": "1.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/drupal-twig-extensions/-/drupal-twig-extensions-1.0.0-beta.5.tgz",
-      "integrity": "sha512-TrijTIs6wAwMmAa6eikQDyHTLNVizHPptpMd2BsRWDGpRozfH4OdY75ZQXbfnQmH5vl9kydKUfp57lUkcgQZBQ==",
+      "resolved": "git+ssh://git@github.com/civictheme/drupal-twig-extensions.git#092058b870917ffd6e15ce07503e32a471484147",
+      "integrity": "sha512-w514xeaPhDNqUiyH3yIj6pZTuKDIW7+CZAFxBid8rTRr5LVjrgFgq2iD4Zf2SEekT3Z5g6fsDHU44liONUXISw==",
       "dev": true,
       "license": "(MIT OR GPL-2.0-only)",
       "dependencies": {
         "drupal-attribute": "^1.0.2",
-        "locutus": "^2.0.16",
+        "locutus": "^3.0.24",
         "lodash.clonedeep": "^4.5.0"
       }
     },
@@ -3280,13 +3280,13 @@
       }
     },
     "node_modules/locutus": {
-      "version": "2.0.39",
-      "resolved": "https://registry.npmjs.org/locutus/-/locutus-2.0.39.tgz",
-      "integrity": "sha512-v2iub44UtGpbIv+pFkkYhZ+JsbIM0bJsQcQ1+VayUNGVA/YhM8+CkBiRACcpuuE9Q0xI1pgNzGNwzZDCp1MCww==",
+      "version": "3.0.36",
+      "resolved": "https://registry.npmjs.org/locutus/-/locutus-3.0.36.tgz",
+      "integrity": "sha512-ilsz33lqEd+KerV9JnSHM9EApVYOZ86/JTGKyafmWvhTFtjYauzT1WmZgdJ4JBGR3dY0N0PTfIq2uLvazw5QsQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">= 10",
+        "node": ">= 22",
         "yarn": ">= 1"
       }
     },
@@ -5090,17 +5090,6 @@
       },
       "engines": {
         "node": ">=22"
-      }
-    },
-    "node_modules/twig/node_modules/locutus": {
-      "version": "3.0.36",
-      "resolved": "https://registry.npmjs.org/locutus/-/locutus-3.0.36.tgz",
-      "integrity": "sha512-ilsz33lqEd+KerV9JnSHM9EApVYOZ86/JTGKyafmWvhTFtjYauzT1WmZgdJ4JBGR3dY0N0PTfIq2uLvazw5QsQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 22",
-        "yarn": ">= 1"
       }
     },
     "node_modules/type-check": {

--- a/web/themes/contrib/civictheme/civictheme_starter_kit/package.json
+++ b/web/themes/contrib/civictheme/civictheme_starter_kit/package.json
@@ -49,13 +49,13 @@
     "stylelint-config-standard-scss": "^17.0.0",
     "twig": "^3.0.0",
     "vite": "^6.4.2",
-    "vite-plugin-twig-drupal": "^1.7.0"
+    "vite-plugin-twig-drupal": "git+https://github.com/civictheme/vite-plugin-twig-drupal.git#semver:^1.7.1-ct.1"
   },
   "dependencies": {
     "@popperjs/core": "^2.11.8"
   },
   "overrides": {
     "drupal-attribute": "npm:@civictheme/drupal-attribute@^2.0.1",
-    "drupal-twig-extensions": "github:civictheme/drupal-twig-extensions#092058b870917ffd6e15ce07503e32a471484147"
+    "drupal-twig-extensions": "github:civictheme/drupal-twig-extensions#semver:^1.0.0-beta.5.ct.1"
   }
 }

--- a/web/themes/contrib/civictheme/civictheme_starter_kit/package.json
+++ b/web/themes/contrib/civictheme/civictheme_starter_kit/package.json
@@ -30,6 +30,7 @@
     "storybook-dev": "storybook dev -p 6006"
   },
   "devDependencies": {
+    "@civictheme/drupal-attribute": "^2.0.0",
     "@civictheme/scss-variables-extractor": "^0.2.1",
     "@storybook/addon-docs": "10.2.13",
     "@storybook/addon-links": "10.2.13",
@@ -46,10 +47,14 @@
     "stylelint": "^17.4.0",
     "stylelint-config-standard": "^40.0.0",
     "stylelint-config-standard-scss": "^17.0.0",
+    "twig": "^3.0.0",
     "vite": "^6.4.2",
-    "vite-plugin-twig-drupal": "^1.6.0"
+    "vite-plugin-twig-drupal": "^1.7.0"
   },
   "dependencies": {
     "@popperjs/core": "^2.11.8"
+  },
+  "overrides": {
+    "drupal-attribute": "npm:@civictheme/drupal-attribute@^2.0.0"
   }
 }

--- a/web/themes/contrib/civictheme/civictheme_starter_kit/package.json
+++ b/web/themes/contrib/civictheme/civictheme_starter_kit/package.json
@@ -30,7 +30,7 @@
     "storybook-dev": "storybook dev -p 6006"
   },
   "devDependencies": {
-    "@civictheme/drupal-attribute": "^2.0.0",
+    "@civictheme/drupal-attribute": "^2.0.1",
     "@civictheme/scss-variables-extractor": "^0.2.1",
     "@storybook/addon-docs": "10.2.13",
     "@storybook/addon-links": "10.2.13",
@@ -55,6 +55,7 @@
     "@popperjs/core": "^2.11.8"
   },
   "overrides": {
-    "drupal-attribute": "npm:@civictheme/drupal-attribute@^2.0.0"
+    "drupal-attribute": "npm:@civictheme/drupal-attribute@^2.0.1",
+    "drupal-twig-extensions": "github:civictheme/drupal-twig-extensions#092058b870917ffd6e15ce07503e32a471484147"
   }
 }

--- a/web/themes/contrib/civictheme/package-lock.json
+++ b/web/themes/contrib/civictheme/package-lock.json
@@ -1984,16 +1984,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -2637,9 +2637,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "dev": true,
       "funding": [
         {
@@ -2973,9 +2973,9 @@
       }
     },
     "node_modules/immutable": {
-      "version": "4.3.8",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.8.tgz",
-      "integrity": "sha512-d/Ld9aLbKpNwyl0KiM2CT1WYvkitQ1TSvmRtkcV8FKStiDoA7Slzgjmb/1G2yhKM1p0XeNOieaTbFZmU1d3Xuw==",
+      "version": "4.3.9",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.9.tgz",
+      "integrity": "sha512-ObHy4YN7ycwZOUCLI1/6svfyAFu7vL8RhAvVu/bh/RZW9EPlOyDaQ9jDQWCtdqzaXUjgXZCW1migtHE7YI7UGQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -3189,10 +3189,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -3445,9 +3455,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
       "dev": true,
       "funding": [
         {
@@ -3656,9 +3666,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.14",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
-      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "dev": true,
       "funding": [
         {
@@ -3676,7 +3686,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -5196,9 +5206,9 @@
       "license": "MIT"
     },
     "node_modules/vite": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
-      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+      "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5856,9 +5866,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "version": "8.21.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.2.tgz",
+      "integrity": "sha512-54dMVAo4WIe6SKy3vBgN+9bJZqqQ8IMRevAkOLQALhi49qkkQDQfWdAZ8KQlXiEabw88ARXXdUrlvtbKQX+aKw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/web/themes/contrib/civictheme/package-lock.json
+++ b/web/themes/contrib/civictheme/package-lock.json
@@ -25,6 +25,7 @@
         "@popperjs/core": "^2.11.8"
       },
       "devDependencies": {
+        "@civictheme/drupal-attribute": "^2.0.0",
         "@civictheme/scss-variables-extractor": "^0.2.1",
         "@eslint/js": "^10.0.1",
         "@storybook/addon-docs": "10.2.13",
@@ -41,8 +42,9 @@
         "stylelint": "^17.4.0",
         "stylelint-config-standard": "^40.0.0",
         "stylelint-config-standard-scss": "^17.0.0",
+        "twig": "^3.0.0",
         "vite": "^6.4.2",
-        "vite-plugin-twig-drupal": "^1.6.0"
+        "vite-plugin-twig-drupal": "^1.7.0"
       },
       "engines": {
         "node": ">=22.6.0"
@@ -156,6 +158,16 @@
       "license": "MIT",
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
+      }
+    },
+    "node_modules/@civictheme/drupal-attribute": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@civictheme/drupal-attribute/-/drupal-attribute-2.0.0.tgz",
+      "integrity": "sha512-Uj9BpGrHC5GM82amQ/8A5sn8bH+/9JpnkfZCaxnESkaKLCOUh5bEEcuUQqVf6gJ1tGBS1/kQVdjK2jIIPL88VA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@civictheme/scss-variables-extractor": {
@@ -2108,13 +2120,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/cosmiconfig": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.1.tgz",
@@ -2306,11 +2311,15 @@
       "peer": true
     },
     "node_modules/drupal-attribute": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/drupal-attribute/-/drupal-attribute-1.2.1.tgz",
-      "integrity": "sha512-SM0Htd9sBEM08X9/6uqIgm9PzWWKY/Bdef/xsuaTzzzmv6eKPuin1QgwY+Vsp3lX4uYWgrKzXehpp6vqFmpxDQ==",
+      "name": "@civictheme/drupal-attribute",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@civictheme/drupal-attribute/-/drupal-attribute-2.0.0.tgz",
+      "integrity": "sha512-Uj9BpGrHC5GM82amQ/8A5sn8bH+/9JpnkfZCaxnESkaKLCOUh5bEEcuUQqVf6gJ1tGBS1/kQVdjK2jIIPL88VA==",
       "dev": true,
-      "license": "MIT License"
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/drupal-twig-extensions": {
       "version": "1.0.0-beta.5",
@@ -5091,53 +5100,33 @@
       "license": "0BSD"
     },
     "node_modules/twig": {
-      "version": "1.17.1",
-      "resolved": "https://registry.npmjs.org/twig/-/twig-1.17.1.tgz",
-      "integrity": "sha512-atxccyr/BHtb1gPMA7Lvki0OuU17XBqHsNH9lzDHt9Rr1293EVZOosSZabEXz/DPVikIW8ZDqSkEddwyJnQN2w==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/twig/-/twig-3.0.0.tgz",
+      "integrity": "sha512-cMfYLWAgdW15B7L5wmanmga113e4phQmo3rk5EFuUrQd99g7I3ncxgynS38P01m4ZXBDSdMYUTV1g3A66/Y56Q==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "@babel/runtime": "^7.8.4",
-        "locutus": "^2.0.11",
-        "minimatch": "3.0.x",
+        "locutus": "^3.0.9",
+        "minimatch": "^10",
         "walk": "2.3.x"
       },
       "bin": {
         "twigjs": "bin/twigjs"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=22"
       }
     },
-    "node_modules/twig/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/twig/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+    "node_modules/twig/node_modules/locutus": {
+      "version": "3.0.36",
+      "resolved": "https://registry.npmjs.org/locutus/-/locutus-3.0.36.tgz",
+      "integrity": "sha512-ilsz33lqEd+KerV9JnSHM9EApVYOZ86/JTGKyafmWvhTFtjYauzT1WmZgdJ4JBGR3dY0N0PTfIq2uLvazw5QsQ==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/twig/node_modules/minimatch": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.8.tgz",
-      "integrity": "sha512-6FsRAQsxQ61mw+qP1ZzbL9Bc78x2p5OqNgNpnoAFLTrX8n5Kxph0CsnhmKKNXTWjXqU5L0pGPR7hYk+XWZr60Q==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
       "engines": {
-        "node": "*"
+        "node": ">= 22",
+        "yarn": ">= 1"
       }
     },
     "node_modules/type-check": {
@@ -5305,15 +5294,15 @@
       }
     },
     "node_modules/vite-plugin-twig-drupal": {
-      "version": "1.6.4",
-      "resolved": "https://registry.npmjs.org/vite-plugin-twig-drupal/-/vite-plugin-twig-drupal-1.6.4.tgz",
-      "integrity": "sha512-MoXL7RXzGV9E6hOygEgP/QNWZHLfc+MsWajYuVtWcY3u2ntWaJmaFVmR71UaOsXKSSVl2bBW/UaK3xHQUZTc6g==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-twig-drupal/-/vite-plugin-twig-drupal-1.7.0.tgz",
+      "integrity": "sha512-yJI5JHm+COQObytCrxiuWanh5m6fZuy2MrIsPFJeeAIPG/OBW2wpdq2q7xLk5Nd+gfzT133j+L6zTmSyYWzOJw==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "drupal-attribute": "^1.0.2",
         "drupal-twig-extensions": "^1.0.0-beta.5",
-        "twig": "^1.16.0"
+        "twig": "^1.16.0 || ^2 || ^3"
       },
       "peerDependencies": {
         "vite": "^4.4.11 || ^5 || ^6 || ^7 || ^8"

--- a/web/themes/contrib/civictheme/package-lock.json
+++ b/web/themes/contrib/civictheme/package-lock.json
@@ -21,7 +21,7 @@
         "win32"
       ],
       "dependencies": {
-        "@civictheme/uikit": "github:civictheme/uikit#2f763a2176858e496274fb059bc8d3ef8a758b66",
+        "@civictheme/uikit": "github:civictheme/uikit#2f205010a77a16af4ab70bc7d5c9216353168183",
         "@popperjs/core": "^2.11.8"
       },
       "devDependencies": {
@@ -179,7 +179,7 @@
     },
     "node_modules/@civictheme/uikit": {
       "version": "1.13.0",
-      "resolved": "git+ssh://git@github.com/civictheme/uikit.git#2f763a2176858e496274fb059bc8d3ef8a758b66",
+      "resolved": "git+ssh://git@github.com/civictheme/uikit.git#2f205010a77a16af4ab70bc7d5c9216353168183",
       "integrity": "sha512-SdsQXHEVt2jmYg96ool3hBYgqkk8vJt39Z9CB7tAI212noMssHLuq9sNTAZKW3wpFFUYtMluHFQU7jnNZ/BZOg==",
       "cpu": [
         "x64",

--- a/web/themes/contrib/civictheme/package-lock.json
+++ b/web/themes/contrib/civictheme/package-lock.json
@@ -21,7 +21,7 @@
         "win32"
       ],
       "dependencies": {
-        "@civictheme/uikit": "github:civictheme/uikit#2f205010a77a16af4ab70bc7d5c9216353168183",
+        "@civictheme/uikit": "github:civictheme/uikit#2f763a2176858e496274fb059bc8d3ef8a758b66",
         "@popperjs/core": "^2.11.8"
       },
       "devDependencies": {
@@ -179,7 +179,7 @@
     },
     "node_modules/@civictheme/uikit": {
       "version": "1.13.0",
-      "resolved": "git+ssh://git@github.com/civictheme/uikit.git#2f205010a77a16af4ab70bc7d5c9216353168183",
+      "resolved": "git+ssh://git@github.com/civictheme/uikit.git#2f763a2176858e496274fb059bc8d3ef8a758b66",
       "integrity": "sha512-SdsQXHEVt2jmYg96ool3hBYgqkk8vJt39Z9CB7tAI212noMssHLuq9sNTAZKW3wpFFUYtMluHFQU7jnNZ/BZOg==",
       "cpu": [
         "x64",

--- a/web/themes/contrib/civictheme/package-lock.json
+++ b/web/themes/contrib/civictheme/package-lock.json
@@ -21,7 +21,7 @@
         "win32"
       ],
       "dependencies": {
-        "@civictheme/uikit": "github:civictheme/uikit#2f763a2176858e496274fb059bc8d3ef8a758b66",
+        "@civictheme/uikit": "github:civictheme/uikit#d822368599a8f91d7af91d82f061f50508301368",
         "@popperjs/core": "^2.11.8"
       },
       "devDependencies": {
@@ -179,7 +179,7 @@
     },
     "node_modules/@civictheme/uikit": {
       "version": "1.13.0",
-      "resolved": "git+ssh://git@github.com/civictheme/uikit.git#2f763a2176858e496274fb059bc8d3ef8a758b66",
+      "resolved": "git+ssh://git@github.com/civictheme/uikit.git#d822368599a8f91d7af91d82f061f50508301368",
       "integrity": "sha512-SdsQXHEVt2jmYg96ool3hBYgqkk8vJt39Z9CB7tAI212noMssHLuq9sNTAZKW3wpFFUYtMluHFQU7jnNZ/BZOg==",
       "cpu": [
         "x64",

--- a/web/themes/contrib/civictheme/package-lock.json
+++ b/web/themes/contrib/civictheme/package-lock.json
@@ -21,7 +21,7 @@
         "win32"
       ],
       "dependencies": {
-        "@civictheme/uikit": "github:civictheme/uikit#83c43d321c0decb76ac1b2d135e37a288d8467a6",
+        "@civictheme/uikit": "github:civictheme/uikit#2f763a2176858e496274fb059bc8d3ef8a758b66",
         "@popperjs/core": "^2.11.8"
       },
       "devDependencies": {
@@ -44,7 +44,7 @@
         "stylelint-config-standard-scss": "^17.0.0",
         "twig": "^3.0.0",
         "vite": "^6.4.2",
-        "vite-plugin-twig-drupal": "^1.7.0"
+        "vite-plugin-twig-drupal": "git+https://github.com/civictheme/vite-plugin-twig-drupal.git#semver:^1.7.1-ct.1"
       },
       "engines": {
         "node": ">=22.6.0"
@@ -179,8 +179,8 @@
     },
     "node_modules/@civictheme/uikit": {
       "version": "1.13.0",
-      "resolved": "git+ssh://git@github.com/civictheme/uikit.git#83c43d321c0decb76ac1b2d135e37a288d8467a6",
-      "integrity": "sha512-voFSk44+YjNYLYcqvM8RCVa5kB/nXgdeQS/0Z37fKmhl0YMoQUkhokErpY4ylXE2A5OvzQPfo2CYMWE4gUJShg==",
+      "resolved": "git+ssh://git@github.com/civictheme/uikit.git#2f763a2176858e496274fb059bc8d3ef8a758b66",
+      "integrity": "sha512-SdsQXHEVt2jmYg96ool3hBYgqkk8vJt39Z9CB7tAI212noMssHLuq9sNTAZKW3wpFFUYtMluHFQU7jnNZ/BZOg==",
       "cpu": [
         "x64",
         "arm",
@@ -2310,25 +2310,13 @@
       "license": "MIT",
       "peer": true
     },
-    "node_modules/drupal-attribute": {
-      "name": "@civictheme/drupal-attribute",
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@civictheme/drupal-attribute/-/drupal-attribute-2.0.1.tgz",
-      "integrity": "sha512-9ivuchfqO7n9MTwwUabi2UBZ3wmdC3IF1ylulR+Ore5bQUEgTLkTGh867WCNiCuhEjNeprVzRA9vyUaNDJXM+w==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=20"
-      }
-    },
     "node_modules/drupal-twig-extensions": {
-      "version": "1.0.0-beta.5",
-      "resolved": "git+ssh://git@github.com/civictheme/drupal-twig-extensions.git#092058b870917ffd6e15ce07503e32a471484147",
-      "integrity": "sha512-w514xeaPhDNqUiyH3yIj6pZTuKDIW7+CZAFxBid8rTRr5LVjrgFgq2iD4Zf2SEekT3Z5g6fsDHU44liONUXISw==",
+      "version": "1.0.0-beta.5.ct.1",
+      "resolved": "git+ssh://git@github.com/civictheme/drupal-twig-extensions.git#a893a09d3526c0de0f5414ddc5d24755479ef46f",
       "dev": true,
       "license": "(MIT OR GPL-2.0-only)",
       "dependencies": {
-        "drupal-attribute": "^1.0.2",
+        "@civictheme/drupal-attribute": "^2.0.1",
         "locutus": "^3.0.24",
         "lodash.clonedeep": "^4.5.0"
       }
@@ -5283,14 +5271,13 @@
       }
     },
     "node_modules/vite-plugin-twig-drupal": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/vite-plugin-twig-drupal/-/vite-plugin-twig-drupal-1.7.0.tgz",
-      "integrity": "sha512-yJI5JHm+COQObytCrxiuWanh5m6fZuy2MrIsPFJeeAIPG/OBW2wpdq2q7xLk5Nd+gfzT133j+L6zTmSyYWzOJw==",
+      "version": "1.7.1-ct.1",
+      "resolved": "git+ssh://git@github.com/civictheme/vite-plugin-twig-drupal.git#752b285ac7aa66e83e5560af0d120ccf52957b57",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "drupal-attribute": "^1.0.2",
-        "drupal-twig-extensions": "^1.0.0-beta.5",
+        "@civictheme/drupal-attribute": "^2.0.1",
+        "drupal-twig-extensions": "github:civictheme/drupal-twig-extensions#semver:^1.0.0-beta.5.ct.1",
         "twig": "^1.16.0 || ^2 || ^3"
       },
       "peerDependencies": {

--- a/web/themes/contrib/civictheme/package-lock.json
+++ b/web/themes/contrib/civictheme/package-lock.json
@@ -25,7 +25,7 @@
         "@popperjs/core": "^2.11.8"
       },
       "devDependencies": {
-        "@civictheme/drupal-attribute": "^2.0.0",
+        "@civictheme/drupal-attribute": "^2.0.1",
         "@civictheme/scss-variables-extractor": "^0.2.1",
         "@eslint/js": "^10.0.1",
         "@storybook/addon-docs": "10.2.13",
@@ -161,9 +161,9 @@
       }
     },
     "node_modules/@civictheme/drupal-attribute": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@civictheme/drupal-attribute/-/drupal-attribute-2.0.0.tgz",
-      "integrity": "sha512-Uj9BpGrHC5GM82amQ/8A5sn8bH+/9JpnkfZCaxnESkaKLCOUh5bEEcuUQqVf6gJ1tGBS1/kQVdjK2jIIPL88VA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@civictheme/drupal-attribute/-/drupal-attribute-2.0.1.tgz",
+      "integrity": "sha512-9ivuchfqO7n9MTwwUabi2UBZ3wmdC3IF1ylulR+Ore5bQUEgTLkTGh867WCNiCuhEjNeprVzRA9vyUaNDJXM+w==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -2312,9 +2312,9 @@
     },
     "node_modules/drupal-attribute": {
       "name": "@civictheme/drupal-attribute",
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@civictheme/drupal-attribute/-/drupal-attribute-2.0.0.tgz",
-      "integrity": "sha512-Uj9BpGrHC5GM82amQ/8A5sn8bH+/9JpnkfZCaxnESkaKLCOUh5bEEcuUQqVf6gJ1tGBS1/kQVdjK2jIIPL88VA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@civictheme/drupal-attribute/-/drupal-attribute-2.0.1.tgz",
+      "integrity": "sha512-9ivuchfqO7n9MTwwUabi2UBZ3wmdC3IF1ylulR+Ore5bQUEgTLkTGh867WCNiCuhEjNeprVzRA9vyUaNDJXM+w==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -2323,13 +2323,13 @@
     },
     "node_modules/drupal-twig-extensions": {
       "version": "1.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/drupal-twig-extensions/-/drupal-twig-extensions-1.0.0-beta.5.tgz",
-      "integrity": "sha512-TrijTIs6wAwMmAa6eikQDyHTLNVizHPptpMd2BsRWDGpRozfH4OdY75ZQXbfnQmH5vl9kydKUfp57lUkcgQZBQ==",
+      "resolved": "git+ssh://git@github.com/civictheme/drupal-twig-extensions.git#092058b870917ffd6e15ce07503e32a471484147",
+      "integrity": "sha512-w514xeaPhDNqUiyH3yIj6pZTuKDIW7+CZAFxBid8rTRr5LVjrgFgq2iD4Zf2SEekT3Z5g6fsDHU44liONUXISw==",
       "dev": true,
       "license": "(MIT OR GPL-2.0-only)",
       "dependencies": {
         "drupal-attribute": "^1.0.2",
-        "locutus": "^2.0.16",
+        "locutus": "^3.0.24",
         "lodash.clonedeep": "^4.5.0"
       }
     },
@@ -3306,13 +3306,13 @@
       }
     },
     "node_modules/locutus": {
-      "version": "2.0.39",
-      "resolved": "https://registry.npmjs.org/locutus/-/locutus-2.0.39.tgz",
-      "integrity": "sha512-v2iub44UtGpbIv+pFkkYhZ+JsbIM0bJsQcQ1+VayUNGVA/YhM8+CkBiRACcpuuE9Q0xI1pgNzGNwzZDCp1MCww==",
+      "version": "3.0.36",
+      "resolved": "https://registry.npmjs.org/locutus/-/locutus-3.0.36.tgz",
+      "integrity": "sha512-ilsz33lqEd+KerV9JnSHM9EApVYOZ86/JTGKyafmWvhTFtjYauzT1WmZgdJ4JBGR3dY0N0PTfIq2uLvazw5QsQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">= 10",
+        "node": ">= 22",
         "yarn": ">= 1"
       }
     },
@@ -5116,17 +5116,6 @@
       },
       "engines": {
         "node": ">=22"
-      }
-    },
-    "node_modules/twig/node_modules/locutus": {
-      "version": "3.0.36",
-      "resolved": "https://registry.npmjs.org/locutus/-/locutus-3.0.36.tgz",
-      "integrity": "sha512-ilsz33lqEd+KerV9JnSHM9EApVYOZ86/JTGKyafmWvhTFtjYauzT1WmZgdJ4JBGR3dY0N0PTfIq2uLvazw5QsQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 22",
-        "yarn": ">= 1"
       }
     },
     "node_modules/type-check": {

--- a/web/themes/contrib/civictheme/package.json
+++ b/web/themes/contrib/civictheme/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "@popperjs/core": "^2.11.8",
-    "@civictheme/uikit": "github:civictheme/uikit#83c43d321c0decb76ac1b2d135e37a288d8467a6"
+    "@civictheme/uikit": "github:civictheme/uikit#2f763a2176858e496274fb059bc8d3ef8a758b66"
   },
   "devDependencies": {
     "@civictheme/drupal-attribute": "^2.0.1",
@@ -62,10 +62,10 @@
     "stylelint-config-standard-scss": "^17.0.0",
     "twig": "^3.0.0",
     "vite": "^6.4.2",
-    "vite-plugin-twig-drupal": "^1.7.0"
+    "vite-plugin-twig-drupal": "git+https://github.com/civictheme/vite-plugin-twig-drupal.git#semver:^1.7.1-ct.1"
   },
   "overrides": {
     "drupal-attribute": "npm:@civictheme/drupal-attribute@^2.0.1",
-    "drupal-twig-extensions": "github:civictheme/drupal-twig-extensions#092058b870917ffd6e15ce07503e32a471484147"
+    "drupal-twig-extensions": "github:civictheme/drupal-twig-extensions#semver:^1.0.0-beta.5.ct.1"
   }
 }

--- a/web/themes/contrib/civictheme/package.json
+++ b/web/themes/contrib/civictheme/package.json
@@ -43,7 +43,7 @@
     "@civictheme/uikit": "github:civictheme/uikit#83c43d321c0decb76ac1b2d135e37a288d8467a6"
   },
   "devDependencies": {
-    "@civictheme/drupal-attribute": "^2.0.0",
+    "@civictheme/drupal-attribute": "^2.0.1",
     "@civictheme/scss-variables-extractor": "^0.2.1",
     "@storybook/addon-docs": "10.2.13",
     "@storybook/addon-links": "10.2.13",
@@ -65,6 +65,7 @@
     "vite-plugin-twig-drupal": "^1.7.0"
   },
   "overrides": {
-    "drupal-attribute": "npm:@civictheme/drupal-attribute@^2.0.0"
+    "drupal-attribute": "npm:@civictheme/drupal-attribute@^2.0.1",
+    "drupal-twig-extensions": "github:civictheme/drupal-twig-extensions#092058b870917ffd6e15ce07503e32a471484147"
   }
 }

--- a/web/themes/contrib/civictheme/package.json
+++ b/web/themes/contrib/civictheme/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "@popperjs/core": "^2.11.8",
-    "@civictheme/uikit": "github:civictheme/uikit#2f763a2176858e496274fb059bc8d3ef8a758b66"
+    "@civictheme/uikit": "github:civictheme/uikit#2f205010a77a16af4ab70bc7d5c9216353168183"
   },
   "devDependencies": {
     "@civictheme/drupal-attribute": "^2.0.1",

--- a/web/themes/contrib/civictheme/package.json
+++ b/web/themes/contrib/civictheme/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "@popperjs/core": "^2.11.8",
-    "@civictheme/uikit": "github:civictheme/uikit#2f205010a77a16af4ab70bc7d5c9216353168183"
+    "@civictheme/uikit": "github:civictheme/uikit#2f763a2176858e496274fb059bc8d3ef8a758b66"
   },
   "devDependencies": {
     "@civictheme/drupal-attribute": "^2.0.1",

--- a/web/themes/contrib/civictheme/package.json
+++ b/web/themes/contrib/civictheme/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "@popperjs/core": "^2.11.8",
-    "@civictheme/uikit": "github:civictheme/uikit#2f763a2176858e496274fb059bc8d3ef8a758b66"
+    "@civictheme/uikit": "github:civictheme/uikit#d822368599a8f91d7af91d82f061f50508301368"
   },
   "devDependencies": {
     "@civictheme/drupal-attribute": "^2.0.1",

--- a/web/themes/contrib/civictheme/package.json
+++ b/web/themes/contrib/civictheme/package.json
@@ -43,6 +43,7 @@
     "@civictheme/uikit": "github:civictheme/uikit#83c43d321c0decb76ac1b2d135e37a288d8467a6"
   },
   "devDependencies": {
+    "@civictheme/drupal-attribute": "^2.0.0",
     "@civictheme/scss-variables-extractor": "^0.2.1",
     "@storybook/addon-docs": "10.2.13",
     "@storybook/addon-links": "10.2.13",
@@ -59,7 +60,11 @@
     "stylelint": "^17.4.0",
     "stylelint-config-standard": "^40.0.0",
     "stylelint-config-standard-scss": "^17.0.0",
+    "twig": "^3.0.0",
     "vite": "^6.4.2",
-    "vite-plugin-twig-drupal": "^1.6.0"
+    "vite-plugin-twig-drupal": "^1.7.0"
+  },
+  "overrides": {
+    "drupal-attribute": "npm:@civictheme/drupal-attribute@^2.0.0"
   }
 }


### PR DESCRIPTION
## Changed

1. Override the transitive `drupal-attribute` with `@civictheme/drupal-attribute@2.0.1`. Twig.js stamps compiled object literals with a `_keys` array, which the old class rendered as an HTML attribute. An `overrides` entry is required — `2.x` does not satisfy the `^1.0.2` its dependents pin.
2. Register `createAttribute()` with Twig.js in both `.storybook/preview.js` so attributes keep template order. It patches `Twig.extendFunction`, since every compiled module re-registers the unfixed version on import.
3. Point `drupal-twig-extensions` at the SHA-pinned [civictheme fork](https://github.com/civictheme/drupal-twig-extensions) for locutus 3 (critical advisory cleared); bump `vite-plugin-twig-drupal` to 1.7.0 for Twig.js 3.

## Notes

```html
<!-- before -->  <a href="#top" data-skip-to-target="" _keys="data-skip-to-target">
<!-- after -->   <a href="#top" data-skip-to-target="">
```

Beyond `_keys`, rendered markup changes: attribute order follows the template, empty values render as `key=""`, and `toString()` now escapes with `Html::escape()` parity — all matching Drupal's PHP `Attribute`. Downstream snapshots need review rather than blind re-baselining.

All 26 `create_attribute` callers were rendered through the Vite pipeline, both with and without the registration, so the failure was observed first. No `_keys` in any of them; both Storybook builds and both lint runs pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved authored HTML attribute ordering in Twig-rendered components.
  * Improved consistency when templates are compiled or refreshed in Storybook.
  * Ensured consistent attribute handling across CivicTheme and the starter kit.

* **Developer Experience**
  * Improved Storybook template rendering for more reliable component previews.
  * Expanded version-management tooling to display and process more branches and releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->