### PR TITLE
Updated remaining workflow actions to Node 24 runtimes.

### DIFF
--- a/.github/workflows/auto-assign-pr-author.yml
+++ b/.github/workflows/auto-assign-pr-author.yml
@@ -11,4 +11,4 @@ jobs:
   assign-author:
     runs-on: ubuntu-latest
     steps:
-      - uses: toshimaru/auto-author-assign@v2.0.1
+      - uses: toshimaru/auto-author-assign@v3.1.0

--- a/.github/workflows/auto-label-conflict.yml
+++ b/.github/workflows/auto-label-conflict.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check if PRs have conflicts
-        uses: eps1lon/actions-label-merge-conflict@releases/2.x
+        uses: eps1lon/actions-label-merge-conflict@v3.1.0
         with:
           dirtyLabel: "State: CONFLICT"
           removeOnDirtyLabel: "State: Needs review"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,6 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@v5
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: release-drafter/release-drafter@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Follow-up to #1542, which covered `build-deploy.yml`. These are the remaining workflows that use actions, all of which targeted the deprecated Node 20 runtime.

| Workflow | Action | Before | After |
| --- | --- | --- | --- |
| `release.yml` | `release-drafter/release-drafter` | `v5` | `v7` |
| `auto-label-conflict.yml` | `eps1lon/actions-label-merge-conflict` | `releases/2.x` | `v3.1.0` |
| `auto-assign-pr-author.yml` | `toshimaru/auto-author-assign` | `v2.0.1` | `v3.1.0` |

`dispatch-webhook-lagoon.yml` has no `uses:` steps, so it needs no change.

## Pinning

`release-drafter` publishes a moving `v7` tag, matching the existing `v5` style. Neither of the other two publishes a bare `v3` tag, so both are pinned exactly, matching the existing `v2.0.1` style. For `actions-label-merge-conflict`, v3.1.0 is also the floor: v3.0.x is still node20, and only v3.1.0 moved to node24. That repo has a `v3` *branch*, deliberately not used here — a branch ref is mutable.

## release-drafter v7

v7 is the largest change. It rewrites the action off Probot and removes several config options. Verified against this repo's setup:

- **Token.** v7 drops the `GITHUB_TOKEN` env variable in favour of a `token` input. `release.yml` is updated accordingly.
- **Permissions.** v7's README asks for `contents: write` and `pull-requests: read`. The job already grants `contents: write` and `pull-requests: write`, a superset. No change needed.
- **Config.** `.github/release-drafter.yml` uses none of the removed or reworked keys — no `categories`, no `autolabeler`, no `references`, no `include-pre-releases`, and nothing relying on Joi's `array.single()` shorthand. `version-resolver: default: minor` validates against v7's zod schema.
- **Autolabeler.** v7 splits the autolabeler into a separate action. This repo runs the drafter only, so no second step is added.
- **Template variables.** The config references `$RESOLVED_VERSION`, `$PREVIOUS_TAG`, `$CHANGES`, `$CONTRIBUTORS`, `$OWNER` and `$REPOSITORY`. All still resolve in v7 (`src/actions/drafter/lib/build-release-payload/build-release-payload.ts`). The variables v7 changed — `$INPUT_VERSION` and the `$NEXT_PRERELEASE_*` family — are not used here.

## Other two

`auto-author-assign` v3.0.0 is a Node 20 to 24 bump with no input changes; the workflow passes no inputs. `actions-label-merge-conflict` keeps `dirtyLabel`, `removeOnDirtyLabel` and `repoToken`; the source diff from `releases/2.x` is formatting plus one loosened error check (`endsWith` to `includes` when detecting missing-permission errors).

## Verification

Only one of the three is exercised by this PR. `auto-label-conflict.yml` fires on bare `push`, so it ran from this branch against v3.1.0 and passed.

The other two are not verified here:

- `auto-assign-pr-author.yml` fires on `pull_request_target`, which always runs the workflow definition from the base branch. The run triggered by this PR therefore uses `v2.0.1` from `develop`, not the `v3.1.0` in this diff.
- `release.yml` only fires on push to `develop` or on a tag.

Both — including the release-drafter v7 bump, the one with real breaking changes — will first run against these versions after merge.
