### PR TITLE
Updated build-deploy actions to Node 24 runtimes.

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -24,13 +24,13 @@ jobs:
     steps:
 
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@v4
 
     - name: Initialize Quant Cloud
-      uses: quantcdn/quant-cloud-init-action@v1.1.2
+      uses: quantcdn/quant-cloud-init-action@v4
       id: init
       with:
         quant_organization: ${{ secrets.QUANT_ORGANIZATION }}
@@ -52,7 +52,7 @@ jobs:
 
 
     - name: Build and push cli image
-      uses: docker/build-push-action@v5
+      uses: docker/build-push-action@v7
       with:
         context: .
         file: ./.docker/cli.dockerfile
@@ -68,7 +68,7 @@ jobs:
           }}:cli${{ steps.override-outputs.outputs.image_suffix }}
 
     - name: Build and push nginx image
-      uses: docker/build-push-action@v5
+      uses: docker/build-push-action@v7
       with:
         context: .
         file: ./.docker/nginx-drupal.dockerfile
@@ -84,7 +84,7 @@ jobs:
           }}:cli${{ steps.override-outputs.outputs.image_suffix }}
 
     - name: Build and push php image
-      uses: docker/build-push-action@v5
+      uses: docker/build-push-action@v7
       with:
         context: .
         file: ./.docker/php.dockerfile
@@ -101,7 +101,7 @@ jobs:
 
     - name: Create environment if it doesn't exist
       if: ${{ !startsWith(github.ref, 'refs/tags/') && steps.override-outputs.outputs.environment_exists == 'false' }}
-      uses: quantcdn/quant-cloud-environment-action@v1.2.1
+      uses: quantcdn/quant-cloud-environment-action@v4
       with:
         api_key: ${{ secrets.QUANT_API_KEY }}
         organization: ${{ secrets.QUANT_ORGANIZATION }}
@@ -112,7 +112,7 @@ jobs:
 
     - name: Redeploy existing environment
       if: ${{ !startsWith(github.ref, 'refs/tags/') && steps.override-outputs.outputs.environment_exists == 'true' }}
-      uses: quantcdn/quant-cloud-environment-state-action@v1
+      uses: quantcdn/quant-cloud-environment-state-action@v4
       with:
         api_key: ${{ secrets.QUANT_API_KEY }}
         organization: ${{ secrets.QUANT_ORGANIZATION }}


### PR DESCRIPTION
Every action in `build-deploy.yml` targeted the deprecated Node 20 runtime and was being forced onto Node 24 by the runner, producing the deprecation annotation on every run. All eight `uses:` refs now resolve to actions declaring `using: node24`.

| Action | Before | After |
| --- | --- | --- |
| `actions/checkout` | `v4` | `v5` |
| `docker/setup-buildx-action` | `v3` | `v4` |
| `docker/build-push-action` (x3) | `v5` | `v7` |
| `quantcdn/quant-cloud-init-action` | `v1.1.2` | `v4` |
| `quantcdn/quant-cloud-environment-action` | `v1.2.1` | `v4` |
| `quantcdn/quant-cloud-environment-state-action` | `v1` | `v4` |

## Compatibility

- No input names changed across any of the bumps.
- `quant-cloud-init-action` v4 removes the `feature/` special cases from environment name and image suffix generation. Those branches had bodies identical to their `else` branches, so environment names and image tags are unchanged (`content/highereducation` still maps to environment `content-highereducation`, suffix `-content-highereducation`). No orphaned environments, no re-tagged images.
- v4 of the init action also emits `image_suffix_clean` natively. The existing `Override outputs for special branches` step still computes it and is left in place.
- `build-push-action` v6+ emits build summaries by default, so the run UI will look different. `setup-buildx-action` v4 and `build-push-action` v7 require Actions Runner v2.327.1+, satisfied on GitHub-hosted `ubuntu-24.04-arm`.

## This may not fix the deploy failure

The workflow has been red since 2026-05-15 (last green 2026-05-06) on `Initialize Quant Cloud`:

```
Organization '***' does not exist or is not accessible: HTTP request failed
```

That is not a Node runtime break. In `quant-ts-client`, `HTTP request failed` is the `HttpError` message for any non-2xx response, so the Quant API answered with a status code rather than failing to connect. Probing by hand, both `/api/v3/organisations/<org>/applications` (old client, British spelling) and `/api/v3/organizations/...` (v4 client) return the API's `{"error":true,"message":"Unable to find matching result"}` 404, while an unmatched route returns an HTML 404 — so both paths are registered and the organisation lookup is failing on its merits.

`QUANT_ORGANIZATION` and `QUANT_API_KEY` were both last updated 2025-09-14 and were green with those values through 2026-05-06, so nothing changed on our side. Either the organisation was renamed/deleted or the API key was revoked in Quant Cloud — or the British-spelled route became a dead alias, in which case this bump is the fix. Worth confirming in the Quant Cloud dashboard.

## Verification

This branch does not match the workflow's trigger list, so the change is not exercised by this PR. Merging to `develop` will run it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the deployment workflow’s build, packaging, and cloud environment actions to newer versions.
  * Preserved existing Docker image build behavior and deployment conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->