### PR TITLE
Issue #1000 by sonictruth: Update sidebar navigation title style to match design

### DIFF
--- a/web/themes/contrib/civictheme/includes/sidebar_navigation.inc
+++ b/web/themes/contrib/civictheme/includes/sidebar_navigation.inc
@@ -18,6 +18,7 @@ function civictheme_preprocess_block__menu_block__civictheme_sidebar_navigation(
   $variables['theme'] = civictheme_get_theme_config_manager()->load('components.header.theme', CivicthemeConstants::HEADER_THEME_DEFAULT);
   $variables['items'] = $variables['content']['#items'] ?? [];
   $variables['title'] = $variables['configuration']['label_display'] ? $variables['configuration']['label'] : '';
+  $variables['label'] = '';
   $variables['in_sidebar'] = TRUE;
   $expand_all_items = $variables['configuration']['expand_all_items'] ?? FALSE;
   _civictheme_preprocess_menu_items($variables['items'], $expand_all_items);

--- a/web/themes/contrib/civictheme/templates/block/block--menu-block--civictheme-sidebar-navigation.html.twig
+++ b/web/themes/contrib/civictheme/templates/block/block--menu-block--civictheme-sidebar-navigation.html.twig
@@ -5,8 +5,7 @@
  */
 #}
 {% extends 'block.html.twig' %}
-{# If the block's 'Display title' is on then it's value will get piped into the title variable passed to civictheme:side-navigation for display but we never want to show the block title. #}
-{% set label = '' %}
+
 {% block content_block %}
   {% include 'civictheme:side-navigation' with {
     title: title,

--- a/web/themes/contrib/civictheme/templates/block/block--menu-block--civictheme-sidebar-navigation.html.twig
+++ b/web/themes/contrib/civictheme/templates/block/block--menu-block--civictheme-sidebar-navigation.html.twig
@@ -5,9 +5,11 @@
  */
 #}
 {% extends 'block.html.twig' %}
-
+{# If the block's 'Display title' is on then it's value will get piped into the title variable passed to civictheme:side-navigation for display but we never want to show the block title. #}
+{% set label = '' %}
 {% block content_block %}
   {% include 'civictheme:side-navigation' with {
+    title: title,
     theme: theme|default('light'),
     items,
     modifier_class: 'ct-sidebar-navigation ' ~ modifier_class|default(''),


### PR DESCRIPTION
https://github.com/civictheme/uikit/issues/1000


## Checklist before requesting a review

- [x] I have formatted the subject to include ticket number as `Issue #123456 by drupal_org_username: Issue title`
- [x] I have added a link to the issue tracker
- [x] I have provided information in `Changed` section about WHY something was done if this was not a normal implementation
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run new and existing relevant tests locally with my changes, and they passed
- [x] I have provided screenshots, where applicable

## Changed

1. Passed title variable through to the `civictheme:side-navigation` component
2 unset the block label

## Screenshots
With 'display title' off: 
<img width="399" height="232" alt="image" src="https://github.com/user-attachments/assets/db3fafdc-88e4-41f8-9174-b1acab7a1193" />

With 'display title' on:
<img width="446" height="265" alt="image" src="https://github.com/user-attachments/assets/0211baed-661a-4c9d-b7fc-d939527546e8" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved sidebar navigation rendering by preventing unintended label text from appearing.
  - Sidebar navigation components now receive and display their configured title consistently.
  - Enhanced consistency of navigation headings across pages using the civic theme.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->